### PR TITLE
Automatic update of FluentValidation.AspNetCore to 8.6.2

### DIFF
--- a/src/Equinor.Procosys.Preservation.Command/Equinor.Procosys.Preservation.Command.csproj
+++ b/src/Equinor.Procosys.Preservation.Command/Equinor.Procosys.Preservation.Command.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.1" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.2" />
     <PackageReference Include="MediatR" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.2" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />

--- a/src/Equinor.Procosys.Preservation.Query/Equinor.Procosys.Preservation.Query.csproj
+++ b/src/Equinor.Procosys.Preservation.Query/Equinor.Procosys.Preservation.Query.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.1" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.2" />
     <PackageReference Include="MediatR" Version="8.0.0" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />
   </ItemGroup>

--- a/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
+++ b/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.1" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.2" />
     <PackageReference Include="MediatR" Version="8.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="3.0.0-rc.5" />

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Equinor.Procosys.Preservation.Command.Tests.csproj
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Equinor.Procosys.Preservation.Command.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.1" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `FluentValidation.AspNetCore` to `8.6.2` from `8.6.1`
`FluentValidation.AspNetCore 8.6.2` was published at `2020-02-29T16:12:13Z`, 2 months ago

4 project updates:
Updated `src\Equinor.Procosys.Preservation.Command\Equinor.Procosys.Preservation.Command.csproj` to `FluentValidation.AspNetCore` `8.6.2` from `8.6.1`
Updated `src\Equinor.Procosys.Preservation.Query\Equinor.Procosys.Preservation.Query.csproj` to `FluentValidation.AspNetCore` `8.6.2` from `8.6.1`
Updated `src\Equinor.Procosys.Preservation.WebApi\Equinor.Procosys.Preservation.WebApi.csproj` to `FluentValidation.AspNetCore` `8.6.2` from `8.6.1`
Updated `src\tests\Equinor.Procosys.Preservation.Command.Tests\Equinor.Procosys.Preservation.Command.Tests.csproj` to `FluentValidation.AspNetCore` `8.6.2` from `8.6.1`

[FluentValidation.AspNetCore 8.6.2 on NuGet.org](https://www.nuget.org/packages/FluentValidation.AspNetCore/8.6.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
