### PR TITLE
73419 Bugfix: No NextMode or NextResposible if Tag do not follow a Journey

### DIFF
--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/Tag.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/Tag.cs
@@ -239,7 +239,7 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate
                 throw new ArgumentNullException(nameof(journey));
             }
 
-            return Status == PreservationStatus.Active && TagFollowsAJourney && journey.GetNextStep(StepId) != null;
+            return Status == PreservationStatus.Active && FollowsAJourney && journey.GetNextStep(StepId) != null;
         }
 
         public bool IsReadyToBeStopped(Journey journey)
@@ -250,7 +250,7 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate
             }
 
             return Status == PreservationStatus.Active && 
-                   (!TagFollowsAJourney || TagFollowsAJourney && journey.GetNextStep(StepId) == null);
+                   (!FollowsAJourney || FollowsAJourney && journey.GetNextStep(StepId) == null);
         }
 
         public void Transfer(Journey journey)
@@ -288,6 +288,8 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate
 
         public TagAttachment GetAttachmentByFileName(string fileName) => _attachments.SingleOrDefault(a => a.FileName.ToUpper() == fileName.ToUpper());
 
+        public bool FollowsAJourney => TagType == TagType.Standard || TagType == TagType.PreArea;
+
         private void Preserve(Person preservedBy, bool bulkPreserved)
         {
             if (!IsReadyToBePreserved())
@@ -308,7 +310,5 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate
 
         private void UpdateNextDueTimeUtc()
             => NextDueTimeUtc = OrderedRequirements().FirstOrDefault()?.NextDueTimeUtc;
-
-        private bool TagFollowsAJourney => TagType == TagType.Standard || TagType == TagType.PreArea;
     }
 }

--- a/src/Equinor.Procosys.Preservation.Query/GetTags/GetTagsQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetTags/GetTagsQueryHandler.cs
@@ -135,11 +135,11 @@ namespace Equinor.Procosys.Preservation.Query.GetTags
                 var isReadyToBeStarted = tagWithRequirements.IsReadyToBeStarted();
                 var isReadyToBeTransferred = tagWithRequirements.IsReadyToBeTransferred(dto.JourneyWithSteps);
 
-                var nextMode = isReadyToBeTransferred && dto.NextStep != null 
+                var nextMode = tagWithRequirements.FollowsAJourney && dto.NextStep != null 
                     ? nextModes.Single(m => m.Id == dto.NextStep.ModeId)
                     : null;
                 
-                var nextResponsible = isReadyToBeTransferred && dto.NextStep != null
+                var nextResponsible = tagWithRequirements.FollowsAJourney && dto.NextStep != null
                     ? nextResponsibles.Single(m => m.Id == dto.NextStep.ResponsibleId)
                     : null;
 

--- a/src/Equinor.Procosys.Preservation.Query/GetTags/GetTagsQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetTags/GetTagsQueryHandler.cs
@@ -135,8 +135,11 @@ namespace Equinor.Procosys.Preservation.Query.GetTags
                 var isReadyToBeStarted = tagWithRequirements.IsReadyToBeStarted();
                 var isReadyToBeTransferred = tagWithRequirements.IsReadyToBeTransferred(dto.JourneyWithSteps);
 
-                var nextMode = dto.NextStep != null ? nextModes.Single(m => m.Id == dto.NextStep.ModeId) : null;
-                var nextResponsible = dto.NextStep != null
+                var nextMode = isReadyToBeTransferred && dto.NextStep != null 
+                    ? nextModes.Single(m => m.Id == dto.NextStep.ModeId)
+                    : null;
+                
+                var nextResponsible = isReadyToBeTransferred && dto.NextStep != null
                     ? nextResponsibles.Single(m => m.Id == dto.NextStep.ResponsibleId)
                     : null;
 

--- a/src/tests/Equinor.Procosys.Preservation.Domain.Tests/AggregateModels/ProjectAggregate/TagTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Domain.Tests/AggregateModels/ProjectAggregate/TagTests.cs
@@ -1016,5 +1016,49 @@ namespace Equinor.Procosys.Preservation.Domain.Tests.AggregateModels.ProjectAggr
         }
 
         #endregion
+        
+        #region FollowsAJourney
+
+        [TestMethod]
+        public void FollowsAJourney_ShouldGetBeTrueForStandardTag()
+        {
+            // Arrange
+            var dut = new Tag(TestPlant, TagType.Standard, "", "", _step1Mock.Object, _oneReq_NotNeedInputTwoWeekInterval);
+
+            // Act and Arrange
+            Assert.IsTrue(dut.FollowsAJourney);
+        }
+
+        [TestMethod]
+        public void FollowsAJourney_ShouldGetBeFalseForSiteAreaTag()
+        {
+            // Arrange
+            var dut = new Tag(TestPlant, TagType.SiteArea, "", "", _step1Mock.Object, _oneReq_NotNeedInputTwoWeekInterval);
+
+            // Act and Arrange
+            Assert.IsFalse(dut.FollowsAJourney);
+        }
+
+        [TestMethod]
+        public void FollowsAJourney_ShouldGetBeTrueForPreAreaTag()
+        {
+            // Arrange
+            var dut = new Tag(TestPlant, TagType.PreArea, "", "", _step1Mock.Object, _oneReq_NotNeedInputTwoWeekInterval);
+
+            // Act and Arrange
+            Assert.IsTrue(dut.FollowsAJourney);
+        }
+
+        [TestMethod]
+        public void FollowsAJourney_ShouldGetBeFalseForPoAreaTag()
+        {
+            // Arrange
+            var dut = new Tag(TestPlant, TagType.PoArea, "", "", _step1Mock.Object, _oneReq_NotNeedInputTwoWeekInterval);
+
+            // Act and Arrange
+            Assert.IsFalse(dut.FollowsAJourney);
+        }
+
+        #endregion
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTags/GetTagsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTags/GetTagsQueryHandlerTests.cs
@@ -859,7 +859,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTags
         }
         
         [TestMethod]
-        public async Task HandleGetAllTagsInProjectQuery_ShouldNotReturnNextStepInfo_WhenCanNotBeTransferred()
+        public async Task HandleGetAllTagsInProjectQuery_ShouldNotReturnNextModeOrResponsible_WhenTagCantBeTransferred()
         {
             int tagId;
             var tagTitle = "D43CDE9C5568";


### PR DESCRIPTION
#SITE and #PO area tags do not follow a Journey. Then it is better to **not** show NextMode or NextResponsible in Transfer dialog if user try to transfer such tags