### PR TITLE
71858 Endpoint getting unique and used requirement types on tags

### DIFF
--- a/src/Equinor.Procosys.Preservation.Query/GetTagRequirements/GetTagRequirementsQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetTagRequirements/GetTagRequirementsQueryHandler.cs
@@ -15,10 +15,7 @@ namespace Equinor.Procosys.Preservation.Query.GetTagRequirements
     {
         private readonly IReadOnlyContext _context;
 
-        public GetTagRequirementsQueryHandler(IReadOnlyContext context)
-        {
-            _context = context;
-        }
+        public GetTagRequirementsQueryHandler(IReadOnlyContext context) => _context = context;
 
         public async Task<Result<List<RequirementDto>>> Handle(GetTagRequirementsQuery request, CancellationToken cancellationToken)
         {
@@ -26,7 +23,7 @@ namespace Equinor.Procosys.Preservation.Query.GetTagRequirements
             var tag = await
                 (from t in _context.QuerySet<Tag>()
                         .Include(t => t.Requirements).ThenInclude(r => r.PreservationPeriods).ThenInclude(p => p.PreservationRecord)
-                        .Include(p => p.Requirements).ThenInclude(r => r.PreservationPeriods).ThenInclude(p => p.FieldValues)
+                        .Include(t => t.Requirements).ThenInclude(r => r.PreservationPeriods).ThenInclude(p => p.FieldValues)
                  where t.Id == request.Id
                  select t).FirstOrDefaultAsync(cancellationToken);
 

--- a/src/Equinor.Procosys.Preservation.Query/GetUniqueTagRequirementTypes/GetUniqueTagRequirementTypesQuery.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetUniqueTagRequirementTypes/GetUniqueTagRequirementTypesQuery.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using MediatR;
+using ServiceResult;
+
+namespace Equinor.Procosys.Preservation.Query.GetUniqueTagRequirementTypes
+{
+    public class GetUniqueTagRequirementTypesQuery : IRequest<Result<List<RequirementTypeDto>>>
+    {
+        public GetUniqueTagRequirementTypesQuery(string projectName) => ProjectName = projectName;
+
+        public string ProjectName { get; }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Query/GetUniqueTagRequirementTypes/GetUniqueTagRequirementTypesQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetUniqueTagRequirementTypes/GetUniqueTagRequirementTypesQueryHandler.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Domain;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using ServiceResult;
+
+namespace Equinor.Procosys.Preservation.Query.GetUniqueTagRequirementTypes
+{
+    public class GetUniqueTagRequirementTypesQueryHandler : IRequestHandler<GetUniqueTagRequirementTypesQuery, Result<List<RequirementTypeDto>>>
+    {
+        private readonly IReadOnlyContext _context;
+
+        public GetUniqueTagRequirementTypesQueryHandler(IReadOnlyContext context) => _context = context;
+
+        public async Task<Result<List<RequirementTypeDto>>> Handle(GetUniqueTagRequirementTypesQuery request, CancellationToken cancellationToken)
+        {
+            var requirementTypes = await
+                (from requirementType in _context.QuerySet<RequirementType>()
+                        join requirementDefinition in _context.QuerySet<RequirementDefinition>()
+                            on requirementType.Id equals EF.Property<int>(requirementDefinition, "RequirementTypeId")
+                        join requirement in _context.QuerySet<Requirement>()
+                            on requirementDefinition.Id equals requirement.RequirementDefinitionId
+                        join tag in _context.QuerySet<Tag>()
+                            on EF.Property<int>(requirement, "TagId") equals tag.Id
+                        join project in _context.QuerySet<Project>()
+                            on EF.Property<int>(tag, "ProjectId") equals project.Id
+                 where project.Name == request.ProjectName
+                 select new RequirementTypeDto(
+                     requirementType.Id,
+                     requirementType.Code,
+                     requirementType.Title))
+                .Distinct()
+                .ToListAsync(cancellationToken);
+            
+            return new SuccessResult<List<RequirementTypeDto>>(requirementTypes);
+        }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Query/GetUniqueTagRequirementTypes/RequirementTypeDto.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetUniqueTagRequirementTypes/RequirementTypeDto.cs
@@ -1,0 +1,16 @@
+﻿namespace Equinor.Procosys.Preservation.Query.GetUniqueTagRequirementTypes
+{
+    public class RequirementTypeDto
+    {
+        public RequirementTypeDto(int id, string code, string title)
+        {
+            Id = id;
+            Code = code;
+            Title = title;
+        }
+
+        public int Id { get; }
+        public string Code { get; }
+        public string Title { get; }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/FilterValues/FilterValuesController.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/FilterValues/FilterValuesController.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Query.GetUniqueTagRequirementTypes;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using ServiceResult.ApiExtensions;
+
+namespace Equinor.Procosys.Preservation.WebApi.Controllers.FilterValues
+{
+    [ApiController]
+    [Route("FilterValues")]
+    public class FilterValuesController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+
+        public FilterValuesController(IMediator mediator) => _mediator = mediator;
+
+        [HttpGet("RequirementTypes")]
+        public async Task<ActionResult<List<RequirementTypeDto>>> GetRequirementType([FromQuery] string projectName)
+        {
+            var result = await _mediator.Send(new GetUniqueTagRequirementTypesQuery(projectName));
+            return this.FromResult(result);
+        }
+
+        // Henning: I've added code for 2 more endpoints to let you see how I think .... one endpoint pr. filter type. There will be for Responsible, Area, Mode, Discipline, TagFunction too
+        // Implementation inside each GetUniqueTagXXXXXQuery will be as GetUniqueTagRequirementTypesQuery: pick unique used values for all tags in project to give user filter value to choose from
+        //[HttpGet("Steps")]
+        //public async Task<ActionResult<List<StepDto>>> GetSteps([FromQuery] string projectName)
+        //{
+        //    var result = await _mediator.Send(new GetUniqueTagStepsQuery(projectName));
+        //    return this.FromResult(result);
+        //}
+
+        //[HttpGet("Journeys")]
+        //public async Task<ActionResult<List<JourneyDto>>> GetJourneys([FromQuery] string projectName)
+        //{
+        //    var result = await _mediator.Send(new GetUniqueTagJourneys|Query(projectName));
+        //    return this.FromResult(result);
+        //}
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/FieldValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/FieldValidatorTests.cs
@@ -19,8 +19,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                AddPerson(context, _currentUserOid, "Ole", "Lukkøye");
-
                 var rd = AddRequirementTypeWith1DefWithoutField(context, "T", "D").RequirementDefinitions.Single();
 
                 _infoFieldId = AddInfoField(context, rd, "I").Id;

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/FieldValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/FieldValidatorTests.cs
@@ -56,7 +56,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
             {
                 var field = context.Fields.Single(f => f.Id == _infoFieldId);
                 field.Void();
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
             }
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/JourneyValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/JourneyValidatorTests.cs
@@ -73,7 +73,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
             {
                 var journey = context.Journeys.Single(j => j.Id == _journeyId);
                 journey.Void();
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
             }
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/JourneyValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/JourneyValidatorTests.cs
@@ -18,8 +18,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                AddPerson(context, _currentUserOid, "Ole", "Lukkøye");
-
                 _journeyId = AddJourneyWithStep(context, JourneyTitle, AddMode(context, "M"), AddResponsible(context, "R")).Id;
             }
         }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/ModeValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/ModeValidatorTests.cs
@@ -76,7 +76,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
             {
                 var mode = context.Modes.Single(m => m.Id == _modeId);
                 mode.Void();
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
             }
 
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/ModeValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/ModeValidatorTests.cs
@@ -18,8 +18,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                AddPerson(context, _currentUserOid, "Ole", "Lukkøye");
-
                 var mode = AddMode(context, ModeTitle);
                 var responsible = AddResponsible(context, "R");
                 AddJourneyWithStep(context, "J", mode, responsible);

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/ProjectValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/ProjectValidatorTests.cs
@@ -22,8 +22,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                AddPerson(context, _currentUserOid, "Ole", "Lukkøye");
-
                 var step = AddJourneyWithStep(context, "J", AddMode(context, "M"), AddResponsible(context, "R")).Steps.First();
                 var notClosedProject = AddProject(context, ProjectNameNotClosed, "Project description");
                 var closedProject = AddProject(context, ProjectNameClosed, "Project description", true);

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RequirementDefinitionValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RequirementDefinitionValidatorTests.cs
@@ -50,7 +50,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
             {
                 var reqDef = context.RequirementDefinitions.Single(rd => rd.Id == _reqDefId);
                 reqDef.Void();
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
             }
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RequirementDefinitionValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RequirementDefinitionValidatorTests.cs
@@ -17,8 +17,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                AddPerson(context, _currentUserOid, "Ole", "Lukkøye");
-
                 _reqDefId = AddRequirementTypeWith1DefWithoutField(context, "R", "D").RequirementDefinitions.First().Id;
             }
         }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/ResponsibleValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/ResponsibleValidatorTests.cs
@@ -50,7 +50,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
             {
                 var responsible = context.Responsibles.Single(r => r.Id == _responsibleId);
                 responsible.Void();
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
             }
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/ResponsibleValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/ResponsibleValidatorTests.cs
@@ -17,8 +17,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                AddPerson(context, _currentUserOid, "Ole", "Lukkøye");
-
                 _responsibleId = AddResponsible(context, "R").Id;
             }
         }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/StepValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/StepValidatorTests.cs
@@ -17,8 +17,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                AddPerson(context, _currentUserOid, "Ole", "Lukkøye");
-
                 _stepId = AddJourneyWithStep(context, "J", AddMode(context, "M"), AddResponsible(context, "R")).Steps.First().Id;
             }
         }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/StepValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/StepValidatorTests.cs
@@ -50,7 +50,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
             {
                 var step = context.Steps.Single(s => s.Id == _stepId);
                 step.Void();
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
             }
 
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/TagValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/TagValidatorTests.cs
@@ -33,8 +33,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                AddPerson(context, _currentUserOid, "Ole", "Lukkøye");
-
                 var project = AddProject(context, ProjectName, "Project description");
                 var journey = AddJourneyWithStep(context, "J", AddMode(context, "M1"), AddResponsible(context, "R1"));
                 journey.AddStep(new Step(TestPlant, AddMode(context, "M2"), AddResponsible(context, "R2")));

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/TagValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/TagValidatorTests.cs
@@ -56,7 +56,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
 
                 _reqStartedPreservationId = reqStartedPreservation.Id;
                 _reqNotStartedPreservationId = reqNotStartedPreservation.Id;
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
             }
         }
 
