### PR TITLE
Bugfix when checking access to non-existing Tag id

### DIFF
--- a/src/Equinor.Procosys.Preservation.WebApi/Authorizations/ContentRestrictionsChecker.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Authorizations/ContentRestrictionsChecker.cs
@@ -24,7 +24,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Authorizations
         {
             if (string.IsNullOrEmpty(responsibleCode))
             {
-                throw new ArgumentNullException(nameof(responsibleCode));
+                return false;
             }
             
             var claimWithContentRestriction = GetContentRestrictionClaims(_currentUserProvider.GetCurrentUser().Claims);

--- a/src/Equinor.Procosys.Preservation.WebApi/Authorizations/ProjectAccessChecker.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Authorizations/ProjectAccessChecker.cs
@@ -15,7 +15,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Authorizations
         {
             if (string.IsNullOrEmpty(projectName))
             {
-                throw new ArgumentNullException(nameof(projectName));
+                return false;
             }
             
             var userDataClaimWithProject = ClaimsTransformation.GetProjectClaimValue(projectName);

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Authorizations/ContentRestrictionsCheckerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Authorizations/ContentRestrictionsCheckerTests.cs
@@ -103,5 +103,19 @@ namespace Equinor.Procosys.Preservation.WebApi.Tests.Authorizations
             // Assert
             Assert.IsFalse(result);
         }
+
+        [TestMethod]
+        public void HasCurrentUserExplicitAccessToContent_ShouldReturnFalse_WhenRestrictionToCheckNotGiven()
+        {
+            _claimsIdentity.AddClaim(_normalContentRestrictionClaim);
+
+            // Act
+            var result1 = _dut.HasCurrentUserExplicitAccessToContent(null);
+            var result2 = _dut.HasCurrentUserExplicitAccessToContent("");
+
+            // Assert
+            Assert.IsFalse(result1);
+            Assert.IsFalse(result2);
+        }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Authorizations/ProjectAccessCheckerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Authorizations/ProjectAccessCheckerTests.cs
@@ -44,5 +44,17 @@ namespace Equinor.Procosys.Preservation.WebApi.Tests.Authorizations
             // Assert
             Assert.IsTrue(result);
         }
+
+        [TestMethod]
+        public void HasCurrentUserAccessToProject_ShouldReturnFalse_WhenProjectToCheckNotGiven()
+        {
+            // Act
+            var result1 = _dut.HasCurrentUserAccessToProject(null);
+            var result2 = _dut.HasCurrentUserAccessToProject("");
+
+            // Assert
+            Assert.IsFalse(result1);
+            Assert.IsFalse(result2);
+        }
     }
 }


### PR DESCRIPTION
When checking access to responsible or project. return false instead of exception when not given (such will happend when client ask for non-existing Tag)