### PR TITLE
73178 refactor tag validators for start and stop

### DIFF
--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/StartPreservation/StartPreservationCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/StartPreservation/StartPreservationCommandValidator.cs
@@ -34,12 +34,10 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.StartPreservation
                     .WithMessage((_, id) => $"Tag doesn't exist! Tag={id}")
                     .MustAsync((_, tagId, __, token) => NotBeAVoidedTagAsync(tagId, token))
                     .WithMessage((_, id) => $"Tag is voided! Tag={id}")
-                    .MustAsync((_, tagId, __, token) => PreservationIsNotStartedAsync(tagId, token))
-                    .WithMessage((_, id) => $"Tag must have status {PreservationStatus.NotStarted} to start! Tag={id}")
+                    .MustAsync((_, tagId, __, token) => IsReadyToBeStartedAsync(tagId, token))
+                    .WithMessage((_, id) => $"Preservation on tag can not be started! Tag={id}")
                     .MustAsync((_, tagId, __, token) => HaveAtLeastOneNonVoidedRequirementAsync(tagId, token))
-                    .WithMessage((_, id) => $"Tag do not have any non voided requirement! Tag={id}")
-                    .MustAsync((_, tagId, __, token) => HaveExistingRequirementDefinitionsAsync(tagId, token))
-                    .WithMessage((_, id) => $"A requirement definition doesn't exists! Tag={id}");
+                    .WithMessage((_, id) => $"Tag do not have any non voided requirement! Tag={id}");
             });
 
             bool BeUniqueTags(IEnumerable<int> tagIds)
@@ -60,14 +58,11 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.StartPreservation
             async Task<bool> NotBeAVoidedTagAsync(int tagId, CancellationToken token)
                 => !await tagValidator.IsVoidedAsync(tagId, token);
 
-            async Task<bool> PreservationIsNotStartedAsync(int tagId, CancellationToken token)
-                => await tagValidator.VerifyPreservationStatusAsync(tagId, PreservationStatus.NotStarted, token);
+            async Task<bool> IsReadyToBeStartedAsync(int tagId, CancellationToken token)
+                => await tagValidator.IsReadyToBeStartedAsync(tagId, token);
 
             async Task<bool> HaveAtLeastOneNonVoidedRequirementAsync(int tagId, CancellationToken token)
                 => await tagValidator.HasANonVoidedRequirementAsync(tagId, token);
-            
-            async Task<bool> HaveExistingRequirementDefinitionsAsync(int tagId, CancellationToken token)
-                => await tagValidator.AllRequirementDefinitionsExistAsync(tagId, token);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/StopPreservation/StopPreservationCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/StopPreservation/StopPreservationCommandValidator.cs
@@ -34,10 +34,8 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.StopPreservation
                     .WithMessage((_, id) => $"Tag doesn't exists! Tag={id}")
                     .MustAsync((_, tagId, __, token) => NotBeAVoidedTagAsync(tagId, token))
                     .WithMessage((_, id) => $"Tag is voided! Tag={id}")
-                    .MustAsync((_, tagId, __, token) => PreservationIsActiveAsync(tagId, token))
-                    .WithMessage((_, id) => $"Tag must have status {PreservationStatus.Active} to be able to stop! Tag={id}")
-                    .MustAsync((_, tagId, __, token) => CanBeStoppedAsync(tagId, token))
-                    .WithMessage((_, id) => $"{TagType.Standard} and {TagType.PreArea} tags must be in last step of journey to be able to stop! Tag={id}");
+                    .MustAsync((_, tagId, __, token) => IsReadyToBeStoppedAsync(tagId, token))
+                    .WithMessage((_, id) => $"Preservation on tag can not be stopped! Tag={id}");
             });
 
             bool BeUniqueTags(IEnumerable<int> tagIds)
@@ -58,14 +56,8 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.StopPreservation
             async Task<bool> NotBeAVoidedTagAsync(int tagId, CancellationToken token)
                 => !await tagValidator.IsVoidedAsync(tagId, token);
 
-            async Task<bool> PreservationIsActiveAsync(int tagId, CancellationToken token)
-                => await tagValidator.VerifyPreservationStatusAsync(tagId, PreservationStatus.Active, token);
-
-            async Task<bool> CanBeStoppedAsync(int tagId, CancellationToken token)
-            {
-                var tagFollowsAJourney = await tagValidator.TagFollowsAJourneyAsync(tagId, token);
-                return !tagFollowsAJourney || !await tagValidator.HaveNextStepAsync(tagId, token);
-            }
+            async Task<bool> IsReadyToBeStoppedAsync(int tagId, CancellationToken token)
+                => await tagValidator.IsReadyToBeStoppedAsync(tagId, token);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/Transfer/TransferCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/Transfer/TransferCommandValidator.cs
@@ -32,12 +32,8 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.Transfer
                     .WithMessage((_, id) => $"Tag doesn't exist! Tag={id}")
                     .MustAsync((_, tagId, __, token) => NotBeAVoidedTagAsync(tagId, token))
                     .WithMessage((_, id) => $"Tag is voided! Tag={id}")