@@ -100,7 +100,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
             {
                 var tag = context.Tags.Single(t => t.Id == _tagNotStartedPreservationId);
                 tag.Void();
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
             }
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -150,7 +150,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
             {
                 var req = context.Requirements.Single(r => r.Id == _reqNotStartedPreservationId);
                 req.Void();
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
             }
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -257,7 +257,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
             {
                 var tag = context.Tags.Include(t => t.Requirements).ThenInclude(r => r.PreservationPeriods).Single(t => t.Id == _tagNotStartedPreservationId);
                 tag.StartPreservation();
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
             }
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetActionDetails/GetActionDetailsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetActionDetails/GetActionDetailsQueryHandlerTests.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.PersonAggregate;
-using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Equinor.Procosys.Preservation.Infrastructure;
 using Equinor.Procosys.Preservation.Query.GetTagActionDetails;
 using Equinor.Procosys.Preservation.Test.Common;
@@ -24,35 +22,22 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetActionDetails
         private Action _closedAction;
         private static DateTime _utcNow = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         private static DateTime _dueUtc = _utcNow.AddDays(30);
-        private Person _closer;
+        private TestDataSet _testDataSet;
 
         protected override void SetupNewDatabase(DbContextOptions<PreservationContext> dbContextOptions)
         {
             using (var context = new PreservationContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                AddPerson(context, _currentUserOid, "Ole", "Lukkøye");
-                _closer = AddPerson(context, Guid.Empty, "Jon", "Blund");
+                _testDataSet = AddTestDataSet(context);
 
-                var journey = AddJourneyWithStep(context, "J1", AddMode(context, "M1"), AddResponsible(context, "R1"));
-
-                var reqType = AddRequirementTypeWith1DefWithoutField(context, "T1", "D1");
-
-                var tag = new Tag(TestPlant, TagType.Standard, "", "", "", "", "", "", "", "", "", "",
-                    journey.Steps.ElementAt(0),
-                    new List<Requirement>
-                    {
-                        new Requirement(TestPlant, 2, reqType.RequirementDefinitions.ElementAt(0))
-                    });
-
-                context.Tags.Add(tag);
+                var tag = _testDataSet.Project1.Tags.First();
 
                 _openAction = new Action(TestPlant, "Open", "Desc1", _dueUtc);
                 tag.AddAction(_openAction);
                 _closedAction = new Action(TestPlant, "Closed", "Desc2", _dueUtc);
-                _closedAction.Close(_utcNow, _closer);
+                _closedAction.Close(_utcNow, _testDataSet.Person);
                 tag.AddAction(_closedAction);
-
-                context.SaveChangesAsync().Wait(); // todo should we perform this in all tests
+                context.SaveChangesAsync().Wait();
 
                 _tagId = tag.Id;
                 _openActionId = _openAction.Id;
@@ -75,7 +60,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetActionDetails
                 
                 var actionDetailDto = result.Data;
 
-                AssertClosedAction(actionDetailDto, _closedAction, _closer);
+                AssertClosedAction(actionDetailDto, _closedAction, _testDataSet.Person);
             }
         }
 

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetActionDetails/GetActionDetailsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetActionDetails/GetActionDetailsQueryHandlerTests.cs
@@ -35,7 +35,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetActionDetails
                 _openAction = new Action(TestPlant, "Open", "Desc1", _dueUtc);
                 tag.AddAction(_openAction);
                 _closedAction = new Action(TestPlant, "Closed", "Desc2", _dueUtc);
