### PR TITLE
Automatic update of MockQueryable.Moq to 3.1.2

### DIFF
--- a/src/tests/Equinor.Procosys.Preservation.Infrastructure.Tests/Equinor.Procosys.Preservation.Infrastructure.Tests.csproj
+++ b/src/tests/Equinor.Procosys.Preservation.Infrastructure.Tests/Equinor.Procosys.Preservation.Infrastructure.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MockQueryable.Moq" Version="3.1.1" />
+    <PackageReference Include="MockQueryable.Moq" Version="3.1.2" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `MockQueryable.Moq` to `3.1.2` from `3.1.1`
`MockQueryable.Moq 3.1.2` was published at `2020-04-17T16:19:08Z`, 9 days ago

1 project update:
Updated `src/tests/Equinor.Procosys.Preservation.Infrastructure.Tests/Equinor.Procosys.Preservation.Infrastructure.Tests.csproj` to `MockQueryable.Moq` `3.1.2` from `3.1.1`

[MockQueryable.Moq 3.1.2 on NuGet.org](https://www.nuget.org/packages/MockQueryable.Moq/3.1.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
