### PR TITLE
Move next due date column

### DIFF
--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/TagAggregate/PreservationRecord.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/TagAggregate/PreservationRecord.cs
@@ -14,16 +14,11 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.TagAggregate
         
         public PreservationRecord(
             string schema,
-            Requirement requirement,
             DateTime preservedAtUtc,
             Person preservedBy,
             bool bulkPreserved,
             string comment) : base(schema)
         {
-            if (requirement == null)
-            {
-                throw new ArgumentNullException(nameof(requirement));
-            }
             if (preservedBy == null)
             {
                 throw new ArgumentNullException(nameof(preservedBy));
@@ -32,14 +27,12 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.TagAggregate
             {
                 throw new ArgumentException($"{nameof(preservedAtUtc)} is not Utc");
             }
-            RequirementId = requirement.Id;
             PreservedAtUtc = preservedAtUtc;
             PreservedByPersonId = preservedBy.Id;
             Comment = comment;
             BulkPreserved = bulkPreserved;
         }
 
-        public int RequirementId { get; private set; }
         public DateTime PreservedAtUtc { get; private set; }
         public int PreservedByPersonId { get; private set; }
         public string Comment { get; private set; }

--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/TagAggregate/PreservationRecord.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/TagAggregate/PreservationRecord.cs
@@ -12,48 +12,37 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.TagAggregate
         {
         }
         
-        public PreservationRecord(string schema, Requirement requirement, DateTime currentTime) : base(schema)
+        public PreservationRecord(
+            string schema,
+            Requirement requirement,
+            DateTime preservedAtUtc,
+            Person preservedBy,
+            bool bulkPreserved,
+            string comment) : base(schema)
         {
             if (requirement == null)
             {
                 throw new ArgumentNullException(nameof(requirement));
             }
-            if (currentTime.Kind != DateTimeKind.Utc)
-            {
-                throw new ArgumentException($"{nameof(currentTime)} is not Utc");
-            }
-
-            RequirementId = requirement.Id;
-            NextDueTimeUtc = currentTime.AddDays(7*requirement.IntervalWeeks);
-        }
-
-        public int RequirementId { get; private set; }
-        public DateTime NextDueTimeUtc { get; private set; }
-        public bool? BulkPreserved { get; set; }
-        public DateTime? PreservedAtUtc { get; set; }
-        public int? PreservedBy { get; set; }
-        public string Comment { get; set; }
- 
-        public void Preserve(Person preservedBy, string comment, DateTime currentTime) => Preserve(preservedBy, comment, false, currentTime);
-
-        public void BulkPreserve(Person preservedBy, DateTime currentTime) => Preserve(preservedBy, null, true, currentTime);
-
-        private void Preserve(Person preservedBy, string comment, bool bulkPreserve, DateTime currentTime)
-        {
             if (preservedBy == null)
             {
                 throw new ArgumentNullException(nameof(preservedBy));
             }
-
-            if (currentTime.Kind != DateTimeKind.Utc)
+            if (preservedAtUtc.Kind != DateTimeKind.Utc)
             {
-                throw new ArgumentException($"{nameof(currentTime)} is not Utc");
+                throw new ArgumentException($"{nameof(preservedAtUtc)} is not Utc");
             }
-
-            PreservedBy = preservedBy.Id;
-            PreservedAtUtc = currentTime;
+            RequirementId = requirement.Id;
+            PreservedAtUtc = preservedAtUtc;
+            PreservedByPersonId = preservedBy.Id;
             Comment = comment;
-            BulkPreserved = bulkPreserve;
+            BulkPreserved = bulkPreserved;
         }
+
+        public int RequirementId { get; private set; }
+        public DateTime PreservedAtUtc { get; private set; }
+        public int PreservedByPersonId { get; private set; }
+        public string Comment { get; private set; }
+        public bool BulkPreserved { get; private set; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/TagAggregate/Requirement.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/TagAggregate/Requirement.cs
@@ -26,6 +26,7 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.TagAggregate
         }
 
         public int IntervalWeeks { get; private set; }
+        public DateTime? NextDueTimeUtc { get; private set; }
         public bool IsVoided { get; private set; }
         public int RequirementDefinitionId { get; set; }
         public IReadOnlyCollection<PreservationRecord> PreservationRecords => _preservationRecords.AsReadOnly();
@@ -41,6 +42,16 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.TagAggregate
             }
 
             _preservationRecords.Add(preservationRecord);
