### PR TITLE
Automatic update of Microsoft.EntityFrameworkCore to 3.1.3

### DIFF
--- a/src/Equinor.Procosys.Preservation.Command/Equinor.Procosys.Preservation.Command.csproj
+++ b/src/Equinor.Procosys.Preservation.Command/Equinor.Procosys.Preservation.Command.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.1" />
     <PackageReference Include="MediatR" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.3" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />
     <PackageReference Include="System.Text.Json" Version="4.7.1" />
   </ItemGroup>

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Equinor.Procosys.Preservation.Infrastructure.csproj
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Equinor.Procosys.Preservation.Infrastructure.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>

--- a/src/tests/Equinor.Procosys.Preservation.Test.Common/Equinor.Procosys.Preservation.Test.Common.csproj
+++ b/src/tests/Equinor.Procosys.Preservation.Test.Common/Equinor.Procosys.Preservation.Test.Common.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.3" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore` to `3.1.3` from `3.1.2`
`Microsoft.EntityFrameworkCore 3.1.3` was published at `2020-03-24T17:14:25Z`, 12 days ago

3 project updates:
Updated `src\Equinor.Procosys.Preservation.Command\Equinor.Procosys.Preservation.Command.csproj` to `Microsoft.EntityFrameworkCore` `3.1.3` from `3.1.2`
Updated `src\Equinor.Procosys.Preservation.Infrastructure\Equinor.Procosys.Preservation.Infrastructure.csproj` to `Microsoft.EntityFrameworkCore` `3.1.3` from `3.1.2`
Updated `src\tests\Equinor.Procosys.Preservation.Test.Common\Equinor.Procosys.Preservation.Test.Common.csproj` to `Microsoft.EntityFrameworkCore` `3.1.3` from `3.1.2`

[Microsoft.EntityFrameworkCore 3.1.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/3.1.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