-                _closedAction.Close(_utcNow, _testDataSet.Person);
+                _closedAction.Close(_utcNow, _testDataSet.CurrentUser);
                 tag.AddAction(_closedAction);
                 context.SaveChangesAsync().Wait();
 
@@ -60,7 +60,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetActionDetails
                 
                 var actionDetailDto = result.Data;
 
-                AssertClosedAction(actionDetailDto, _closedAction, _testDataSet.Person);
+                AssertClosedAction(actionDetailDto, _closedAction, _testDataSet.CurrentUser);
             }
         }
 

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagActions/GetTagActionsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagActions/GetTagActionsQueryHandlerTests.cs
@@ -33,7 +33,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagActions
                 _openAction = new Action(TestPlant, "Open", "Desc1", _utcNow);
                 tag.AddAction(_openAction);
                 _closedAction = new Action(TestPlant, "Closed", "Desc2", _utcNow);
-                _closedAction.Close(_utcNow, _testDataSet.Person);
+                _closedAction.Close(_utcNow, _testDataSet.CurrentUser);
                 tag.AddAction(_closedAction);
 
                 context.SaveChangesAsync().Wait();

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagActions/GetTagActionsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagActions/GetTagActionsQueryHandlerTests.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Equinor.Procosys.Preservation.Domain.AggregateModels.PersonAggregate;
-using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Equinor.Procosys.Preservation.Infrastructure;
 using Equinor.Procosys.Preservation.Query.GetTagActions;
 using Equinor.Procosys.Preservation.Test.Common;
@@ -22,37 +19,24 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagActions
         private int _closedActionId;
         private Action _openAction;
         private Action _closedAction;
-        private DateTime _utcNow = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-        private Person _creator;
+        private readonly DateTime _utcNow = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        private TestDataSet _testDataSet;
 
         protected override void SetupNewDatabase(DbContextOptions<PreservationContext> dbContextOptions)
         {
             using (var context = new PreservationContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                AddPerson(context, _currentUserOid, "Ole", "Lukkøye");
+                _testDataSet = AddTestDataSet(context);
 
-                var journey = AddJourneyWithStep(context, "J1", AddMode(context, "M1"), AddResponsible(context, "R1"));
-
-                var reqType = AddRequirementTypeWith1DefWithoutField(context, "T1", "D1");
-
-                _creator = AddPerson(context, Guid.Empty, "Ole", "Lukkøye");
-
-                var tag = new Tag(TestPlant, TagType.Standard, "", "", "", "", "", "", "", "", "", "",
-                    journey.Steps.ElementAt(0),
-                    new List<Requirement>
-                    {
-                        new Requirement(TestPlant, 2, reqType.RequirementDefinitions.ElementAt(0))
-                    });
-
-                context.Tags.Add(tag);
+                var tag = _testDataSet.Project1.Tags.First();
 
                 _openAction = new Action(TestPlant, "Open", "Desc1", _utcNow);
                 tag.AddAction(_openAction);
                 _closedAction = new Action(TestPlant, "Closed", "Desc2", _utcNow);
-                _closedAction.Close(_utcNow, _creator);
+                _closedAction.Close(_utcNow, _testDataSet.Person);
                 tag.AddAction(_closedAction);
 
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
 
                 _tagId = tag.Id;
                 _openActionId = _openAction.Id;

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagDetails/GetTagDetailsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagDetails/GetTagDetailsQueryHandlerTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Equinor.Procosys.Preservation.Infrastructure;
@@ -14,46 +13,19 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagDetails
     [TestClass]
     public class GetTagDetailsQueryHandlerTests : ReadOnlyTestsBase
     {
-        private string _journeyTitle = "J1";
-        private string _modeTitle = "M1";
-        private string _respCode = "R1";
-        private int _tagId;
-        private int _intervalWeeks = 2;
+        private Tag _testTag;
+        private TestDataSet _testDataSet;
 
         protected override void SetupNewDatabase(DbContextOptions<PreservationContext> dbContextOptions)
         {
             using (var context = new PreservationContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                AddPerson(context, _currentUserOid, "Ole", "Lukkøye");
+                _testDataSet = AddTestDataSet(context);
 
-                var journey = AddJourneyWithStep(context, _journeyTitle, 
-                    AddMode(context, _modeTitle), 
-                    AddResponsible(context, _respCode));
-                var reqType = AddRequirementTypeWith1DefWithoutField(context, "T1", "D1");
+                _testTag = _testDataSet.Project1.Tags.First();
 
-                var tag = new Tag(TestPlant,
-                    TagType.Standard,
-                    "TagNo",
-                    "Description",
-                    "AreaCode",
-                    "Calloff",
-                    "DisciplineCode",
-                    "McPkgNo",
-                    "CommPkgNo",
-                    "PurchaseOrderNo",
-                    "Remark",
-                    "TagFunctionCode",
-                    journey.Steps.ElementAt(0),
-                    new List<Requirement>
-                    {
-                        new Requirement(TestPlant, _intervalWeeks, reqType.RequirementDefinitions.ElementAt(0))
-                    });
-
-                tag.StartPreservation();
-                context.Tags.Add(tag);
-                context.SaveChanges();
-
-                _tagId = tag.Id;
+                _testTag.StartPreservation();
+                context.SaveChangesAsync().Wait();
             }
         }
 
@@ -62,9 +34,9 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagDetails
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                _timeProvider.ElapseWeeks(_intervalWeeks);
+                _timeProvider.ElapseWeeks(_testDataSet.IntervalWeeks);
 
-                var query = new GetTagDetailsQuery(_tagId);
+                var query = new GetTagDetailsQuery(_testTag.Id);
                 var dut = new GetTagDetailsQueryHandler(context);
 
                 var result = await dut.Handle(query, default);
@@ -73,19 +45,24 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagDetails
                 Assert.AreEqual(ResultType.Ok, result.ResultType);
                 
                 var dto = result.Data;
-                Assert.AreEqual("AreaCode", dto.AreaCode);
-                Assert.AreEqual("CommPkgNo", dto.CommPkgNo);
-                Assert.AreEqual("Description", dto.Description);
-                Assert.AreEqual(_tagId, dto.Id);
-                Assert.AreEqual(_journeyTitle, dto.JourneyTitle);
-                Assert.AreEqual("McPkgNo", dto.McPkgNo);
-                Assert.AreEqual(_modeTitle, dto.Mode);
-                Assert.AreEqual("PurchaseOrderNo", dto.PurchaseOrderNo);
-                Assert.AreEqual(_respCode, dto.ResponsibleName);
+                Assert.AreEqual(_testTag.AreaCode, dto.AreaCode);
+                Assert.AreEqual(_testTag.CommPkgNo, dto.CommPkgNo);
+                Assert.AreEqual(_testTag.Description, dto.Description);
+                Assert.AreEqual(_testTag.Id, dto.Id);
+                Assert.AreEqual(_testTag.McPkgNo, dto.McPkgNo);
+                Assert.AreEqual(_testTag.PurchaseOrderNo, dto.PurchaseOrderNo);
                 Assert.AreEqual(PreservationStatus.Active, dto.Status);
-                Assert.AreEqual("TagNo", dto.TagNo);
-                Assert.AreEqual(TagType.Standard, dto.TagType);
-                Assert.IsTrue(dto.ReadyToBePreserved);
+                Assert.AreEqual(_testTag.TagNo, dto.TagNo);
+                Assert.AreEqual(_testTag.TagType, dto.TagType);
+                Assert.AreEqual(_testTag.IsReadyToBePreserved(), dto.ReadyToBePreserved);
+
+                var step = context.Steps.Single(s => s.Id == _testTag.StepId);
+                var mode = context.Modes.Single(m => m.Id == step.ModeId);
+                var resp = context.Responsibles.Single(r => r.Id == step.ResponsibleId);
+                var journey = context.Journeys.Single(j => j.Steps.Any(s => s.Id == step.Id));
+                Assert.AreEqual(journey.Title, dto.JourneyTitle);
+                Assert.AreEqual(mode.Title, dto.Mode);
+                Assert.AreEqual(resp.Code, dto.ResponsibleName);
             }
         }
 

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagRequirements/GetTagRequirementsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagRequirements/GetTagRequirementsQueryHandlerTests.cs
@@ -60,8 +60,6 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagRequirements
         {
             using (var context = new PreservationContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                AddPerson(context, _currentUserOid, "Ole", "Lukkøye");
-
                 var journey = AddJourneyWithStep(context, "J1", AddMode(context, "M1"), AddResponsible(context, "R1"));
 
                 var requirementType1 = new RequirementType(TestPlant, _requirementType1Code, _requirementType1Title, 0);

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagRequirements/GetTagRequirementsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagRequirements/GetTagRequirementsQueryHandlerTests.cs
@@ -68,7 +68,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagRequirements
                 context.RequirementTypes.Add(requirementType1);
                 var requirementType2 = new RequirementType(TestPlant, _requirementType2Code, _requirementType2Title, 0);
                 context.RequirementTypes.Add(requirementType2);
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
 
                 var requirementDefinitionWithoutField = new RequirementDefinition(TestPlant, _requirementDefinitionWithoutFieldTitle, 2, 1);
                 requirementType1.AddRequirementDefinition(requirementDefinitionWithoutField);
@@ -99,7 +99,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagRequirements
                 requirementDefinitionWithOneNumberNoPrev.AddField(numberFieldNoPrev);
                 requirementType2.AddRequirementDefinition(requirementDefinitionWithOneNumberNoPrev);
 
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
 
                 var requirementWithoutField = new Requirement(TestPlant, _interval, requirementDefinitionWithoutField);
                 var requirementWithOneInfo = new Requirement(TestPlant, _interval, requirementDefinitionWithOneInfo);
@@ -129,7 +129,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagRequirements
                         requirementWithThreeNumberShowPrev
                     });
                 context.Tags.Add(tag);
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
 
                 _tagId = tag.Id;
 
@@ -184,7 +184,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagRequirements
             {
                 var tag = context.Tags.Include(t => t.Requirements).Single();
                 tag.StartPreservation();
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
             }
 
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
@@ -221,7 +221,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagRequirements
             {
                 var tag = context.Tags.Include(t => t.Requirements).Single();
                 tag.StartPreservation();
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
 
                 var requirementDefinition = context.RequirementDefinitions.Include(rd => rd.Fields)
                     .Single(rd => rd.Id == _requirementDefinitionWithTwoCheckBoxesId);
@@ -230,7 +230,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagRequirements
                     new Dictionary<int, string> {{fieldId, "true"}},
                     "CommentABC",
                     requirementDefinition);
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
             }
 
             using (var context = new PreservationContext(_dbContextOptions, _plantProviderMock.Object, _eventDispatcher, _currentUserProvider))