+        }
+
+        public void SetNextDueTimeUtc(DateTime currentTime)
+        {
+            if (currentTime.Kind != DateTimeKind.Utc)
+            {
+                throw new ArgumentException($"{nameof(currentTime)} is not Utc");
+            }
+
+            NextDueTimeUtc = currentTime.AddWeeks(IntervalWeeks);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/TagAggregate/Requirement.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/TagAggregate/Requirement.cs
@@ -34,7 +34,7 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.TagAggregate
         public void Void() => IsVoided = true;
         public void UnVoid() => IsVoided = false;
 
-        public void AddPreservationRecord(PreservationRecord preservationRecord)
+        public void Preserve(PreservationRecord preservationRecord)
         {
             if (preservationRecord == null)
             {
@@ -42,16 +42,7 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.TagAggregate
             }
 
             _preservationRecords.Add(preservationRecord);
-        }
-
-        public void SetNextDueTimeUtc(DateTime currentTime)
-        {
-            if (currentTime.Kind != DateTimeKind.Utc)
-            {
-                throw new ArgumentException($"{nameof(currentTime)} is not Utc");
-            }
-
-            NextDueTimeUtc = currentTime.AddWeeks(IntervalWeeks);
+            NextDueTimeUtc = preservationRecord.PreservedAtUtc.AddWeeks(IntervalWeeks);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Domain/DateTimeExtensions.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/DateTimeExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Equinor.Procosys.Preservation.Command
+namespace Equinor.Procosys.Preservation.Domain
 {
     public static class DateTimeExtensions
     {

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/PersonConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/PersonConfiguration.cs
@@ -22,7 +22,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.Entityconfigurations
 
             builder.HasMany<PreservationRecord>()
                 .WithOne()
-                .HasForeignKey(pr => pr.PreservedBy)
+                .HasForeignKey(pr => pr.PreservedByPersonId)
                 .OnDelete(DeleteBehavior.NoAction)
                 .IsRequired(false);        }
     }

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200116131211_MovedNextDueDateColumn.Designer.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200116131211_MovedNextDueDateColumn.Designer.cs
@@ -4,14 +4,16 @@ using Equinor.Procosys.Preservation.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Equinor.Procosys.Preservation.Infrastructure.Migrations
 {
     [DbContext(typeof(PreservationContext))]
-    partial class PreservationContextModelSnapshot : ModelSnapshot
+    [Migration("20200116131211_MovedNextDueDateColumn")]
+    partial class MovedNextDueDateColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200116131211_MovedNextDueDateColumn.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200116131211_MovedNextDueDateColumn.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Equinor.Procosys.Preservation.Infrastructure.Migrations
+{
+    public partial class MovedNextDueDateColumn : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_PreservationRecords_Persons_PreservedBy",
+                table: "PreservationRecords");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PreservationRecords_PreservedBy",
+                table: "PreservationRecords");
+
+            migrationBuilder.DropColumn(
+                name: "NextDueTimeUtc",
+                table: "PreservationRecords");
+
+            migrationBuilder.DropColumn(
+                name: "PreservedBy",
+                table: "PreservationRecords");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "NextDueTimeUtc",
+                table: "Requirements",
+                nullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "PreservedAtUtc",
+                table: "PreservationRecords",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "BulkPreserved",
+                table: "PreservationRecords",
+                nullable: false,
+                oldClrType: typeof(bool),
+                oldType: "bit",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PreservedByPersonId",
+                table: "PreservationRecords",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PreservationRecords_PreservedByPersonId",
+                table: "PreservationRecords",
+                column: "PreservedByPersonId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PreservationRecords_Persons_PreservedByPersonId",
+                table: "PreservationRecords",
+                column: "PreservedByPersonId",
+                principalTable: "Persons",
+                principalColumn: "Id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_PreservationRecords_Persons_PreservedByPersonId",
+                table: "PreservationRecords");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PreservationRecords_PreservedByPersonId",
+                table: "PreservationRecords");
+
+            migrationBuilder.DropColumn(
+                name: "NextDueTimeUtc",
+                table: "Requirements");
+
+            migrationBuilder.DropColumn(
+                name: "PreservedByPersonId",
+                table: "PreservationRecords");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "PreservedAtUtc",
+                table: "PreservationRecords",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime));
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "BulkPreserved",
+                table: "PreservationRecords",
+                type: "bit",
+                nullable: true,
+                oldClrType: typeof(bool));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "NextDueTimeUtc",
+                table: "PreservationRecords",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<int>(
+                name: "PreservedBy",
+                table: "PreservationRecords",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PreservationRecords_PreservedBy",
+                table: "PreservationRecords",
+                column: "PreservedBy");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PreservationRecords_Persons_PreservedBy",
+                table: "PreservationRecords",
+                column: "PreservedBy",
+                principalTable: "Persons",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.Domain.Tests/AggregateModels/TagAggregate/PreservationRecordTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Domain.Tests/AggregateModels/TagAggregate/PreservationRecordTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.PersonAggregate;
-using Equinor.Procosys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.TagAggregate;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -29,123 +28,27 @@ namespace Equinor.Procosys.Preservation.Domain.Tests.AggregateModels.TagAggregat
         {
             _reqMock.SetupGet(r => r.Id).Returns(3);
 
-            var dut = new PreservationRecord("SchemaA", _reqMock.Object, _utcNow);
+            var dut = new PreservationRecord("SchemaA", _reqMock.Object, _utcNow, _preservedByMock.Object, true, "Comment");
 
             Assert.AreEqual("SchemaA", dut.Schema);
             Assert.AreEqual(_reqMock.Object.Id, dut.RequirementId);
-            Assert.IsFalse(dut.BulkPreserved.HasValue);
-            Assert.IsFalse(dut.PreservedAtUtc.HasValue);
-            Assert.IsFalse(dut.PreservedBy.HasValue);
-        }
-        [TestMethod]
-
-        public void Constructor_ShouldSetCorrectNextDueDateBasedOnRequirement()
-        {
-            var rdMock = new Mock<RequirementDefinition>();
-            var intervalWeeks = 8;
-            var r = new Requirement("SchemaA", intervalWeeks, rdMock.Object);
-
-            var dut = new PreservationRecord("SchemaA", r, _utcNow);
-
-            var expectedNextDueTimeUtc = _utcNow.AddDays(7 * intervalWeeks);
-            Assert.AreEqual(expectedNextDueTimeUtc, dut.NextDueTimeUtc);
+            Assert.AreEqual(_utcNow, dut.PreservedAtUtc);
+            Assert.AreEqual(_preservedById, dut.PreservedByPersonId);
+            Assert.IsTrue(dut.BulkPreserved);
+            Assert.AreEqual("Comment", dut.Comment);
         }
 
         [TestMethod]
         public void Constructor_ShouldThrowException_WhenRequirementNotGiven()
             => Assert.ThrowsException<ArgumentNullException>(() =>
-                new PreservationRecord("SchemaA", null, _utcNow)
+                new PreservationRecord("SchemaA", null, _utcNow, _preservedByMock.Object, true, "Comment")
             );
 
         [TestMethod]
