### PR TITLE
Unit test on all command handlers

### DIFF
--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/JourneyAggregate/Journey.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/JourneyAggregate/Journey.cs
@@ -10,7 +10,7 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate
 
         private readonly List<Step> _steps = new List<Step>();
 
-        private Journey()
+        protected Journey()
             : base(null)
         {
         }
@@ -25,7 +25,7 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate
         public void Void() => IsVoided = true;
         public void UnVoid() => IsVoided = false;
 
-        public void AddStep(Step step)
+        public virtual void AddStep(Step step)
         {
             if (step == null)
             {

--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/TagAggregate/Tag.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/TagAggregate/Tag.cs
@@ -78,7 +78,7 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.TagAggregate
         public void Void() => IsVoided = true;
         public void UnVoid() => IsVoided = false;
 
-        public void SetStep(Step step)
+        public virtual void SetStep(Step step)
         {
             if (step == null)
             {

--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/TagAggregate/Tag.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/TagAggregate/Tag.cs
@@ -78,7 +78,7 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.TagAggregate
         public void Void() => IsVoided = true;
         public void UnVoid() => IsVoided = false;
 
-        public virtual void SetStep(Step step)
+        public void SetStep(Step step)
         {
             if (step == null)
             {

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/CommandHandlerTestsBase.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/CommandHandlerTestsBase.cs
@@ -1,0 +1,24 @@
+﻿using Equinor.Procosys.Preservation.Domain;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Equinor.Procosys.Preservation.Command.Tests
+{
+    [TestClass]
+    public class CommandHandlerTestsBase
+    {
+        protected const string TestPlant = "TestPlant";
+        protected Mock<IUnitOfWork> _unitOfWorkMock;
+        protected Mock<IPlantProvider> _plantProviderMock;
+
+        [TestInitialize]
+        public void BaseSetup()
+        {
+            _unitOfWorkMock = new Mock<IUnitOfWork>();
+            _plantProviderMock = new Mock<IPlantProvider>();
+            _plantProviderMock
+                .Setup(x => x.Plant)
+                .Returns(TestPlant);
+        }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/CommandHandlerTestsBase.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/CommandHandlerTestsBase.cs
@@ -5,18 +5,18 @@ using Moq;
 namespace Equinor.Procosys.Preservation.Command.Tests
 {
     [TestClass]
-    public class CommandHandlerTestsBase
+    public abstract class CommandHandlerTestsBase
     {
         protected const string TestPlant = "TestPlant";
-        protected Mock<IUnitOfWork> _unitOfWorkMock;
-        protected Mock<IPlantProvider> _plantProviderMock;
+        protected Mock<IUnitOfWork> UnitOfWorkMock;
+        protected Mock<IPlantProvider> PlantProviderMock;
 
         [TestInitialize]
         public void BaseSetup()
         {
-            _unitOfWorkMock = new Mock<IUnitOfWork>();
-            _plantProviderMock = new Mock<IPlantProvider>();
-            _plantProviderMock
+            UnitOfWorkMock = new Mock<IUnitOfWork>();
+            PlantProviderMock = new Mock<IPlantProvider>();
+            PlantProviderMock
                 .Setup(x => x.Plant)
                 .Returns(TestPlant);
         }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/CreateJourney/CreateJourneyCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/CreateJourney/CreateJourneyCommandHandlerTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.JourneyCommands.CreateJourney;
-using Equinor.Procosys.Preservation.Domain;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -8,14 +7,11 @@ using Moq;
 namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.CreateJourney
 {
     [TestClass]
-    public class CreateJourneyCommandHandlerTests
+    public class CreateJourneyCommandHandlerTests : CommandHandlerTestsBase
     {
-        private const string TestPlant = "TestPlant";
         private const string TestJourney = "TestJourney";
         private Journey _journeyAdded;
         private Mock<IJourneyRepository> _journeyRepositoryMock;
-        private Mock<IUnitOfWork> _unitOfWorkMock;
-        private Mock<IPlantProvider> _plantProviderMock;
         private CreateJourneyCommand _command;
         private CreateJourneyCommandHandler _dut;
         
@@ -30,11 +26,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.CreateJour
                 {
                     _journeyAdded = journey;
                 });
-            _unitOfWorkMock = new Mock<IUnitOfWork>();
-            _plantProviderMock = new Mock<IPlantProvider>();
-            _plantProviderMock
-                .Setup(x => x.Plant)
-                .Returns(TestPlant);
 
             _command = new CreateJourneyCommand(TestJourney);
 

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/CreateJourney/CreateJourneyCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/CreateJourney/CreateJourneyCommandHandlerTests.cs
@@ -1,7 +1,71 @@
-﻿namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.CreateJourney
+﻿using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.JourneyCommands.CreateJourney;
+using Equinor.Procosys.Preservation.Domain;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.CreateJourney
 {
+    [TestClass]
     public class CreateJourneyCommandHandlerTests
     {
-        // todo Henning
+        private const string TestPlant = "TestPlant";
+        private const string TestJourney = "TestJourney";
+        private Journey _journeyAdded;
+        private Mock<IJourneyRepository> _journeyRepositoryMock;
+        private Mock<IUnitOfWork> _unitOfWorkMock;
+        private Mock<IPlantProvider> _plantProviderMock;
+        private CreateJourneyCommand _command;
+        private CreateJourneyCommandHandler _dut;
+        
+        [TestInitialize]
+        public void Setup()
+        {
+            // Arrange
+            _journeyRepositoryMock = new Mock<IJourneyRepository>();
+            _journeyRepositoryMock
+                .Setup(repo => repo.Add(It.IsAny<Journey>()))
+                .Callback<Journey>(journey =>
+                {
+                    _journeyAdded = journey;
+                });
+            _unitOfWorkMock = new Mock<IUnitOfWork>();
+            _plantProviderMock = new Mock<IPlantProvider>();
+            _plantProviderMock
+                .Setup(x => x.Plant)
+                .Returns(TestPlant);
+
+            _command = new CreateJourneyCommand(TestJourney);
+
+            _dut = new CreateJourneyCommandHandler(
+                _journeyRepositoryMock.Object,
+                _unitOfWorkMock.Object,
+                _plantProviderMock.Object);
+        }
+
+        [TestMethod]
+        public async Task HandlingCreateJourneyCommand_ShouldAddJourneyToRepository()
+        {
+            // Act
+            var result = await _dut.Handle(_command, default);
+            
+            // Assert
+            Assert.AreEqual(0, result.Errors.Count);
+            Assert.AreEqual(0, result.Data);
+            Assert.AreEqual(0, _journeyAdded.Id);
+            Assert.AreEqual(TestJourney, _journeyAdded.Title);
+            Assert.AreEqual(TestPlant, _journeyAdded.Schema);
+        }
+
+        [TestMethod]
+        public async Task HandlingCreateJourneyCommand_ShouldSave()
+        {
+            // Act
+            await _dut.Handle(_command, default);
+            
+            // Assert
+            _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+        }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/CreateJourney/CreateJourneyCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/CreateJourney/CreateJourneyCommandHandlerTests.cs
@@ -31,8 +31,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.CreateJour
 
             _dut = new CreateJourneyCommandHandler(
                 _journeyRepositoryMock.Object,
-                _unitOfWorkMock.Object,
-                _plantProviderMock.Object);
+                UnitOfWorkMock.Object,
+                PlantProviderMock.Object);
         }
 
         [TestMethod]
@@ -56,7 +56,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.CreateJour
             await _dut.Handle(_command, default);
             
             // Assert
-            _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+            UnitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/CreateStep/CreateStepCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/CreateStep/CreateStepCommandHandlerTests.cs
@@ -60,8 +60,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.CreateStep
             _dut = new CreateStepCommandHandler(_journeyRepositoryMock.Object,
                 _modeRepositoryMock.Object,
                 _responsibleRepositoryMock.Object,
-                _unitOfWorkMock.Object,
-                _plantProviderMock.Object);
+                UnitOfWorkMock.Object,
+                PlantProviderMock.Object);
         }
 
         [TestMethod]
@@ -83,7 +83,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.CreateStep
             await _dut.Handle(_command, default);
             
             // Assert
-            _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+            UnitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/CreateStep/CreateStepCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/CreateStep/CreateStepCommandHandlerTests.cs
@@ -10,9 +10,8 @@ using Moq;
 namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.CreateStep
 {
     [TestClass]
-    public class CreateStepCommandHandlerTests
+    public class CreateStepCommandHandlerTests : CommandHandlerTestsBase
     {
-        private const string TestPlant = "TestPlant";
         private const int JourneyId = 1;
         private const int ModeId = 2;
         private const int ResponsibleId = 3;
@@ -23,8 +22,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.CreateStep
         private Mock<Responsible> _responsibleMock;
         private Mock<IModeRepository> _modeRepositoryMock;
         private Mock<IResponsibleRepository> _responsibleRepositoryMock;
-        private Mock<IUnitOfWork> _unitOfWorkMock;
-        private Mock<IPlantProvider> _plantProviderMock;
         private CreateStepCommand _command;
         private CreateStepCommandHandler _dut;
 
@@ -57,12 +54,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.CreateStep
             _responsibleRepositoryMock
                 .Setup(r => r.GetByIdAsync(ResponsibleId))
                 .Returns(Task.FromResult(_responsibleMock.Object));
-
-            _unitOfWorkMock = new Mock<IUnitOfWork>();
-            _plantProviderMock = new Mock<IPlantProvider>();
-            _plantProviderMock
-                .Setup(x => x.Plant)
-                .Returns(TestPlant);
 
             _command = new CreateStepCommand(JourneyId, ModeId, ResponsibleId);
 

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/CreateStep/CreateStepCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/CreateStep/CreateStepCommandHandlerTests.cs
@@ -1,7 +1,98 @@
-﻿namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.CreateStep
+﻿using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.JourneyCommands.CreateStep;
+using Equinor.Procosys.Preservation.Domain;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.ModeAggregate;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.ResponsibleAggregate;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.CreateStep
 {
+    [TestClass]
     public class CreateStepCommandHandlerTests
     {
-        // todo Henning
+        private const string TestPlant = "TestPlant";
+        private const int JourneyId = 1;
+        private const int ModeId = 2;
+        private const int ResponsibleId = 3;
+        private Step _stepAdded;
+        private Mock<IJourneyRepository> _journeyRepositoryMock;
+        private Mock<Journey> _journeyMock;
+        private Mock<Mode> _modeMock;
+        private Mock<Responsible> _responsibleMock;
+        private Mock<IModeRepository> _modeRepositoryMock;
+        private Mock<IResponsibleRepository> _responsibleRepositoryMock;
+        private Mock<IUnitOfWork> _unitOfWorkMock;
+        private Mock<IPlantProvider> _plantProviderMock;
+        private CreateStepCommand _command;
+        private CreateStepCommandHandler _dut;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            // Arrange
+            _journeyRepositoryMock = new Mock<IJourneyRepository>();
+            _journeyMock = new Mock<Journey>();
+            _journeyRepositoryMock
+                .Setup(r => r.GetByIdAsync(JourneyId))
+                .Returns(Task.FromResult(_journeyMock.Object));
+            _journeyMock
+                .Setup(journey => journey.AddStep(It.IsAny<Step>()))
+                .Callback<Step>(step =>
+                {
+                    _stepAdded = step;
+                });
+
+            _modeRepositoryMock = new Mock<IModeRepository>();
+            _modeMock = new Mock<Mode>();
+            _modeMock.SetupGet(x => x.Id).Returns(ModeId);
+            _modeRepositoryMock
+                .Setup(r => r.GetByIdAsync(ModeId))
+                .Returns(Task.FromResult(_modeMock.Object));
+
+            _responsibleRepositoryMock = new Mock<IResponsibleRepository>();
+            _responsibleMock = new Mock<Responsible>();
+            _responsibleMock.SetupGet(x => x.Id).Returns(ResponsibleId);
+            _responsibleRepositoryMock
+                .Setup(r => r.GetByIdAsync(ResponsibleId))
+                .Returns(Task.FromResult(_responsibleMock.Object));
+
+            _unitOfWorkMock = new Mock<IUnitOfWork>();
+            _plantProviderMock = new Mock<IPlantProvider>();
+            _plantProviderMock
+                .Setup(x => x.Plant)
+                .Returns(TestPlant);
+
+            _command = new CreateStepCommand(JourneyId, ModeId, ResponsibleId);
+
+            _dut = new CreateStepCommandHandler(_journeyRepositoryMock.Object,
+                _modeRepositoryMock.Object,
+                _responsibleRepositoryMock.Object,
+                _unitOfWorkMock.Object,
+                _plantProviderMock.Object);
+        }
+
+        [TestMethod]
+        public async Task HandlingCreateStepCommand_ShouldAddStepToJourney()
+        {
+            // Act
+            var result = await _dut.Handle(_command, default);
+            
+            // Assert
+            _journeyMock.Verify(u => u.AddStep(It.IsAny<Step>()), Times.Once);
+            Assert.AreEqual(ModeId, _stepAdded.ModeId);
+            Assert.AreEqual(ResponsibleId, _stepAdded.ResponsibleId);
+        }
+
+        [TestMethod]
+        public async Task HandlingCreateStepCommand_ShouldSave()
+        {
+            // Act
+            await _dut.Handle(_command, default);
+            
+            // Assert
+            _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+        }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/CreateMode/CreateModeCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/CreateMode/CreateModeCommandHandlerTests.cs
@@ -59,6 +59,5 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.CreateMode
             // Assert
             _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
         }
-
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/CreateMode/CreateModeCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/CreateMode/CreateModeCommandHandlerTests.cs
@@ -3,7 +3,7 @@
 namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.CreateMode
 {
     [TestClass]
-    public class DeleteModeCommandHandlerTests
+    public class CreateModeCommandHandlerTests
     {
         // todo Henning
     }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/CreateMode/CreateModeCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/CreateMode/CreateModeCommandHandlerTests.cs
@@ -31,8 +31,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.CreateMode
 
             _dut = new CreateModeCommandHandler(
                 _modeRepositoryMock.Object,
-                _unitOfWorkMock.Object,
-                _plantProviderMock.Object
+                UnitOfWorkMock.Object,
+                PlantProviderMock.Object
                 );
         }
 
@@ -57,7 +57,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.CreateMode
             await _dut.Handle(_command, default);
             
             // Assert
-            _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+            UnitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/CreateMode/CreateModeCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/CreateMode/CreateModeCommandHandlerTests.cs
@@ -1,10 +1,64 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.ModeCommands.CreateMode;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.ModeAggregate;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 
 namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.CreateMode
 {
     [TestClass]
-    public class CreateModeCommandHandlerTests
+    public class CreateModeCommandHandlerTests : CommandHandlerTestsBase
     {
-        // todo Henning
+        private const string TestMode = "TestMode";
+        private Mock<IModeRepository> _modeRepositoryMock;
+        private Mode _modeAdded;
+        private CreateModeCommand _command;
+        private CreateModeCommandHandler _dut;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            // Arrange
+            _modeRepositoryMock = new Mock<IModeRepository>();
+            _modeRepositoryMock
+                .Setup(x => x.Add(It.IsAny<Mode>()))
+                .Callback<Mode>(x =>
+                {
+                    _modeAdded = x;
+                });
+
+            _command = new CreateModeCommand(TestMode);
+
+            _dut = new CreateModeCommandHandler(
+                _modeRepositoryMock.Object,
+                _unitOfWorkMock.Object,
+                _plantProviderMock.Object
+                );
+        }
+
+        
+        [TestMethod]
+        public async Task HandlingCreateModeCommand_ShouldAddModeToRepository()
+        {
+            // Act
+            var result = await _dut.Handle(_command, default);
+            
+            // Assert
+            Assert.AreEqual(0, result.Errors.Count);
+            Assert.AreEqual(0, result.Data);
+            Assert.AreEqual(0, _modeAdded.Id);
+            Assert.AreEqual(TestMode, _modeAdded.Title);
+        }
+
+        [TestMethod]
+        public async Task HandlingCreateModeCommand_ShouldSave()
+        {
+            // Act
+            await _dut.Handle(_command, default);
+            
+            // Assert
+            _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+        }
+
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/DeleteMode/DeleteModeCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/DeleteMode/DeleteModeCommandHandlerTests.cs
@@ -30,7 +30,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.DeleteMode
 
             _dut = new DeleteModeCommandHandler(
                 _modeRepositoryMock.Object,
-                _unitOfWorkMock.Object
+                UnitOfWorkMock.Object
             );
         }
 
@@ -51,7 +51,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.DeleteMode
             await _dut.Handle(_command, default);
             
             // Assert
-            _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+            UnitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/DeleteMode/DeleteModeCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/DeleteMode/DeleteModeCommandHandlerTests.cs
@@ -1,10 +1,57 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.ModeCommands.DeleteMode;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.ModeAggregate;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 
 namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.DeleteMode
 {
     [TestClass]
-    public class DeleteModeCommandHandlerTests
+    public class DeleteModeCommandHandlerTests : CommandHandlerTestsBase
     {
-        // todo Henning
+        private const int ModeId = 12;
+        private Mock<IModeRepository> _modeRepositoryMock;
+        private Mock<Mode> _modeMock;
+        private DeleteModeCommand _command;
+        private DeleteModeCommandHandler _dut;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            // Arrange
+            _modeRepositoryMock = new Mock<IModeRepository>();
+            _modeMock = new Mock<Mode>();
+            _modeMock.SetupGet(m => m.Id).Returns(ModeId);
+            _modeRepositoryMock
+                .Setup(x => x.GetByIdAsync(ModeId))
+                    .Returns(Task.FromResult(_modeMock.Object));
+
+            _command = new DeleteModeCommand(ModeId);
+
+            _dut = new DeleteModeCommandHandler(
+                _modeRepositoryMock.Object,
+                _unitOfWorkMock.Object
+            );
+        }
+
+        [TestMethod]
+        public async Task HandlingDeleteModeCommand_ShouldDeleteModeFromRepository()
+        {
+            // Act
+            await _dut.Handle(_command, default);
+            
+            // Assert
+            _modeRepositoryMock.Verify(r => r.Remove(_modeMock.Object), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task HandlingDeleteModeCommand_ShouldSave()
+        {
+            // Act
+            await _dut.Handle(_command, default);
+            
+            // Assert
+            _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+        }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateTag/CreateTagCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateTag/CreateTagCommandHandlerTests.cs
@@ -97,7 +97,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateTag
         [TestMethod]
         public async Task HandlingCreateTagCommand_ShouldAddTagToRepository()
         {
-            // Arrange
             // Act
             var result = await _dut.Handle(_command, default);
 

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateTag/CreateTagCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateTag/CreateTagCommandHandlerTests.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.TagCommands.CreateTag;
-using Equinor.Procosys.Preservation.Domain;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.ModeAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
@@ -16,7 +15,7 @@ using Requirement = Equinor.Procosys.Preservation.Command.TagCommands.CreateTag.
 namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateTag
 {
     [TestClass]
-    public class CreateTagCommandHandlerTests
+    public class CreateTagCommandHandlerTests : CommandHandlerTestsBase
     {
         [TestMethod]
         public async Task HandlingCreateTagCommand_ShouldAddTagToRepository()
@@ -49,12 +48,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateTag
                 .Setup(r => r.GetRequirementDefinitionByIdAsync(requirementDefinitionId))
                 .Returns(Task.FromResult(requirementDefinition.Object));
 
-            var unitOfWork = new Mock<IUnitOfWork>();
-
-            var plantProvider = new Mock<IPlantProvider>();
-            plantProvider
-                .Setup(x => x.Plant)
-                .Returns("TestPlant");
 
             var tagDetails = new ProcosysTagDetails();
             tagDetails.AreaCode = "AreaCode";
@@ -84,8 +77,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateTag
                 tagRepository.Object,
                 journeyRepository.Object,
                 requirementTypeRepository.Object,
-                unitOfWork.Object,
-                plantProvider.Object,
+                _unitOfWorkMock.Object,
+                _plantProviderMock.Object,
                 tagApiService.Object);
 
             // Act

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateTag/CreateTagCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateTag/CreateTagCommandHandlerTests.cs
@@ -89,8 +89,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateTag
                 _tagRepositoryMock.Object,
                 _journeyRepositoryMock.Object,
                 _rtRepositoryMock.Object,
-                _unitOfWorkMock.Object,
-                _plantProviderMock.Object,
+                UnitOfWorkMock.Object,
+                PlantProviderMock.Object,
                 _tagApiServiceMock.Object);
         }
 
@@ -128,7 +128,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateTag
             await _dut.Handle(_command, default);
             
             // Assert
-            _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+            UnitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateTag/CreateTagCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateTag/CreateTagCommandHandlerTests.cs
@@ -3,9 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.TagCommands.CreateTag;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate;
-using Equinor.Procosys.Preservation.Domain.AggregateModels.ModeAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
-using Equinor.Procosys.Preservation.Domain.AggregateModels.ResponsibleAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.TagAggregate;
 using Equinor.Procosys.Preservation.MainApi.Tag;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -17,91 +15,120 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateTag
     [TestClass]
     public class CreateTagCommandHandlerTests : CommandHandlerTestsBase
     {
+        private const int StepId = 11;
+        private const int RequirementDefinitionId = 99;
+
+        private Mock<Step> _stepMock;
+        private Mock<IJourneyRepository> _journeyRepositoryMock;
+        private Tag _tagAddedToRepository;
+        private Mock<ITagRepository> _tagRepositoryMock;
+        private Mock<IRequirementTypeRepository> _rtRepositoryMock;
+        private Mock<RequirementDefinition> _rdMock;
+        private Mock<ITagApiService> _tagApiServiceMock;
+
+        private ProcosysTagDetails _mainTagDetails;
+        private CreateTagCommand _command;
+        private CreateTagCommandHandler _dut;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            // Arrange
+            _stepMock = new Mock<Step>();
+            _stepMock.SetupGet(x => x.Id).Returns(StepId);
+            
+            _journeyRepositoryMock = new Mock<IJourneyRepository>();
+            _journeyRepositoryMock
+                .Setup(x => x.GetStepByStepIdAsync(StepId))
+                .Returns(Task.FromResult(_stepMock.Object));
+
+            _tagRepositoryMock = new Mock<ITagRepository>();
+            _tagRepositoryMock
+                .Setup(x => x.Add(It.IsAny<Tag>()))
+                .Callback<Tag>(x =>
+                {
+                    _tagAddedToRepository = x;
+                });
+
+            _rtRepositoryMock = new Mock<IRequirementTypeRepository>();
+            _rdMock = new Mock<RequirementDefinition>();
+            _rdMock.SetupGet(x => x.Id).Returns(RequirementDefinitionId);
+            _rtRepositoryMock
+                .Setup(r => r.GetRequirementDefinitionByIdAsync(RequirementDefinitionId))
+                .Returns(Task.FromResult(_rdMock.Object));
+
+            _mainTagDetails =
+                new ProcosysTagDetails
+                {
+                    AreaCode = "AreaCode",
+                    CallOffNo = "CalloffNo",
+                    CommPkgNo = "CommPkgNo",
+                    Description = "Description",
+                    DisciplineCode = "DisciplineCode",
+                    McPkgNo = "McPkgNo",
+                    PurchaseOrderNo = "PurchaseOrderNo",
+                    TagFunctionCode = "TagFunctionCode",
+                    TagNo = "TagNo"
+                };
+            
+            _tagApiServiceMock = new Mock<ITagApiService>();
+            _tagApiServiceMock
+                .Setup(x => x.GetTagDetails(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(Task.FromResult(_mainTagDetails));
+
+            _command = new CreateTagCommand(
+                "TagNo",
+                "ProjectNumber",
+                StepId,
+                new List<Requirement>
+                {
+                    new Requirement(RequirementDefinitionId, 1)
+                });
+            
+            _dut = new CreateTagCommandHandler(
+                _tagRepositoryMock.Object,
+                _journeyRepositoryMock.Object,
+                _rtRepositoryMock.Object,
+                _unitOfWorkMock.Object,
+                _plantProviderMock.Object,
+                _tagApiServiceMock.Object);
+        }
+
         [TestMethod]
         public async Task HandlingCreateTagCommand_ShouldAddTagToRepository()
         {
             // Arrange
-            var mode = new Mock<Mode>("TestPlant", "ModeTitle");
-            var responsible = new Mock<Responsible>("TestPlant", "ResponsibleName");
-            var stepId = 11;
-            var step = new Mock<Step>("TestPlant", mode.Object, responsible.Object);
-            step.SetupGet(x => x.Id).Returns(stepId);
-            var journeyRepository = new Mock<IJourneyRepository>();
-            journeyRepository
-                .Setup(x => x.GetStepByStepIdAsync(stepId))
-                .Returns(Task.FromResult(step.Object));
-
-            Tag tagAddedToRepository = null;
-            var tagRepository = new Mock<ITagRepository>();
-            tagRepository
-                .Setup(x => x.Add(It.IsAny<Tag>()))
-                .Callback<Tag>(x =>
-                {
-                    tagAddedToRepository = x;
-                });
-
-            var requirementTypeRepository = new Mock<IRequirementTypeRepository>();
-            var requirementDefinition = new Mock<RequirementDefinition>("TestPlant", "Title", 4, 1);
-            var requirementDefinitionId = 99;
-            requirementDefinition.SetupGet(x => x.Id).Returns(requirementDefinitionId);
-            requirementTypeRepository
-                .Setup(r => r.GetRequirementDefinitionByIdAsync(requirementDefinitionId))
-                .Returns(Task.FromResult(requirementDefinition.Object));
-
-
-            var tagDetails = new ProcosysTagDetails();
-            tagDetails.AreaCode = "AreaCode";
-            tagDetails.CallOffNo = "CalloffNo";
-            tagDetails.CommPkgNo = "CommPkgNo";
-            tagDetails.Description = "Description";
-            tagDetails.DisciplineCode = "DisciplineCode";
-            tagDetails.McPkgNo = "McPkgNo";
-            tagDetails.PurchaseOrderNo = "PurchaseOrderNo";
-            tagDetails.TagFunctionCode = "TagFunctionCode";
-            tagDetails.TagNo = "TagNo";
-            var tagApiService = new Mock<ITagApiService>();
-            tagApiService
-                .Setup(x => x.GetTagDetails(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(Task.FromResult(tagDetails));
-
-            var command = new CreateTagCommand(
-                "TagNo",
-                "ProjectNumber",
-                stepId,
-                new List<Requirement>
-                {
-                    new Requirement(requirementDefinitionId, 1)
-                });
-            
-            var dut = new CreateTagCommandHandler(
-                tagRepository.Object,
-                journeyRepository.Object,
-                requirementTypeRepository.Object,
-                _unitOfWorkMock.Object,
-                _plantProviderMock.Object,
-                tagApiService.Object);
-
             // Act
-            var result = await dut.Handle(command, default);
+            var result = await _dut.Handle(_command, default);
 
             // Assert
             Assert.AreEqual(0, result.Errors.Count);
             Assert.AreEqual(0, result.Data);
-            Assert.AreEqual("AreaCode", tagAddedToRepository.AreaCode);
-            Assert.AreEqual("CalloffNo", tagAddedToRepository.CalloffNumber);
-            Assert.AreEqual("CommPkgNo", tagAddedToRepository.CommPkgNumber);
-            Assert.AreEqual("DisciplineCode", tagAddedToRepository.DisciplineCode);
-            Assert.AreEqual(0, tagAddedToRepository.Id);
-            Assert.AreEqual(false, tagAddedToRepository.IsAreaTag);
-            Assert.AreEqual("McPkgNo", tagAddedToRepository.McPkcNumber);
-            Assert.AreEqual("ProjectNumber", tagAddedToRepository.ProjectNumber);
-            Assert.AreEqual("PurchaseOrderNo", tagAddedToRepository.PurchaseOrderNumber);
-            Assert.AreEqual("TestPlant", tagAddedToRepository.Schema);
-            Assert.AreEqual(stepId, tagAddedToRepository.StepId);
-            Assert.AreEqual("TagFunctionCode", tagAddedToRepository.TagFunctionCode);
-            Assert.AreEqual("TagNo", tagAddedToRepository.TagNo);
-            Assert.AreEqual(1, tagAddedToRepository.Requirements.Count);
-            Assert.AreEqual(requirementDefinitionId, tagAddedToRepository.Requirements.First().RequirementDefinitionId);
+            Assert.AreEqual("AreaCode", _tagAddedToRepository.AreaCode);
+            Assert.AreEqual("CalloffNo", _tagAddedToRepository.CalloffNumber);
+            Assert.AreEqual("CommPkgNo", _tagAddedToRepository.CommPkgNumber);
+            Assert.AreEqual("DisciplineCode", _tagAddedToRepository.DisciplineCode);
+            Assert.AreEqual(0, _tagAddedToRepository.Id);
+            Assert.AreEqual(false, _tagAddedToRepository.IsAreaTag);
+            Assert.AreEqual("McPkgNo", _tagAddedToRepository.McPkcNumber);
+            Assert.AreEqual("ProjectNumber", _tagAddedToRepository.ProjectNumber);
+            Assert.AreEqual("PurchaseOrderNo", _tagAddedToRepository.PurchaseOrderNumber);
+            Assert.AreEqual("TestPlant", _tagAddedToRepository.Schema);
+            Assert.AreEqual(StepId, _tagAddedToRepository.StepId);
+            Assert.AreEqual("TagFunctionCode", _tagAddedToRepository.TagFunctionCode);
+            Assert.AreEqual("TagNo", _tagAddedToRepository.TagNo);
+            Assert.AreEqual(1, _tagAddedToRepository.Requirements.Count);
+            Assert.AreEqual(RequirementDefinitionId, _tagAddedToRepository.Requirements.First().RequirementDefinitionId);
+        }
+
+        [TestMethod]
+        public async Task HandlingCreateTagCommand_ShouldSave()
+        {
+            // Act
+            await _dut.Handle(_command, default);
+            
+            // Assert
+            _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/SetStep/SetStepCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/SetStep/SetStepCommandHandlerTests.cs
@@ -1,7 +1,70 @@
-﻿namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.SetStep
+﻿using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.TagCommands.SetStep;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.TagAggregate;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.SetStep
 {
+    [TestClass]
     public class SetStepCommandHandlerTests : CommandHandlerTestsBase
     {
-        // todo Henning
+        private const int StepId = 11;
+        private const int TagId = 99;
+
+        private Mock<Tag> _tagMock;
+        private Mock<Step> _stepMock;
+        private Mock<IJourneyRepository> _journeyRepositoryMock;
+        private Mock<ITagRepository> _tagRepositoryMock;
+        private SetStepCommand _command;
+        private SetStepCommandHandler _dut;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            // Arrange
+            _tagMock = new Mock<Tag>();
+            _tagMock.SetupGet(x => x.Id).Returns(TagId);
+            _stepMock = new Mock<Step>();
+            _stepMock.SetupGet(x => x.Id).Returns(StepId);
+
+            _tagRepositoryMock = new Mock<ITagRepository>();
+            _tagRepositoryMock
+                .Setup(x => x.GetByIdAsync(TagId))
+                .Returns(Task.FromResult(_tagMock.Object));
+
+            _journeyRepositoryMock = new Mock<IJourneyRepository>();
+            _journeyRepositoryMock
+                .Setup(x => x.GetStepByStepIdAsync(StepId))
+                .Returns(Task.FromResult(_stepMock.Object));
+
+            _command = new SetStepCommand(TagId, StepId);
+            
+            _dut = new SetStepCommandHandler(
+                _tagRepositoryMock.Object,
+                _journeyRepositoryMock.Object,
+                _unitOfWorkMock.Object);
+        }
+
+        [TestMethod]
+        public async Task HandlingSetStepCommand_ShouldAddTagToRepository()
+        {
+            // Act
+            var result = await _dut.Handle(_command, default);
+
+            // Assert
+            _tagMock.Verify(t => t.SetStep(_stepMock.Object), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task HandlingSetStepCommand_ShouldSave()
+        {
+            // Act
+            await _dut.Handle(_command, default);
+            
+            // Assert
+            _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+        }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/SetStep/SetStepCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/SetStep/SetStepCommandHandlerTests.cs
@@ -1,6 +1,6 @@
 ﻿namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.SetStep
 {
-    public class SetStepCommandHandlerTests
+    public class SetStepCommandHandlerTests : CommandHandlerTestsBase
     {
         // todo Henning
     }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/SetStep/SetStepCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/SetStep/SetStepCommandHandlerTests.cs
@@ -48,13 +48,13 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.SetStep
         }
 
         [TestMethod]
-        public async Task HandlingSetStepCommand_ShouldAddTagToRepository()
+        public async Task HandlingSetStepCommand_ShouldSetStepIdOnTag()
         {
             // Act
             var result = await _dut.Handle(_command, default);
 
             // Assert
-            _tagMock.Verify(t => t.SetStep(_stepMock.Object), Times.Once);
+            Assert.AreEqual(StepId, _tagMock.Object.StepId);
         }
 
         [TestMethod]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/SetStep/SetStepCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/SetStep/SetStepCommandHandlerTests.cs
@@ -44,7 +44,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.SetStep
             _dut = new SetStepCommandHandler(
                 _tagRepositoryMock.Object,
                 _journeyRepositoryMock.Object,
-                _unitOfWorkMock.Object);
+                UnitOfWorkMock.Object);
         }
 
         [TestMethod]
@@ -64,7 +64,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.SetStep
             await _dut.Handle(_command, default);
             
             // Assert
-            _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+            UnitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
         }
     }
 }


### PR DESCRIPTION
Unit test on all missing CommandHandlers.
Abstract CommandHandlerTestsBase.cs is base on all test classes testing command handlers since IUnitOfWork and IPlantProvider is often needed