### PR TITLE
Automatic update of Swashbuckle.AspNetCore to 5.3.3

### DIFF
--- a/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
+++ b/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />
     <PackageReference Include="ServiceResult.ApiExtensions" Version="1.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.3.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.3.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a patch update of `Swashbuckle.AspNetCore` to `5.3.3` from `5.3.1`
`Swashbuckle.AspNetCore 5.3.3` was published at `2020-04-20T23:26:42Z`, 7 days ago

1 project update:
Updated `src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj` to `Swashbuckle.AspNetCore` `5.3.3` from `5.3.1`

[Swashbuckle.AspNetCore 5.3.3 on NuGet.org](https://www.nuget.org/packages/Swashbuckle.AspNetCore/5.3.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