-        public void Constructor_ShouldThrowException_WhenCurrentTimeNotGivenInUtc()
-        {
-            var now = new DateTime(2020, 1, 1, 1, 1, 1, DateTimeKind.Local);
-            Assert.ThrowsException<ArgumentException>(() =>
-                new PreservationRecord("SchemaA", _reqMock.Object, now)
+        public void Constructor_ShouldThrowException_WhenPreservedByNotGiven()
+            => Assert.ThrowsException<ArgumentNullException>(() =>
+                new PreservationRecord("SchemaA", _reqMock.Object, _utcNow, null, true, "Comment")
             );
-        }
 
-        [TestMethod]
-        public void WhenPreserve_ShouldSetPreservedNowByPerson()
-        {
-            var dut = new PreservationRecord("SchemaA", _reqMock.Object, _utcNow);
-
-            dut.Preserve(_preservedByMock.Object, "", _utcNow);
-
-            Assert.IsTrue(dut.PreservedBy.HasValue);
-            Assert.AreEqual(_preservedById, dut.PreservedBy.Value);
-            Assert.IsTrue(dut.PreservedAtUtc.HasValue);
-            Assert.AreEqual(_utcNow, dut.PreservedAtUtc.Value);
-        }
-
-        [TestMethod]
-        public void WhenPreserve_ShouldNotSetBulkPreservedButWithComment()
-        {
-            var dut = new PreservationRecord("SchemaA", _reqMock.Object, _utcNow);
-
-            dut.Preserve(_preservedByMock.Object, "Comment", _utcNow);
-
-            Assert.AreEqual("Comment", dut.Comment);
-            Assert.IsTrue(dut.BulkPreserved.HasValue);
-            Assert.IsFalse(dut.BulkPreserved.Value);
-        }
-
-        [TestMethod]
-        public void WhenBulkPreserve_ShouldSetPreservedNowByPerson()
-        {
-            var dut = new PreservationRecord("SchemaA", _reqMock.Object, _utcNow);
-
-            dut.BulkPreserve(_preservedByMock.Object, _utcNow);
-
-            Assert.IsTrue(dut.PreservedBy.HasValue);
-            Assert.AreEqual(_preservedById, dut.PreservedBy.Value);
-            Assert.IsTrue(dut.PreservedAtUtc.HasValue);
-            Assert.AreEqual(_utcNow, dut.PreservedAtUtc.Value);
-        }
-
-        [TestMethod]
-        public void WhenBulkPreserve_ShouldSetBulkPreservedAndNullComment()
-        {
-            var dut = new PreservationRecord("SchemaA", _reqMock.Object, _utcNow);
-
-            dut.BulkPreserve(_preservedByMock.Object, _utcNow);
-
-            Assert.IsNull(dut.Comment);
-            Assert.IsTrue(dut.BulkPreserved.HasValue);
-            Assert.IsTrue(dut.BulkPreserved.Value);
-        }
-
-        [TestMethod]
-        public void WhenPreserve_ShouldThrowException_WhenPreservedByNotGiven()
-        {
-            var dut = new PreservationRecord("SchemaA", _reqMock.Object, _utcNow);
-            Assert.ThrowsException<ArgumentNullException>(() => dut.Preserve(null, "", _utcNow));
-        }
-
-        [TestMethod]
-        public void WhenPreserve_ShouldThrowException_WhenCurrentTimeNotGivenInUtc()
-        {
-            var now = new DateTime(2020, 1, 1, 1, 1, 1, DateTimeKind.Local);
-            
-            var dut = new PreservationRecord("SchemaA", _reqMock.Object, _utcNow);
-            Assert.ThrowsException<ArgumentException>(() => dut.Preserve(_preservedByMock.Object, "", now));
-        }
-
-        [TestMethod]
-        public void WhenBulkPreserve_ShouldThrowException_WhenPreservedByNotGiven()
-        {
-            var dut = new PreservationRecord("SchemaA", _reqMock.Object, _utcNow);
-            Assert.ThrowsException<ArgumentNullException>(() => dut.BulkPreserve(null, _utcNow));
-        }
-
-        [TestMethod]
-        public void WhenBulkPreserve_ShouldThrowException_WhenCurrentTimeNotGivenInUtc()
-        {
-            var now = new DateTime(2020, 1, 1, 1, 1, 1, DateTimeKind.Local);
-            
-            var dut = new PreservationRecord("SchemaA", _reqMock.Object, _utcNow);
-            Assert.ThrowsException<ArgumentException>(() => dut.BulkPreserve(_preservedByMock.Object, now));
-        }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Domain.Tests/AggregateModels/TagAggregate/PreservationRecordTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Domain.Tests/AggregateModels/TagAggregate/PreservationRecordTests.cs
@@ -10,7 +10,6 @@ namespace Equinor.Procosys.Preservation.Domain.Tests.AggregateModels.TagAggregat
     public class PreservationRecordTests
     {
         private DateTime _utcNow;
-        private Mock<Requirement> _reqMock;
         private int _preservedById = 99;
         private Mock<Person> _preservedByMock;
 
@@ -18,7 +17,6 @@ namespace Equinor.Procosys.Preservation.Domain.Tests.AggregateModels.TagAggregat
         public void Setup()
         {
             _utcNow = new DateTime(2020, 1, 1, 1, 1, 1, DateTimeKind.Utc);
-            _reqMock = new Mock<Requirement>();
             _preservedByMock = new Mock<Person>();
             _preservedByMock.SetupGet(p => p.Id).Returns(_preservedById);
         }
@@ -26,12 +24,9 @@ namespace Equinor.Procosys.Preservation.Domain.Tests.AggregateModels.TagAggregat
         [TestMethod]
         public void Constructor_ShouldSetProperties()
         {
-            _reqMock.SetupGet(r => r.Id).Returns(3);
-
-            var dut = new PreservationRecord("SchemaA", _reqMock.Object, _utcNow, _preservedByMock.Object, true, "Comment");
+            var dut = new PreservationRecord("SchemaA", _utcNow, _preservedByMock.Object, true, "Comment");
 
             Assert.AreEqual("SchemaA", dut.Schema);
-            Assert.AreEqual(_reqMock.Object.Id, dut.RequirementId);
             Assert.AreEqual(_utcNow, dut.PreservedAtUtc);
             Assert.AreEqual(_preservedById, dut.PreservedByPersonId);
             Assert.IsTrue(dut.BulkPreserved);
@@ -39,15 +34,9 @@ namespace Equinor.Procosys.Preservation.Domain.Tests.AggregateModels.TagAggregat
         }
 
         [TestMethod]
-        public void Constructor_ShouldThrowException_WhenRequirementNotGiven()
-            => Assert.ThrowsException<ArgumentNullException>(() =>
-                new PreservationRecord("SchemaA", null, _utcNow, _preservedByMock.Object, true, "Comment")
-            );
-
-        [TestMethod]
         public void Constructor_ShouldThrowException_WhenPreservedByNotGiven()
             => Assert.ThrowsException<ArgumentNullException>(() =>
-                new PreservationRecord("SchemaA", _reqMock.Object, _utcNow, null, true, "Comment")
+                new PreservationRecord("SchemaA", _utcNow, null, true, "Comment")
             );
 
     }

--- a/src/tests/Equinor.Procosys.Preservation.Domain.Tests/AggregateModels/TagAggregate/RequirementTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Domain.Tests/AggregateModels/TagAggregate/RequirementTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.TagAggregate;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -35,6 +36,18 @@ namespace Equinor.Procosys.Preservation.Domain.Tests.AggregateModels.TagAggregat
             );
 
         [TestMethod]