@@ -266,7 +266,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagRequirements
             {
                 var tag = context.Tags.Include(t => t.Requirements).Single();
                 tag.StartPreservation();
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
 
                 var requirementDefinition = context.RequirementDefinitions.Include(rd => rd.Fields)
                     .Single(rd => rd.Id == _requirementDefinitionWithThreeNumberShowPrevId);
@@ -280,7 +280,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagRequirements
                     },
                     "",
                     requirementDefinition);
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
             }
 
             using (var context = new PreservationContext(_dbContextOptions, _plantProviderMock.Object, _eventDispatcher, _currentUserProvider))
@@ -342,7 +342,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagRequirements
             {
                 var tag = context.Tags.Include(t => t.Requirements).Single();
                 tag.StartPreservation();
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
 
                 var requirementDefinition = context.RequirementDefinitions.Include(rd => rd.Fields)
                     .Single(rd => rd.Id == _requirementDefinitionWithThreeNumberShowPrevId);
@@ -357,11 +357,11 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagRequirements
                     },
                     "",
                     requirementDefinition);
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
 
                 _timeProvider.ElapseWeeks(_interval);
                 tag.Preserve(new Mock<Person>().Object);
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
             }
 
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTags/GetTagsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTags/GetTagsQueryHandlerTests.cs
@@ -66,7 +66,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTags
                 var step2OnJourney1 = new Step(TestPlant, mode2, responsible2);
 
                 journey1With2Steps.AddStep(step2OnJourney1);
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
 
                 var reqType1 = AddRequirementTypeWith1DefWithoutField(context, _reqType1Code, "D1");
                 _reqType1Id = reqType1.Id;
@@ -139,7 +139,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTags
                 
                     projectAnother.AddTag(tag);
                 }
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
 
                 _query = new GetTagsQuery(_projectName);
             }
@@ -728,7 +728,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTags
                     var journey = context.Journeys.Include(j => j.Steps).Single(j => j.Steps.Any(s => s.Id == tag.StepId));
                     tag.Transfer(journey);
                 }
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
             }
         }
 
@@ -738,7 +738,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTags
             {
                 var tags = context.Tags.Include(t => t.Requirements).ThenInclude(r => r.PreservationPeriods).ToList();
                 tags.ForEach(t => t.StartPreservation());
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
             }
         }
 
