### PR TITLE
Automatic update of Microsoft.Extensions.Caching.Memory to 3.1.3

### DIFF
--- a/src/Equinor.Procosys.Preservation.Infrastructure/Equinor.Procosys.Preservation.Infrastructure.csproj
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Equinor.Procosys.Preservation.Infrastructure.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.2" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.Extensions.Caching.Memory` to `3.1.3` from `3.1.2`
`Microsoft.Extensions.Caching.Memory 3.1.3` was published at `2020-03-24T17:14:51Z`, 12 days ago

1 project update:
Updated `src\Equinor.Procosys.Preservation.Infrastructure\Equinor.Procosys.Preservation.Infrastructure.csproj` to `Microsoft.Extensions.Caching.Memory` `3.1.3` from `3.1.2`

[Microsoft.Extensions.Caching.Memory 3.1.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Caching.Memory/3.1.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