+        public void AddPreservationRecord_ShouldAddPreservationRecordToPreservationRecordsList()
+        {
+            var dut = new Requirement("SchemaA", 24, _reqDefMock.Object);
+            var pr = new Mock<PreservationRecord>();
+
+            dut.AddPreservationRecord(pr.Object);
+
+            Assert.AreEqual(1, dut.PreservationRecords.Count);
+            Assert.IsTrue(dut.PreservationRecords.Contains(pr.Object));
+        }
+
+        [TestMethod]
         public void VoidUnVoid_ShouldToggleIsVoided()
         {
             var dut = new Requirement("SchemaA", 24, _reqDefMock.Object);
@@ -46,5 +59,29 @@ namespace Equinor.Procosys.Preservation.Domain.Tests.AggregateModels.TagAggregat
             dut.UnVoid();
             Assert.IsFalse(dut.IsVoided);
         }
+        
+        [TestMethod]
+        public void SetNextDueTimeUtc_ShouldSetCorrectNextDueDate()
+        {
+            var utcNow = new DateTime(2020, 1, 1, 1, 1, 1, DateTimeKind.Utc);
+            var intervalWeeks = 8;
+            var dut = new Requirement("SchemaA", intervalWeeks, _reqDefMock.Object);
+
+            dut.SetNextDueTimeUtc(utcNow);
+
+            var expectedNextDueTimeUtc = utcNow.AddWeeks(intervalWeeks);
+            Assert.AreEqual(expectedNextDueTimeUtc, dut.NextDueTimeUtc);
+        }
+
+        [TestMethod]
+        public void SetNextDueTimeUtc_ShouldThrowException_WhenTimeNotGivenInUtc()
+        {
+            var dut = new Requirement("SchemaA", 24, _reqDefMock.Object);
+            var now = new DateTime(2020, 1, 1, 1, 1, 1, DateTimeKind.Local);
+            Assert.ThrowsException<ArgumentException>(() =>
+                dut.SetNextDueTimeUtc(now)
+            );
+        }
+
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Domain.Tests/DateTimeExtensionsTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Domain.Tests/DateTimeExtensionsTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Equinor.Procosys.Preservation.Command.Tests
+namespace Equinor.Procosys.Preservation.Domain.Tests
 {
     public class DateTimeExtensionsTests
     {


### PR DESCRIPTION
Moved NextDueTimeUtc column from PreservationRecord to Requirement.
New method on Requirement: SetNextDueTimeUtc
PreservationRecord.PreservedBy renamed to PreservedByPersonId 
Nullable columns in PreservationRecord made not-nullable, and set via ctor.
Updated unit tests