@@ -754,7 +754,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTags
                     var journey = journeys.Single(j => j.Steps.Any(s => s.Id == standardTag.StepId));
                     standardTag.Transfer(journey);
                 }
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
             }
         }
     }

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTags/GetTagsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTags/GetTagsQueryHandlerTests.cs
@@ -44,8 +44,6 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTags
         {
             using (var context = new PreservationContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                AddPerson(context, _currentUserOid, "Ole", "Lukkøye");
-
                 var projectPx = AddProject(context, _projectName, "Project description");
                 var projectAnother = AddProject(context, "Another", "Project description");
 

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetUniqueTagRequirementTypes/GetUniqueTagRequirementTypesQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetUniqueTagRequirementTypes/GetUniqueTagRequirementTypesQueryHandlerTests.cs
@@ -1,0 +1,63 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Infrastructure;
+using Equinor.Procosys.Preservation.Query.GetUniqueTagRequirementTypes;
+using Equinor.Procosys.Preservation.Test.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ServiceResult;
+
+namespace Equinor.Procosys.Preservation.Query.Tests.GetUniqueTagRequirementTypes
+{
+    [TestClass]
+    public class GetUniqueTagRequirementTypesQueryHandlerTests : ReadOnlyTestsBase
+    {
+        private TestDataSet _testDataSet;
+        private GetUniqueTagRequirementTypesQuery _queryForProject1;
+        private GetUniqueTagRequirementTypesQuery _queryForProject2;
+
+        protected override void SetupNewDatabase(DbContextOptions<PreservationContext> dbContextOptions)
+        {
+            using (var context = new PreservationContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                AddPerson(context, _currentUserOid, "Ole", "Lukkøye");
+
+                _testDataSet = ApplyTestDataSet(context);
+
+                _queryForProject1 = new GetUniqueTagRequirementTypesQuery(_testDataSet.Project1.Name);
+                _queryForProject2 = new GetUniqueTagRequirementTypesQuery(_testDataSet.Project2.Name);
+            }
+        }
+
+        [TestMethod]
+        public async Task HandleGetAllTagsInProjectQuery_ShouldReturnOkResult()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new GetUniqueTagRequirementTypesQueryHandler(context);
+                var result = await dut.Handle(_queryForProject1, default);
+
+                Assert.AreEqual(ResultType.Ok, result.ResultType);
+            }
+        }
+
+        [TestMethod]
+        public async Task HandleGetAllTagsInProjectQuery_ShouldReturnCorrectUniqueRequirementTypes()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new GetUniqueTagRequirementTypesQueryHandler(context);
+                var result = await dut.Handle(_queryForProject1, default);
+
+                Assert.AreEqual(2, result.Data.Count);
+                Assert.IsTrue(result.Data.Any(rt => rt.Code == _testDataSet.ReqType1.Code));
+                Assert.IsTrue(result.Data.Any(rt => rt.Code == _testDataSet.ReqType2.Code));
+
+                result = await dut.Handle(_queryForProject2, default);
+
+                Assert.AreEqual(1, result.Data.Count);
+                Assert.IsTrue(result.Data.Any(rt => rt.Code == _testDataSet.ReqType1.Code));
+            }
+        }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetUniqueTagRequirementTypes/GetUniqueTagRequirementTypesQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetUniqueTagRequirementTypes/GetUniqueTagRequirementTypesQueryHandlerTests.cs
@@ -14,18 +14,14 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetUniqueTagRequirementTypes
     {
         private TestDataSet _testDataSet;
         private GetUniqueTagRequirementTypesQuery _queryForProject1;
-        private GetUniqueTagRequirementTypesQuery _queryForProject2;
 
         protected override void SetupNewDatabase(DbContextOptions<PreservationContext> dbContextOptions)
         {
             using (var context = new PreservationContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                AddPerson(context, _currentUserOid, "Ole", "Lukkøye");
-
                 _testDataSet = ApplyTestDataSet(context);
 
                 _queryForProject1 = new GetUniqueTagRequirementTypesQuery(_testDataSet.Project1.Name);
-                _queryForProject2 = new GetUniqueTagRequirementTypesQuery(_testDataSet.Project2.Name);
             }
         }
 
@@ -47,16 +43,18 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetUniqueTagRequirementTypes
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new GetUniqueTagRequirementTypesQueryHandler(context);
+                
                 var result = await dut.Handle(_queryForProject1, default);
-
                 Assert.AreEqual(2, result.Data.Count);
                 Assert.IsTrue(result.Data.Any(rt => rt.Code == _testDataSet.ReqType1.Code));
                 Assert.IsTrue(result.Data.Any(rt => rt.Code == _testDataSet.ReqType2.Code));
 
-                result = await dut.Handle(_queryForProject2, default);
-
+                result = await dut.Handle(new GetUniqueTagRequirementTypesQuery(_testDataSet.Project2.Name), default);
                 Assert.AreEqual(1, result.Data.Count);
                 Assert.IsTrue(result.Data.Any(rt => rt.Code == _testDataSet.ReqType1.Code));
+
+                result = await dut.Handle(new GetUniqueTagRequirementTypesQuery("Unknown"), default);
+                Assert.AreEqual(0, result.Data.Count);
             }
         }
     }

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetUniqueTagRequirementTypes/GetUniqueTagRequirementTypesQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetUniqueTagRequirementTypes/GetUniqueTagRequirementTypesQueryHandlerTests.cs
@@ -19,7 +19,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetUniqueTagRequirementTypes
         {
             using (var context = new PreservationContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                _testDataSet = ApplyTestDataSet(context);
+                _testDataSet = AddTestDataSet(context);
 
                 _queryForProject1 = new GetUniqueTagRequirementTypesQuery(_testDataSet.Project1.Name);
             }

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetUniqueTagRequirementTypes/GetUniqueTagRequirementTypesQueryTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetUniqueTagRequirementTypes/GetUniqueTagRequirementTypesQueryTests.cs
@@ -1,0 +1,17 @@
+﻿using Equinor.Procosys.Preservation.Query.GetUniqueTagRequirementTypes;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.Procosys.Preservation.Query.Tests.GetUniqueTagRequirementTypes
+{
+    [TestClass]
+    public class GetUniqueTagRequirementTypesQueryTests
+    {
+        [TestMethod]
+        public void Constructor_SetsProperties()
+        {
+            var dut = new GetUniqueTagRequirementTypesQuery("PX");
+
+            Assert.AreEqual("PX", dut.ProjectName);
+        }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/JourneyAggregate/GetAllJourneysQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/JourneyAggregate/GetAllJourneysQueryHandlerTests.cs
@@ -26,8 +26,6 @@ namespace Equinor.Procosys.Preservation.Query.Tests.JourneyAggregate
         {
             using (var context = new PreservationContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                AddPerson(context, _currentUserOid, "Ole", "Lukkøye");
-
                 var mode1 = AddMode(context, _mode1Title);
                 var responsible1 = AddResponsible(context, _responsible1Code);
                 var journey = AddJourneyWithStep(context, _journeyTitle, mode1, responsible1);

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/JourneyAggregate/GetAllJourneysQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/JourneyAggregate/GetAllJourneysQueryHandlerTests.cs
@@ -35,7 +35,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.JourneyAggregate
                 var mode2 = AddMode(context, _mode2Title);
                 var responsible2 = AddResponsible(context, _responsible2Code);
                 journey.AddStep(new Step(TestPlant, mode2, responsible2));
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
 
                 _mode1Id = mode1.Id;
                 _mode2Id = mode2.Id;
@@ -77,7 +77,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.JourneyAggregate
                 var journey = context.Journeys.Include(j => j.Steps).First();
                 journey.Void();
                 journey.Steps.ToList().ForEach(s => s.Void());
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
             }
 
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/ModeAggregate/GetAllModesQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/ModeAggregate/GetAllModesQueryHandlerTests.cs
@@ -18,8 +18,6 @@ namespace Equinor.Procosys.Preservation.Query.Tests.ModeAggregate
         {
             using (var context = new PreservationContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                AddPerson(context, _currentUserOid, "Ole", "Lukkøye");
-
                 AddMode(context, _mode1Title);
                 AddMode(context, _mode2Title);
             }

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/RequirementTypeAggregate/GetAllRequirementTypesQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/RequirementTypeAggregate/GetAllRequirementTypesQueryHandlerTests.cs
@@ -31,16 +31,16 @@ namespace Equinor.Procosys.Preservation.Query.Tests.RequirementTypeAggregate
                 var rd2 = new RequirementDefinition(TestPlant, "D2", 2, 1);
                 rd2.Void();
                 reqType1.AddRequirementDefinition(rd2);
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
 
                 AddNumberField(context, rd1, _numberLabel, _numberUnit, true);
                 var f = AddNumberField(context, rd1, "NUMBER", "mm", true);
                 f.Void();
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
 
                 var reqType2 = AddRequirementTypeWith1DefWithoutField(context, "T2", "D2", 7);
                 reqType2.Void();
-                context.SaveChanges();
+                context.SaveChangesAsync().Wait();
                 AddRequirementTypeWith1DefWithoutField(context, "T3", "D3", 10000);
                 AddRequirementTypeWith1DefWithoutField(context, "T4", "D4", 1);
             }

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/RequirementTypeAggregate/GetAllRequirementTypesQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/RequirementTypeAggregate/GetAllRequirementTypesQueryHandlerTests.cs
@@ -22,8 +22,6 @@ namespace Equinor.Procosys.Preservation.Query.Tests.RequirementTypeAggregate
         {
             using (var context = new PreservationContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                AddPerson(context, _currentUserOid, "Ole", "Lukkøye");
-                
                 var reqType1 = AddRequirementTypeWith1DefWithoutField(context, _rtType1, _rdTitle1, 999);
                 _reqType1Id = reqType1.Id;
 

--- a/src/tests/Equinor.Procosys.Preservation.Test.Common/ReadOnlyTestsBase.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Test.Common/ReadOnlyTestsBase.cs
@@ -78,8 +78,7 @@ namespace Equinor.Procosys.Preservation.Test.Common
             return mode;
         }
 
-        protected Journey AddJourneyWithStep(PreservationContext context, string title, Mode mode,
-            Responsible responsible)
+        protected Journey AddJourneyWithStep(PreservationContext context, string title, Mode mode, Responsible responsible)
         {
             var journey = new Journey(TestPlant, title);
             journey.AddStep(new Step(TestPlant, mode, responsible));
@@ -88,8 +87,7 @@ namespace Equinor.Procosys.Preservation.Test.Common
             return journey;
         }
 
-        protected RequirementType AddRequirementTypeWith1DefWithoutField(PreservationContext context, string type,
-            string def, int sortKey = 0)
+        protected RequirementType AddRequirementTypeWith1DefWithoutField(PreservationContext context, string type, string def, int sortKey = 0)
         {
             var requirementType = new RequirementType(TestPlant, type, $"Title{type}", sortKey);
             context.RequirementTypes.Add(requirementType);
@@ -110,8 +108,7 @@ namespace Equinor.Procosys.Preservation.Test.Common
             return person;
         }
 
-        protected Project AddProject(PreservationContext context, string name, string description,
-            bool isClosed = false)
+        protected Project AddProject(PreservationContext context, string name, string description, bool isClosed = false)
         {
             var project = new Project(TestPlant, name, description);
             if (isClosed)
@@ -124,8 +121,7 @@ namespace Equinor.Procosys.Preservation.Test.Common
             return project;
         }
 
-        protected Tag AddTag(PreservationContext context, Project parentProject, TagType tagType, string tagNo,
-            string description, Step step, IEnumerable<Requirement> requirements)
+        protected Tag AddTag(PreservationContext context, Project parentProject, TagType tagType, string tagNo, string description, Step step, IEnumerable<Requirement> requirements)
         {
             var tag = new Tag(TestPlant, tagType, tagNo, description, "", "", "", "", "", "", "", "", step,
                 requirements);
@@ -142,8 +138,7 @@ namespace Equinor.Procosys.Preservation.Test.Common
             return field;
         }
 
-        protected Field AddNumberField(PreservationContext context, RequirementDefinition rd, string label, string unit,
-            bool showPrevious)
+        protected Field AddNumberField(PreservationContext context, RequirementDefinition rd, string label, string unit, bool showPrevious)
         {
             var field = new Field(TestPlant, label, FieldType.Number, 0, unit, showPrevious);
             rd.AddField(field);

--- a/src/tests/Equinor.Procosys.Preservation.Test.Common/ReadOnlyTestsBase.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Test.Common/ReadOnlyTestsBase.cs
@@ -35,8 +35,7 @@ namespace Equinor.Procosys.Preservation.Test.Common
             _plantProvider = _plantProviderMock.Object;
 
             var currentUserProviderMock = new Mock<ICurrentUserProvider>();
-            currentUserProviderMock.Setup(x => x.GetCurrentUser())
-                .Returns(_currentUserOid);
+            currentUserProviderMock.Setup(x => x.GetCurrentUser()).Returns(_currentUserOid);
             _currentUserProvider = currentUserProviderMock.Object;
 
             var eventDispatcher = new Mock<IEventDispatcher>();
@@ -48,6 +47,15 @@ namespace Equinor.Procosys.Preservation.Test.Common
             _dbContextOptions = new DbContextOptionsBuilder<PreservationContext>()
                 .UseInMemoryDatabase(Guid.NewGuid().ToString())
                 .Options;
+
+            // ensure current user exists in db
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                if (context.Persons.SingleOrDefault(p => p.Oid == _currentUserOid) == null)
+                {
+                    AddPerson(context, _currentUserOid, "Ole", "Lukkøye");
+                }
+            }
 
             SetupNewDatabase(_dbContextOptions);
         }
@@ -186,7 +194,7 @@ namespace Equinor.Procosys.Preservation.Test.Common
             
             var testDataSet = new TestDataSet
             {
-                Person = AddPerson(context, _currentUserOid, "Ole", "Lukkøye"),
+                CurrentUser = context.Persons.Single(p => p.Oid == _currentUserOid),
                 Project1 = AddProject(context, _projectName1, "Project 1 description"),
                 Project2 = AddProject(context, _projectName2, "Project 2 description"),
                 Mode1 = AddMode(context, _mode1),

--- a/src/tests/Equinor.Procosys.Preservation.Test.Common/ReadOnlyTestsBase.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Test.Common/ReadOnlyTestsBase.cs
@@ -176,14 +176,6 @@ namespace Equinor.Procosys.Preservation.Test.Common
             var _resp2 = "R2";
             var _reqType1Code = "ROT";
             var _reqType2Code = "AREA";
-            var _stdTagPrefix = "StdTagNo";
-            var _siteTagPrefix = "SiteTagNo";
-            var _callOffPrefix = "CO";
-            var _disciplinePrefix = "DI";
-            var _mcPkgPrefix = "MC";
-            var _commPkgPrefix = "COMM";
-            var _poPrefix = "PO";
-            var _tagFunctionPrefix = "TF";
             
             var testDataSet = new TestDataSet
             {
@@ -211,16 +203,16 @@ namespace Equinor.Procosys.Preservation.Test.Common
             {
                 var tag = new Tag(TestPlant,
                     TagType.Standard,
-                    $"{_stdTagPrefix}-{i}",
+                    $"{testDataSet.StdTagPrefix}-{i}",
                     "Description",
-                    "AreaCode",
-                    $"{_callOffPrefix}-{i}",
-                    $"{_disciplinePrefix}-{i}",
-                    $"{_mcPkgPrefix}-{i}",
-                    $"{_commPkgPrefix}-{i}",
-                    $"{_poPrefix}-{i}",
+                    $"{testDataSet.AreaPrefix}-{i}",
+                    $"{testDataSet.CallOffPrefix}-{i}",
+                    $"{testDataSet.DisciplinePrefix}-{i}",
+                    $"{testDataSet.McPkgPrefix}-{i}",
+                    $"{testDataSet.CommPkgPrefix}-{i}",
+                    $"{testDataSet.PoPrefix}-{i}",
                     "Remark",
-                    $"{_tagFunctionPrefix}-{i}",
+                    $"{testDataSet.TagFunctionPrefix}-{i}",
                     testDataSet.Journey1With2Steps.Steps.ElementAt(0),
                     new List<Requirement>
                     {
@@ -234,16 +226,16 @@ namespace Equinor.Procosys.Preservation.Test.Common
             {
                 var tag = new Tag(TestPlant,
                     TagType.SiteArea,
-                    $"{_siteTagPrefix}-{i}",
+                    $"{testDataSet.SiteTagPrefix}-{i}",
                     "Description",
-                    "AreaCode",
-                    $"{_callOffPrefix}-{i}",
-                    $"{_disciplinePrefix}-{i}",
-                    $"{_mcPkgPrefix}-{i}",
-                    $"{_commPkgPrefix}-{i}",
-                    $"{_poPrefix}-{i}",
+                    $"{testDataSet.AreaPrefix}-{i}",
+                    $"{testDataSet.CallOffPrefix}-{i}",
+                    $"{testDataSet.DisciplinePrefix}-{i}",
+                    $"{testDataSet.McPkgPrefix}-{i}",
+                    $"{testDataSet.CommPkgPrefix}-{i}",
+                    $"{testDataSet.PoPrefix}-{i}",
                     "Remark",
-                    $"{_tagFunctionPrefix}-{i}",
+                    $"{testDataSet.TagFunctionPrefix}-{i}",
                     testDataSet.Journey2With1Steps.Steps.ElementAt(0),
                     new List<Requirement>
                     {

--- a/src/tests/Equinor.Procosys.Preservation.Test.Common/ReadOnlyTestsBase.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Test.Common/ReadOnlyTestsBase.cs
@@ -166,12 +166,12 @@ namespace Equinor.Procosys.Preservation.Test.Common
             //  - 10 tags on project 2 (P2), all tags same as 10 first in P1
             //  - requirement period for all 30 tags is 2 weeks
             var _projectName1 = "P1";
-            var _projectName2 = "P2|";
+            var _projectName2 = "P2";
             var _journeyTitle1 = "J1";
             var _journeyTitle2 = "J2";
             var _mode1 = "M1";
-            var _resp1 = "R1";
             var _mode2 = "M2";
+            var _resp1 = "R1";
             var _resp2 = "R2";
             var _reqType1Code = "ROT";
             var _reqType2Code = "AREA";
@@ -183,25 +183,29 @@ namespace Equinor.Procosys.Preservation.Test.Common
             var _commPkgPrefix = "COMM";
             var _poPrefix = "PO";
             var _tagFunctionPrefix = "TF";
-            var testDataSet = new TestDataSet();
-
-            testDataSet.Project1 = AddProject(context, _projectName1, "Project 1 description");
-
-            testDataSet.Mode1 = AddMode(context, _mode1);
-            testDataSet.Responsible1 = AddResponsible(context, _resp1);
-            testDataSet.Mode2 = AddMode(context, _mode2);
-            testDataSet.Responsible2 = AddResponsible(context, _resp2);
+            
+            var testDataSet = new TestDataSet
+            {
+                Person = AddPerson(context, _currentUserOid, "Ole", "Lukkøye"),
+                Project1 = AddProject(context, _projectName1, "Project 1 description"),
+                Project2 = AddProject(context, _projectName2, "Project 2 description"),
+                Mode1 = AddMode(context, _mode1),
+                Responsible1 = AddResponsible(context, _resp1),
+                Mode2 = AddMode(context, _mode2),
+                Responsible2 = AddResponsible(context, _resp2),
+                ReqType1 = AddRequirementTypeWith1DefWithoutField(context, _reqType1Code, "D1"),
+                ReqType2 = AddRequirementTypeWith1DefWithoutField(context, _reqType2Code, "D2")
+            };
 
             testDataSet.Journey1With2Steps =
                 AddJourneyWithStep(context, _journeyTitle1, testDataSet.Mode1, testDataSet.Responsible1);
             testDataSet.Journey2With1Steps =
                 AddJourneyWithStep(context, _journeyTitle2, testDataSet.Mode1, testDataSet.Responsible1);
-            var step2OnJourney1 = new Step(TestPlant, testDataSet.Mode2, testDataSet.Responsible2);
 
+            var step2OnJourney1 = new Step(TestPlant, testDataSet.Mode2, testDataSet.Responsible2);
             testDataSet.Journey1With2Steps.AddStep(step2OnJourney1);
             context.SaveChanges();
 
-            testDataSet.ReqType1 = AddRequirementTypeWith1DefWithoutField(context, _reqType1Code, "D1");
             for (var i = 0; i < 10; i++)
             {
                 var tag = new Tag(TestPlant,
@@ -225,7 +229,6 @@ namespace Equinor.Procosys.Preservation.Test.Common
                 testDataSet.Project1.AddTag(tag);
             }
 
-            testDataSet.ReqType2 = AddRequirementTypeWith1DefWithoutField(context, _reqType2Code, "D2");
             for (var i = 0; i < 10; i++)
             {
                 var tag = new Tag(TestPlant,
@@ -249,7 +252,6 @@ namespace Equinor.Procosys.Preservation.Test.Common
                 testDataSet.Project1.AddTag(tag);
             }
 
-            testDataSet.Project2 = AddProject(context, _projectName2, "Project 2 description");
             for (var i = 0; i < 10; i++)
             {
                 var tag = new Tag(TestPlant,
@@ -272,6 +274,7 @@ namespace Equinor.Procosys.Preservation.Test.Common
                 
                 testDataSet.Project2.AddTag(tag);
             }
+            
             context.SaveChanges();
 
             return testDataSet;

--- a/src/tests/Equinor.Procosys.Preservation.Test.Common/ReadOnlyTestsBase.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Test.Common/ReadOnlyTestsBase.cs
@@ -151,7 +151,7 @@ namespace Equinor.Procosys.Preservation.Test.Common
             return field;
         }
 
-        protected TestDataSet ApplyTestDataSet(PreservationContext context)
+        protected TestDataSet AddTestDataSet(PreservationContext context)
         {
             // Test data set:
             //  - 2 journeys:

--- a/src/tests/Equinor.Procosys.Preservation.Test.Common/ReadOnlyTestsBase.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Test.Common/ReadOnlyTestsBase.cs
@@ -132,7 +132,7 @@ namespace Equinor.Procosys.Preservation.Test.Common
         {
             var field = new Field(TestPlant, label, FieldType.Info, 0);
             rd.AddField(field);
-            context.SaveChanges();
+            context.SaveChangesAsync().Wait();
             return field;
         }
 
@@ -140,7 +140,7 @@ namespace Equinor.Procosys.Preservation.Test.Common
         {
             var field = new Field(TestPlant, label, FieldType.Number, 0, unit, showPrevious);
             rd.AddField(field);
-            context.SaveChanges();
+            context.SaveChangesAsync().Wait();
             return field;
         }
 
@@ -148,7 +148,7 @@ namespace Equinor.Procosys.Preservation.Test.Common
         {
             var field = new Field(TestPlant, label, FieldType.CheckBox, 0);
             rd.AddField(field);
-            context.SaveChanges();
+            context.SaveChangesAsync().Wait();
             return field;
         }
 
@@ -205,7 +205,7 @@ namespace Equinor.Procosys.Preservation.Test.Common
 
             var step2OnJourney1 = new Step(TestPlant, testDataSet.Mode2, testDataSet.Responsible2);
             testDataSet.Journey1With2Steps.AddStep(step2OnJourney1);
-            context.SaveChanges();
+            context.SaveChangesAsync().Wait();
 
             for (var i = 0; i < 10; i++)
             {
@@ -276,7 +276,7 @@ namespace Equinor.Procosys.Preservation.Test.Common
                 testDataSet.Project2.AddTag(tag);
             }
             
-            context.SaveChanges();
+            context.SaveChangesAsync().Wait();
 
             return testDataSet;
         }

--- a/src/tests/Equinor.Procosys.Preservation.Test.Common/ReadOnlyTestsBase.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Test.Common/ReadOnlyTestsBase.cs
@@ -115,7 +115,6 @@ namespace Equinor.Procosys.Preservation.Test.Common
             {
                 project.Close();
             }
-
             context.Projects.Add(project);
             context.SaveChangesAsync().Wait();
             return project;
@@ -123,8 +122,7 @@ namespace Equinor.Procosys.Preservation.Test.Common
 
         protected Tag AddTag(PreservationContext context, Project parentProject, TagType tagType, string tagNo, string description, Step step, IEnumerable<Requirement> requirements)
         {
-            var tag = new Tag(TestPlant, tagType, tagNo, description, "", "", "", "", "", "", "", "", step,
-                requirements);
+            var tag = new Tag(TestPlant, tagType, tagNo, description, "", "", "", "", "", "", "", "", step, requirements);
             parentProject.AddTag(tag);
             context.SaveChangesAsync().Wait();
             return tag;

--- a/src/tests/Equinor.Procosys.Preservation.Test.Common/TestDataSet.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Test.Common/TestDataSet.cs
@@ -21,6 +21,6 @@ namespace Equinor.Procosys.Preservation.Test.Common
         public Journey Journey2With1Steps { get; set; }
         public RequirementType ReqType1 { get; set; }
         public RequirementType ReqType2 { get; set; }
-        public Person Person { get; set; }
+        public Person CurrentUser { get; set; }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Test.Common/TestDataSet.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Test.Common/TestDataSet.cs
@@ -10,6 +10,15 @@ namespace Equinor.Procosys.Preservation.Test.Common
     public class TestDataSet
     {
         public readonly int IntervalWeeks = 2;
+        public readonly string StdTagPrefix = "StdTagNo";
+        public readonly string SiteTagPrefix = "SiteTagNo";
+        public readonly string CallOffPrefix = "CO";
+        public readonly string AreaPrefix = "AREA";
+        public readonly string DisciplinePrefix = "DI";
+        public readonly string McPkgPrefix = "MC";
+        public readonly string CommPkgPrefix = "COMM";
+        public readonly string PoPrefix = "PO";
+        public readonly string TagFunctionPrefix = "TF";
 
         public Project Project1 { get; set; }
         public Project Project2 { get; set; }

--- a/src/tests/Equinor.Procosys.Preservation.Test.Common/TestDataSet.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Test.Common/TestDataSet.cs
@@ -1,5 +1,6 @@
 ﻿using Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.ModeAggregate;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.PersonAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.ResponsibleAggregate;
@@ -20,5 +21,6 @@ namespace Equinor.Procosys.Preservation.Test.Common
         public Journey Journey2With1Steps { get; set; }
         public RequirementType ReqType1 { get; set; }
         public RequirementType ReqType2 { get; set; }
+        public Person Person { get; set; }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Test.Common/TestDataSet.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Test.Common/TestDataSet.cs
@@ -1,0 +1,24 @@
+﻿using Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.ModeAggregate;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.ResponsibleAggregate;
+
+namespace Equinor.Procosys.Preservation.Test.Common
+{
+    public class TestDataSet
+    {
+        public readonly int IntervalWeeks = 2;
+
+        public Project Project1 { get; set; }
+        public Project Project2 { get; set; }
+        public Mode Mode1 { get; set; }
+        public Responsible Responsible1 { get; set; }
+        public Mode Mode2 { get; set; }
+        public Responsible Responsible2 { get; set; }
+        public Journey Journey1With2Steps { get; set; }
+        public Journey Journey2With1Steps { get; set; }
+        public RequirementType ReqType1 { get; set; }
+        public RequirementType ReqType2 { get; set; }
+    }
+}


### PR DESCRIPTION
See comment inside controller about plan and reason for this.

Refactoring:
context.SaveChangesAsync().Wait() in all tests.
Introduced TestDataSet and AddTestDataSet(context) for testing ReadOnly db. Need similar dataset in most tests. Refactor tests to use TestDataSet.
Create Person for current user in ReadOnlyTestsBase.SetupBase