### PR TITLE
Automatic update of MediatR to 8.0.1

### DIFF
--- a/src/Equinor.Procosys.Preservation.Command/Equinor.Procosys.Preservation.Command.csproj
+++ b/src/Equinor.Procosys.Preservation.Command/Equinor.Procosys.Preservation.Command.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.1" />
-    <PackageReference Include="MediatR" Version="8.0.0" />
+    <PackageReference Include="MediatR" Version="8.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.2" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />
     <PackageReference Include="System.Text.Json" Version="4.7.1" />

--- a/src/Equinor.Procosys.Preservation.Domain/Equinor.Procosys.Preservation.Domain.csproj
+++ b/src/Equinor.Procosys.Preservation.Domain/Equinor.Procosys.Preservation.Domain.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="8.0.0" />
+    <PackageReference Include="MediatR" Version="8.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Equinor.Procosys.Preservation.Query/Equinor.Procosys.Preservation.Query.csproj
+++ b/src/Equinor.Procosys.Preservation.Query/Equinor.Procosys.Preservation.Query.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.1" />
-    <PackageReference Include="MediatR" Version="8.0.0" />
+    <PackageReference Include="MediatR" Version="8.0.1" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
+++ b/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.1" />
-    <PackageReference Include="MediatR" Version="8.0.0" />
+    <PackageReference Include="MediatR" Version="8.0.1" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="3.0.0-rc.5" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.13.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `MediatR` to `8.0.1` from `8.0.0`
`MediatR 8.0.1` was published at `2020-02-27T16:43:56Z`, 2 months ago

4 project updates:
Updated `src\Equinor.Procosys.Preservation.Command\Equinor.Procosys.Preservation.Command.csproj` to `MediatR` `8.0.1` from `8.0.0`
Updated `src\Equinor.Procosys.Preservation.Domain\Equinor.Procosys.Preservation.Domain.csproj` to `MediatR` `8.0.1` from `8.0.0`
Updated `src\Equinor.Procosys.Preservation.Query\Equinor.Procosys.Preservation.Query.csproj` to `MediatR` `8.0.1` from `8.0.0`
Updated `src\Equinor.Procosys.Preservation.WebApi\Equinor.Procosys.Preservation.WebApi.csproj` to `MediatR` `8.0.1` from `8.0.0`

[MediatR 8.0.1 on NuGet.org](https://www.nuget.org/packages/MediatR/8.0.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
