### PR TITLE
71254 optimistic concurrency

### DIFF
--- a/src/Equinor.Procosys.Preservation.Domain/EntityBase.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/EntityBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using MediatR;
 
 namespace Equinor.Procosys.Preservation.Domain
@@ -11,7 +12,21 @@ namespace Equinor.Procosys.Preservation.Domain
         private List<INotification> _domainEvents;
 
         public IReadOnlyCollection<INotification> DomainEvents => _domainEvents?.AsReadOnly() ?? (_domainEvents = new List<INotification>()).AsReadOnly();
+
         public virtual int Id { get; protected set; }
+
+        public byte[] RowVersion { get; protected set; }
+
+        public ulong GetRowVersion() => (ulong) BitConverter.ToInt64(RowVersion);
+        public void SetRowVersion(ulong version)
+        {
+            var newRowVersion = BitConverter.GetBytes(version);
+
+            for (var index = 0; index < newRowVersion.Length; index++)
+            {
+                RowVersion[index] = newRowVersion[index];
+            }
+        }
 
         public void AddDomainEvent(INotification eventItem)
         {

--- a/src/Equinor.Procosys.Preservation.Domain/Exceptions/ConcurrencyException.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/Exceptions/ConcurrencyException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Equinor.Procosys.Preservation.Domain.Exceptions
+{
+    public class ConcurrencyException : Exception
+    {
+        public ConcurrencyException(string message) : base(message)
+        {
+        }
+
+        public ConcurrencyException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Infrastructure/EntityConfigurations/Extensions/ConcurrencyTokenConfigurationExtensions.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/EntityConfigurations/Extensions/ConcurrencyTokenConfigurationExtensions.cs
@@ -1,0 +1,14 @@
+﻿using Equinor.Procosys.Preservation.Domain;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations.Extensions
+{
+    public static class ConcurrencyTokenConfigurationExtensions
+    {
+        public static void ConfigureConcurrencyToken<TEntity>(this EntityTypeBuilder<TEntity> builder)
+            where TEntity : EntityBase =>
+            builder
+                .Property(x => x.RowVersion)
+                .IsRowVersion();
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/ActionConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/ActionConfiguration.cs
@@ -13,6 +13,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
             builder.ConfigurePlant();
             builder.ConfigureCreationAudit();
             builder.ConfigureModificationAudit();
+            builder.ConfigureConcurrencyToken();
 
             builder.Property(x => x.Title)
                 .HasMaxLength(Action.TitleLengthMax)

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/FieldConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/FieldConfiguration.cs
@@ -15,6 +15,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
             builder.ConfigurePlant();
             builder.ConfigureCreationAudit();
             builder.ConfigureModificationAudit();
+            builder.ConfigureConcurrencyToken();
 
             builder.Property(f => f.Label)
                 .HasMaxLength(Field.LabelLengthMax)

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/FieldValueConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/FieldValueConfiguration.cs
@@ -11,6 +11,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
         {
             builder.ConfigurePlant();
             builder.ConfigureCreationAudit();
+            builder.ConfigureConcurrencyToken();
 
             builder
                 .HasDiscriminator<string>("FieldType")

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/JourneyConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/JourneyConfiguration.cs
@@ -12,6 +12,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
             builder.ConfigurePlant();
             builder.ConfigureCreationAudit();
             builder.ConfigureModificationAudit();
+            builder.ConfigureConcurrencyToken();
 
             builder.Property(x => x.Title)
                 .HasMaxLength(Journey.TitleLengthMax)

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/ModeConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/ModeConfiguration.cs
@@ -12,6 +12,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
             builder.ConfigurePlant();
             builder.ConfigureCreationAudit();
             builder.ConfigureModificationAudit();
+            builder.ConfigureConcurrencyToken();
 
             builder.Property(x => x.Title)
                 .HasMaxLength(Mode.TitleLengthMax)

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/PersonConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/PersonConfiguration.cs
@@ -10,6 +10,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
         public void Configure(EntityTypeBuilder<Person> builder)
         {
             builder.ConfigureModificationAudit();
+            builder.ConfigureConcurrencyToken();
 
             builder.Property(x => x.Oid)
                 .IsRequired();

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/PreservationPeriodConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/PreservationPeriodConfiguration.cs
@@ -14,6 +14,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
             builder.ConfigurePlant();
             builder.ConfigureCreationAudit();
             builder.ConfigureModificationAudit();
+            builder.ConfigureConcurrencyToken();
 
             builder.Property(x => x.Comment)
                 .HasMaxLength(PreservationPeriod.CommentLengthMax);

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/PreservationRecordConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/PreservationRecordConfiguration.cs
@@ -12,6 +12,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
         {
             builder.ConfigurePlant();
             builder.ConfigureCreationAudit();
+            builder.ConfigureConcurrencyToken();
 
             builder.Property(x => x.PreservedAtUtc)
                 .HasConversion(PreservationContext.DateTimeKindConverter);

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/ProjectConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/ProjectConfiguration.cs
@@ -12,6 +12,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
             builder.ConfigurePlant();
             builder.ConfigureCreationAudit();
             builder.ConfigureModificationAudit();
+            builder.ConfigureConcurrencyToken();
 
             builder.Property(x => x.Name)
                 .HasMaxLength(Project.NameLengthMax)

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/RequirementDefinitionConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/RequirementDefinitionConfiguration.cs
@@ -12,6 +12,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
             builder.ConfigurePlant();
             builder.ConfigureCreationAudit();
             builder.ConfigureModificationAudit();
+            builder.ConfigureConcurrencyToken();
 
             builder.Property(rt => rt.Title)
                 .IsRequired()

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/RequirementTypeConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/RequirementTypeConfiguration.cs
@@ -12,6 +12,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
             builder.ConfigurePlant();
             builder.ConfigureCreationAudit();
             builder.ConfigureModificationAudit();
+            builder.ConfigureConcurrencyToken();
 
             builder.Property(rt => rt.Code)
                 .IsRequired()

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/ResponsibleConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/ResponsibleConfiguration.cs
@@ -12,6 +12,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
             builder.ConfigurePlant();
             builder.ConfigureCreationAudit();
             builder.ConfigureModificationAudit();
+            builder.ConfigureConcurrencyToken();
 
             builder.Property(x => x.Code)
                 .HasMaxLength(Responsible.CodeLengthMax)

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/StepConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/StepConfiguration.cs
@@ -15,6 +15,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
             builder.ConfigurePlant();
             builder.ConfigureCreationAudit();
             builder.ConfigureModificationAudit();
+            builder.ConfigureConcurrencyToken();
 
             builder.HasOne<Mode>();
             builder.HasOne<Responsible>();

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/TagConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/TagConfiguration.cs
@@ -14,6 +14,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
             builder.ConfigurePlant();
             builder.ConfigureCreationAudit();
             builder.ConfigureModificationAudit();
+            builder.ConfigureConcurrencyToken();
 
             builder.Property(x => x.Description)
                 .HasMaxLength(Tag.DescriptionLengthMax)

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/TagFunctionConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/TagFunctionConfiguration.cs
@@ -12,6 +12,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
             builder.ConfigurePlant();
             builder.ConfigureCreationAudit();
             builder.ConfigureModificationAudit();
+            builder.ConfigureConcurrencyToken();
 
             builder.Property(x => x.Code)
                 .HasMaxLength(TagFunction.CodeLengthMax)

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/TagFunctionRequirementConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/TagFunctionRequirementConfiguration.cs
@@ -13,6 +13,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
             builder.ConfigurePlant();
             builder.ConfigureCreationAudit();
             builder.ConfigureModificationAudit();
+            builder.ConfigureConcurrencyToken();
 
             builder.HasOne<RequirementDefinition>();
         }

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/TagRequirementConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/TagRequirementConfiguration.cs
@@ -15,6 +15,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
             builder.ConfigurePlant();
             builder.ConfigureCreationAudit();
             builder.ConfigureModificationAudit();
+            builder.ConfigureConcurrencyToken();
 
             builder.Property(x => x.NextDueTimeUtc)
                 .HasConversion(PreservationContext.NullableDateTimeKindConverter);

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200420085753_AddedRowVersion.Designer.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200420085753_AddedRowVersion.Designer.cs
@@ -4,14 +4,16 @@ using Equinor.Procosys.Preservation.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Equinor.Procosys.Preservation.Infrastructure.Migrations
 {
     [DbContext(typeof(PreservationContext))]
-    partial class PreservationContextModelSnapshot : ModelSnapshot
+    [Migration("20200420085753_AddedRowVersion")]
+    partial class AddedRowVersion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200420085753_AddedRowVersion.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200420085753_AddedRowVersion.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Equinor.Procosys.Preservation.Infrastructure.Migrations
+{
+    public partial class AddedRowVersion : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "Tags",
+                rowVersion: true,
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "TagRequirements",
+                rowVersion: true,
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "TagFunctions",
+                rowVersion: true,
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "TagFunctionRequirements",
+                rowVersion: true,
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "Steps",
+                rowVersion: true,
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "Responsibles",
+                rowVersion: true,
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "RequirementTypes",
+                rowVersion: true,
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "RequirementDefinitions",
+                rowVersion: true,
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "Projects",
+                rowVersion: true,
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "PreservationRecords",
+                rowVersion: true,
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "PreservationPeriods",
+                rowVersion: true,
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "Persons",
+                rowVersion: true,
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "Modes",
+                rowVersion: true,
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "Journeys",
+                rowVersion: true,
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "FieldValues",
+                rowVersion: true,
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "Fields",
+                rowVersion: true,
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "Actions",
+                rowVersion: true,
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "Tags");
+
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "TagRequirements");
+
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "TagFunctions");
+
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "TagFunctionRequirements");
+
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "Steps");
+
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "Responsibles");
+
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "RequirementTypes");
+
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "RequirementDefinitions");
+
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "Projects");
+
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "PreservationRecords");
+
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "PreservationPeriods");
+
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "Persons");
+
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "Modes");
+
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "Journeys");
+
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "FieldValues");
+
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "Fields");
+
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "Actions");
+        }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Infrastructure/PreservationContext.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/PreservationContext.cs
@@ -12,6 +12,7 @@ using Equinor.Procosys.Preservation.Domain.AggregateModels.ResponsibleAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.TagFunctionAggregate;
 using Equinor.Procosys.Preservation.Domain.Audit;
 using Equinor.Procosys.Preservation.Domain.Events;
