### PR TITLE
Automatic update of MicroElements.Swashbuckle.FluentValidation to 3.1.0

### DIFF
--- a/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
+++ b/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.1" />
     <PackageReference Include="MediatR" Version="8.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="3.0.0-rc.5" />
+    <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="3.1.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.13.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.2" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `MicroElements.Swashbuckle.FluentValidation` to `3.1.0` from `3.0.0-rc.5`
`MicroElements.Swashbuckle.FluentValidation 3.1.0` was published at `2020-03-25T13:28:08Z`, 11 days ago

1 project update:
Updated `src\Equinor.Procosys.Preservation.WebApi\Equinor.Procosys.Preservation.WebApi.csproj` to `MicroElements.Swashbuckle.FluentValidation` `3.1.0` from `3.0.0-rc.5`

[MicroElements.Swashbuckle.FluentValidation 3.1.0 on NuGet.org](https://www.nuget.org/packages/MicroElements.Swashbuckle.FluentValidation/3.1.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
