### PR TITLE
Renamed service interface to clarify its responsibility.

### DIFF
--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateTag/CreateTagCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateTag/CreateTagCommandHandler.cs
@@ -15,26 +15,26 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.CreateTag
         private readonly IJourneyRepository _journeyRepository;
         private readonly IUnitOfWork _unitOfWork;
         private readonly IPlantProvider _plantProvider;
-        private readonly IMainApiService _mainApiService;
+        private readonly ITagApiService _tagApiService;
 
         public CreateTagCommandHandler(
             ITagRepository tagRepository,
             IJourneyRepository journeyRepository,
             IUnitOfWork unitOfWork,
             IPlantProvider plantProvider,
-            IMainApiService mainApiService)
+            ITagApiService tagApiService)
         {
             _tagRepository = tagRepository;
             _journeyRepository = journeyRepository;
             _unitOfWork = unitOfWork;
             _plantProvider = plantProvider;
-            _mainApiService = mainApiService;
+            _tagApiService = tagApiService;
         }
 
         public async Task<int> Handle(CreateTagCommand request, CancellationToken cancellationToken)
         {
             var journey = await _journeyRepository.GetByIdAsync(request.JourneyId);
-            var result = await _mainApiService.GetTags(_plantProvider.Plant, "1");
+            var result = await _tagApiService.GetTags(_plantProvider.Plant, "1");
 
             var tagToAdd = new Tag(_plantProvider.Plant, request.TagNo, request.ProjectNo, journey.Steps.FirstOrDefault(step => step.Id == request.StepId), request.Description);
             _tagRepository.Add(tagToAdd);

--- a/src/Equinor.Procosys.Preservation.MainApi/ITagApiService.cs
+++ b/src/Equinor.Procosys.Preservation.MainApi/ITagApiService.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Equinor.Procosys.Preservation.MainApi
 {
-    public interface IMainApiService
+    public interface ITagApiService
     {
         Task<IEnumerable<MainTagDto>> GetTags(string plant, string searchString);
     }

--- a/src/Equinor.Procosys.Preservation.MainApi/MainApiService.cs
+++ b/src/Equinor.Procosys.Preservation.MainApi/MainApiService.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Equinor.Procosys.Preservation.MainApi
 {
-    public class MainApiService : IMainApiService
+    public class MainApiService : ITagApiService
     {
         private readonly HttpClient _httpClient;
         private readonly IBearerTokenProvider _bearerTokenProvider;

--- a/src/Equinor.Procosys.Preservation.WebApi/DiModules/ApplicationModule.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/DiModules/ApplicationModule.cs
@@ -27,7 +27,7 @@ namespace Equinor.Procosys.Preservation.WebApi.DIModules
                 options.UseSqlServer(dbConnectionString);
             });
 
-            services.AddHttpClient<IMainApiService, MainApiService>(client =>
+            services.AddHttpClient<ITagApiService, MainApiService>(client =>
             {
                 client.BaseAddress = new Uri(mainApiAddress);
             });


### PR DESCRIPTION
Renamed interface to decouple it from the implementation. In the future, tags may come from another source than it does today.