+using Equinor.Procosys.Preservation.Domain.Exceptions;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equinor.Procosys.Preservation.Infrastructure
@@ -86,7 +87,14 @@ namespace Equinor.Procosys.Preservation.Infrastructure
         {
             await DispatchEventsAsync(cancellationToken);
             await SetAuditDataAsync();
-            return await base.SaveChangesAsync(cancellationToken);
+            try
+            {
+                return await base.SaveChangesAsync(cancellationToken);
+            }
+            catch (DbUpdateConcurrencyException concurrencyException)
+            {
+                throw new ConcurrencyException("Data store operation failed. Data may have been modified or deleted since entities were loaded.", concurrencyException);
+            }
         }
 
         private async Task DispatchEventsAsync(CancellationToken cancellationToken = default)

--- a/src/tests/Equinor.Procosys.Preservation.Domain.Tests/EntityBaseTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Domain.Tests/EntityBaseTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using MediatR;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -50,9 +51,26 @@ namespace Equinor.Procosys.Preservation.Domain.Tests
             Assert.AreEqual(0, dut.DomainEvents.Count);
         }
 
-        public class TestableEntityBase : EntityBase
+        [TestMethod]
+        public void GetRowVersion()
         {
-            // The base class is abstract, therefor a sub class is needed to test it.
+            var dut = new TestableEntityBase();
+            dut.SetProtectedRowVersion(123);
+            dut.GetRowVersion().Equals(123);
+        }
+
+        [TestMethod]
+        public void SetRowVersion()
+        {
+            var dut = new TestableEntityBase();
+            dut.SetProtectedRowVersion(123);
+            dut.SetRowVersion(123);
+            dut.GetRowVersion().Equals(123);
+        }
+
+        public class TestableEntityBase : EntityBase // The base class is abstract, therefor a sub class is needed to test it.
+        {
+            public void SetProtectedRowVersion(ulong rowVersion) => base.RowVersion = BitConverter.GetBytes(rowVersion);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Domain.Tests/EntityBaseTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Domain.Tests/EntityBaseTests.cs
@@ -9,6 +9,9 @@ namespace Equinor.Procosys.Preservation.Domain.Tests
     [TestClass]
     public class EntityBaseTests
     {
+        private const ulong OldRowVersion = 123;
+        private const ulong NewRowVersion = 456;
+
         [TestMethod]
         public void ReturningEmptyDomainEventsListTest()
         {
@@ -52,25 +55,67 @@ namespace Equinor.Procosys.Preservation.Domain.Tests
         }
 
         [TestMethod]
-        public void GetRowVersion()
+        public void GetRowVersion_ShouldReturnLastSetRowVersion()
         {
             var dut = new TestableEntityBase();
             dut.SetProtectedRowVersion(123);
             dut.GetRowVersion().Equals(123);
+        }    
+        
+        [TestMethod]
+        public void SetRowVersion_ShouldSucceed()
+        {
+            var dut = new TestableEntityBase();
+            dut.SetProtectedRowVersion(OldRowVersion);
+
+            dut.SetRowVersion(NewRowVersion);
         }
 
         [TestMethod]
-        public void SetRowVersion()
+        public void SetRowVersion_ByReplacingByteArrayContent_ShouldSucceed()
         {
-            var dut = new TestableEntityBase();
-            dut.SetProtectedRowVersion(123);
-            dut.SetRowVersion(123);
-            dut.GetRowVersion().Equals(123);
+            unsafe
+            {
+                var dut = new TestableEntityBase();
+
+                dut.SetProtectedRowVersion(OldRowVersion);
+                var originalByteArrayPointer = dut.GetRowVersionPointer();
+
+                dut.SetRowVersion(NewRowVersion);
+                var newByteArrayPointer = dut.GetRowVersionPointer();
+
+                Assert.IsTrue(originalByteArrayPointer == newByteArrayPointer, "Reference equals should be true as we replace the array content, not the entire byte array");
+            }
+        }
+
+        [TestMethod]
+        public void SetRowVersion_ByReplacingByteArray_ShouldFail()
+        {
+            unsafe
+            {
+                var dut = new TestableEntityBase();
+
+                dut.SetProtectedRowVersion(OldRowVersion);
+                var originalByteArray = dut.GetRowVersionPointer();
+
+                dut.SetProtectedRowVersion(NewRowVersion);
+                var newByteArray = dut.GetRowVersionPointer();
+
+                Assert.IsFalse(originalByteArray == newByteArray, "Reference equals should be false as we replace the byte array");
+            }
         }
 
         public class TestableEntityBase : EntityBase // The base class is abstract, therefor a sub class is needed to test it.
         {
             public void SetProtectedRowVersion(ulong rowVersion) => base.RowVersion = BitConverter.GetBytes(rowVersion);
+
+            public unsafe byte* GetRowVersionPointer()
+            { 
+                fixed (byte* first = &RowVersion[7])
+                {
+                    return first;
+                }
+            }
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Domain.Tests/Equinor.Procosys.Preservation.Domain.Tests.csproj
+++ b/src/tests/Equinor.Procosys.Preservation.Domain.Tests/Equinor.Procosys.Preservation.Domain.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Setting the solution up for optimistic concurrency in order to handle conflicts faced with two or more requests updating the same object or the same entity instance.

As of right now this code does not interfere with any of the existing functionality.