### PR TITLE
Automatic update of Microsoft.Extensions.Logging.Abstractions to 3.1.3

### DIFF
--- a/src/Equinor.Procosys.Preservation.MainApi/Equinor.Procosys.Preservation.MainApi.csproj
+++ b/src/Equinor.Procosys.Preservation.MainApi/Equinor.Procosys.Preservation.MainApi.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.3" />
     <PackageReference Include="System.Text.Json" Version="4.7.1" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.Extensions.Logging.Abstractions` to `3.1.3` from `3.1.2`
`Microsoft.Extensions.Logging.Abstractions 3.1.3` was published at `2020-03-24T17:15:42Z`, 12 days ago

1 project update:
Updated `src\Equinor.Procosys.Preservation.MainApi\Equinor.Procosys.Preservation.MainApi.csproj` to `Microsoft.Extensions.Logging.Abstractions` `3.1.3` from `3.1.2`

[Microsoft.Extensions.Logging.Abstractions 3.1.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions/3.1.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