-                    .MustAsync((_, tagId, __, token) => PreservationIsStartedAsync(tagId, token))
-                    .WithMessage((_, id) => $"Tag must have status {PreservationStatus.Active} to transfer! Tag={id}")
-                    .MustAsync((_, tagId, __, token) => TagTypeCanBeTransferredAsync(tagId, token))
-                    .WithMessage((_, id) => $"Tags of this type can not be transferred! Tag={id}")
-                    .MustAsync((_, tagId, __, token) => HaveNextStepAsync(tagId, token))
-                    .WithMessage((_, id) => $"Tag doesn't have a next step to transfer to! Tag={id}");
+                    .MustAsync((_, tagId, __, token) => IsReadyToBeTransferredAsyncAsync(tagId, token))
+                    .WithMessage((_, id) => $"Tag can not be transferred! Tag={id}");
             });
 
             bool BeUniqueTags(IEnumerable<int> tagIds)
@@ -55,14 +51,8 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.Transfer
             async Task<bool> NotBeAVoidedTagAsync(int tagId, CancellationToken token)
                 => ! await tagValidator.IsVoidedAsync(tagId, token);
 
-            async Task<bool> PreservationIsStartedAsync(int tagId, CancellationToken token)
-                => await tagValidator.VerifyPreservationStatusAsync(tagId, PreservationStatus.Active, token);
-
-            async Task<bool> TagTypeCanBeTransferredAsync(int tagId, CancellationToken token)
-                => await tagValidator.TagFollowsAJourneyAsync(tagId, token);
-            
-            async Task<bool> HaveNextStepAsync(int tagId, CancellationToken token)
-                => await tagValidator.HaveNextStepAsync(tagId, token);
+            async Task<bool> IsReadyToBeTransferredAsyncAsync(int tagId, CancellationToken token)
+                => await tagValidator.IsReadyToBeTransferredAsync(tagId, token);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/Validators/TagValidators/ITagValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/TagValidators/ITagValidator.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
 
@@ -16,17 +15,17 @@ namespace Equinor.Procosys.Preservation.Command.Validators.TagValidators
         Task<bool> VerifyPreservationStatusAsync(int tagId, PreservationStatus status, CancellationToken token);
         
         Task<bool> HasANonVoidedRequirementAsync(int tagId, CancellationToken token);
-        
-        Task<bool> AllRequirementDefinitionsExistAsync(int tagId, CancellationToken token);
 
         Task<bool> ReadyToBePreservedAsync(int tagId, CancellationToken token);
         
         Task<bool> HasRequirementWithActivePeriodAsync(int tagId, int requirementId, CancellationToken token);
         
-        Task<bool> HaveNextStepAsync(int tagId, CancellationToken token);
-        
         Task<bool> RequirementIsReadyToBePreservedAsync(int tagId, int requirementId, CancellationToken token);
         
-        Task<bool> TagFollowsAJourneyAsync(int tagId, CancellationToken token);
+        Task<bool> IsReadyToBeStartedAsync(int tagId, CancellationToken token);
+        
+        Task<bool> IsReadyToBeStoppedAsync(int tagId, CancellationToken token);
+            
+        Task<bool> IsReadyToBeTransferredAsync(int tagId, CancellationToken token);
     }
 }

--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/Tag.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/Tag.cs
@@ -222,7 +222,7 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate
                 throw new ArgumentNullException(nameof(journey));
             }
 
-            return Status == PreservationStatus.Active && TagType != TagType.SiteArea && journey.GetNextStep(StepId) != null;
+            return Status == PreservationStatus.Active && TagFollowsAJourney && journey.GetNextStep(StepId) != null;
         }
 
         public bool IsReadyToBeStopped(Journey journey)
@@ -233,8 +233,7 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate
             }
 
             return Status == PreservationStatus.Active && 
-                   (TagType == TagType.SiteArea || TagType == TagType.PoArea || 
-                   (TagType == TagType.Standard || TagType == TagType.PreArea) && journey.GetNextStep(StepId) == null);
+                   (!TagFollowsAJourney || TagFollowsAJourney && journey.GetNextStep(StepId) == null);
         }
 
         public void Transfer(Journey journey)
@@ -290,5 +289,7 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate
 
         private void UpdateNextDueTimeUtc()
             => NextDueTimeUtc = OrderedRequirements().FirstOrDefault()?.NextDueTimeUtc;
+
+        private bool TagFollowsAJourney => TagType == TagType.Standard || TagType == TagType.PreArea;
     }
 }


### PR DESCRIPTION
When using StartPreservation command when onboarding Demissie for making StopPreservation, I found that validation logic for checking IsReadyToBeXXXX could be made better to reuse same logic in Tag domain class. Before this PR "same" logic was duplicated both in Tag.cs and in validators