### PR TITLE
73422 rename stop to complete

### DIFF
--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/CompletePreservation/CompletePreservationCommand.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/CompletePreservation/CompletePreservationCommand.cs
@@ -4,11 +4,11 @@ using System.Linq;
 using MediatR;
 using ServiceResult;
 
-namespace Equinor.Procosys.Preservation.Command.TagCommands.StopPreservation
+namespace Equinor.Procosys.Preservation.Command.TagCommands.CompletePreservation
 {
-    public class StopPreservationCommand : IRequest<Result<Unit>>, ITagCommandRequest
+    public class CompletePreservationCommand : IRequest<Result<Unit>>, ITagCommandRequest
     {
-        public StopPreservationCommand(IEnumerable<int> tagIds)
+        public CompletePreservationCommand(IEnumerable<int> tagIds)
             => TagIds = tagIds ?? new List<int>();
 
         public IEnumerable<int> TagIds { get; }

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/CompletePreservation/CompletePreservationCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/CompletePreservation/CompletePreservationCommandHandler.cs
@@ -7,22 +7,22 @@ using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using MediatR;
 using ServiceResult;
 
-namespace Equinor.Procosys.Preservation.Command.TagCommands.StopPreservation
+namespace Equinor.Procosys.Preservation.Command.TagCommands.CompletePreservation
 {
-    public class StopPreservationCommandHandler : IRequestHandler<StopPreservationCommand, Result<Unit>>
+    public class CompletePreservationCommandHandler : IRequestHandler<CompletePreservationCommand, Result<Unit>>
     {
         private readonly IProjectRepository _projectRepository;
         private readonly IJourneyRepository _journeyRepository;
         private readonly IUnitOfWork _unitOfWork;
 
-        public StopPreservationCommandHandler(IProjectRepository projectRepository, IJourneyRepository journeyRepository, IUnitOfWork unitOfWork)
+        public CompletePreservationCommandHandler(IProjectRepository projectRepository, IJourneyRepository journeyRepository, IUnitOfWork unitOfWork)
         {
             _projectRepository = projectRepository;
             _unitOfWork = unitOfWork;
             _journeyRepository = journeyRepository;
         }
 
-        public async Task<Result<Unit>> Handle(StopPreservationCommand request, CancellationToken cancellationToken)
+        public async Task<Result<Unit>> Handle(CompletePreservationCommand request, CancellationToken cancellationToken)
         {
             var tags = await _projectRepository.GetTagsByTagIdsAsync(request.TagIds);
 
@@ -32,7 +32,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.StopPreservation
             foreach (var tag in tags)
             {
                 var journey = journeys.Single(j => j.Steps.Any(s => s.Id == tag.StepId));
-                tag.StopPreservation(journey);
+                tag.CompletePreservation(journey);
             }
             
             await _unitOfWork.SaveChangesAsync(cancellationToken);

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/CompletePreservation/CompletePreservationCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/CompletePreservation/CompletePreservationCommandValidator.cs
@@ -3,15 +3,14 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.Validators.TagValidators;
-using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Equinor.Procosys.Preservation.Command.Validators.ProjectValidators;
 using FluentValidation;
 
-namespace Equinor.Procosys.Preservation.Command.TagCommands.StopPreservation
+namespace Equinor.Procosys.Preservation.Command.TagCommands.CompletePreservation
 {
-    public class StopPreservationCommandValidator : AbstractValidator<StopPreservationCommand>
+    public class CompletePreservationCommandValidator : AbstractValidator<CompletePreservationCommand>
     {
-        public StopPreservationCommandValidator(
+        public CompletePreservationCommandValidator(
             IProjectValidator projectValidator,
             ITagValidator tagValidator)
         {
@@ -34,8 +33,8 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.StopPreservation
                     .WithMessage((_, id) => $"Tag doesn't exists! Tag={id}")
                     .MustAsync((_, tagId, __, token) => NotBeAVoidedTagAsync(tagId, token))
                     .WithMessage((_, id) => $"Tag is voided! Tag={id}")
-                    .MustAsync((_, tagId, __, token) => IsReadyToBeStoppedAsync(tagId, token))
-                    .WithMessage((_, id) => $"Preservation on tag can not be stopped! Tag={id}");
+                    .MustAsync((_, tagId, __, token) => IsReadyToBeCompletedAsync(tagId, token))
+                    .WithMessage((_, id) => $"Preservation on tag can not be completed! Tag={id}");
             });
 
             bool BeUniqueTags(IEnumerable<int> tagIds)
@@ -56,8 +55,8 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.StopPreservation
             async Task<bool> NotBeAVoidedTagAsync(int tagId, CancellationToken token)
                 => !await tagValidator.IsVoidedAsync(tagId, token);
 
-            async Task<bool> IsReadyToBeStoppedAsync(int tagId, CancellationToken token)
-                => await tagValidator.IsReadyToBeStoppedAsync(tagId, token);
+            async Task<bool> IsReadyToBeCompletedAsync(int tagId, CancellationToken token)
+                => await tagValidator.IsReadyToBeCompletedAsync(tagId, token);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/StartPreservation/StartPreservationCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/StartPreservation/StartPreservationCommandValidator.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.Validators.TagValidators;
-using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Equinor.Procosys.Preservation.Command.Validators.ProjectValidators;
 using FluentValidation;
 

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/Transfer/TransferCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/Transfer/TransferCommandValidator.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.Validators.ProjectValidators;
 using Equinor.Procosys.Preservation.Command.Validators.TagValidators;
-using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using FluentValidation;
 
 namespace Equinor.Procosys.Preservation.Command.TagCommands.Transfer

--- a/src/Equinor.Procosys.Preservation.Command/Validators/TagValidators/ITagValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/TagValidators/ITagValidator.cs
@@ -26,7 +26,7 @@ namespace Equinor.Procosys.Preservation.Command.Validators.TagValidators
 
         Task<bool> IsReadyToBeStartedAsync(int tagId, CancellationToken token);
         
-        Task<bool> IsReadyToBeStoppedAsync(int tagId, CancellationToken token);
+        Task<bool> IsReadyToBeCompletedAsync(int tagId, CancellationToken token);
             
         Task<bool> IsReadyToBeTransferredAsync(int tagId, CancellationToken token);
     }

--- a/src/Equinor.Procosys.Preservation.Command/Validators/TagValidators/TagValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/TagValidators/TagValidator.cs
@@ -90,7 +90,7 @@ namespace Equinor.Procosys.Preservation.Command.Validators.TagValidators
             return tag.IsReadyToBeStarted();
         }
 
-        public async Task<bool> IsReadyToBeStoppedAsync(int tagId, CancellationToken cancellationToken)
+        public async Task<bool> IsReadyToBeCompletedAsync(int tagId, CancellationToken cancellationToken)
         {
             var tag = await GetTagWithoutIncludes(tagId, cancellationToken);
             if (tag == null)
@@ -102,7 +102,7 @@ namespace Equinor.Procosys.Preservation.Command.Validators.TagValidators
                 where j.Steps.Any(s => s.Id == tag.StepId)
                 select j).SingleOrDefaultAsync(cancellationToken);
 
-            return tag.IsReadyToBeStopped(journey);
+            return tag.IsReadyToBeCompleted(journey);
         }
 
         public async Task<bool> IsReadyToBeTransferredAsync(int tagId, CancellationToken cancellationToken)

--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/PreservationPeriodStatus.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/PreservationPeriodStatus.cs
@@ -4,7 +4,7 @@
     {
         NeedsUserInput,
         ReadyToBePreserved,
-        Preserved,
-        Stopped
+        Preserved
+        //Stopped
     }
 }

--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/Tag.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/Tag.cs
@@ -188,15 +188,15 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate
             UpdateNextDueTimeUtc();
         }
 
-        public void StopPreservation(Journey journey)
+        public void CompletePreservation(Journey journey)
         {
-            if (!IsReadyToBeStopped(journey))
+            if (!IsReadyToBeCompleted(journey))
             {
-                throw new Exception($"Preservation on {nameof(Tag)} {Id} can not be stopped. Status = {Status}");
+                throw new Exception($"Preservation on {nameof(Tag)} {Id} can not be completed. Status = {Status}");
             }
             foreach (var requirement in Requirements.Where(r => !r.IsVoided))
             {
-                requirement.StopPreservation();
+                requirement.CompletePreservation();
             }
 
             Status = PreservationStatus.Completed;
@@ -242,7 +242,7 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate
             return Status == PreservationStatus.Active && TagFollowsAJourney && journey.GetNextStep(StepId) != null;
         }
 
-        public bool IsReadyToBeStopped(Journey journey)
+        public bool IsReadyToBeCompleted(Journey journey)
         {
             if (journey == null)
             {

--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/TagRequirement.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/TagRequirement.cs
@@ -92,7 +92,7 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate
             PrepareNewPreservation();
         }
 
-        public void StopPreservation() => NextDueTimeUtc = null;
+        public void CompletePreservation() => NextDueTimeUtc = null;
 
         public void Preserve(Person preservedBy, bool bulkPreserved)
         {

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200429183340_RemovePreservationPeriodStatusStopped.Designer.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200429183340_RemovePreservationPeriodStatusStopped.Designer.cs
@@ -4,14 +4,16 @@ using Equinor.Procosys.Preservation.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Equinor.Procosys.Preservation.Infrastructure.Migrations
 {
     [DbContext(typeof(PreservationContext))]
-    partial class PreservationContextModelSnapshot : ModelSnapshot
+    [Migration("20200429183340_RemovePreservationPeriodStatusStopped")]
+    partial class RemovePreservationPeriodStatusStopped
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200429183340_RemovePreservationPeriodStatusStopped.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200429183340_RemovePreservationPeriodStatusStopped.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Equinor.Procosys.Preservation.Infrastructure.Migrations
+{
+    public partial class RemovePreservationPeriodStatusStopped : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "constraint_period_check_valid_status",
+                table: "PreservationPeriods");
+
+            migrationBuilder.CreateCheckConstraint(
+                name: "constraint_period_check_valid_status",
+                table: "PreservationPeriods",
+                sql: "Status in ('NeedsUserInput','ReadyToBePreserved','Preserved')");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "constraint_period_check_valid_status",
+                table: "PreservationPeriods");
+
+            migrationBuilder.CreateCheckConstraint(
+                name: "constraint_period_check_valid_status",
+                table: "PreservationPeriods",
+                sql: "Status in ('NeedsUserInput','ReadyToBePreserved','Preserved','Stopped')");
+        }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Tags/TagsController.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Tags/TagsController.cs
@@ -13,7 +13,7 @@ using Equinor.Procosys.Preservation.Command.TagCommands.CreateAreaTag;
 using Equinor.Procosys.Preservation.Command.TagCommands.CreateTags;
 using Equinor.Procosys.Preservation.Command.TagCommands.Preserve;
 using Equinor.Procosys.Preservation.Command.TagCommands.StartPreservation;
-using Equinor.Procosys.Preservation.Command.TagCommands.StopPreservation;
+using Equinor.Procosys.Preservation.Command.TagCommands.CompletePreservation;
 using Equinor.Procosys.Preservation.Command.TagCommands.Transfer;
 using Equinor.Procosys.Preservation.Command.TagCommands.UpdateTag;
 using Equinor.Procosys.Preservation.Command.TagCommands.VoidTag;
@@ -334,28 +334,28 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Tags
         }
 
         [Authorize(Roles = Permissions.PRESERVATION_PLAN_WRITE)]
-        [HttpPut("{id}/StopPreservation")]
-        public async Task<IActionResult> StopPreservation(
+        [HttpPut("{id}/CompletePreservation")]
+        public async Task<IActionResult> CompletePreservation(
             [FromHeader( Name = PlantProvider.PlantHeader)]
             [Required]
             [StringLength(PlantEntityBase.PlantLengthMax, MinimumLength = PlantEntityBase.PlantLengthMin)]
             string plant,
             [FromRoute] int id)
         {
-            var result = await _mediator.Send(new StopPreservationCommand(new List<int> { id }));
+            var result = await _mediator.Send(new CompletePreservationCommand(new List<int> { id }));
             return this.FromResult(result);
         }
 
         [Authorize(Roles = Permissions.PRESERVATION_PLAN_WRITE)]
-        [HttpPut("StopPreservation")]
-        public async Task<IActionResult> StopPreservation(
+        [HttpPut("CompletePreservation")]
+        public async Task<IActionResult> CompletePreservation(
             [FromHeader( Name = PlantProvider.PlantHeader)]
             [Required]
             [StringLength(PlantEntityBase.PlantLengthMax, MinimumLength = PlantEntityBase.PlantLengthMin)]
             string plant,
             [FromBody] List<int> tagIds)
         {
-            var result = await _mediator.Send(new StopPreservationCommand(tagIds));
+            var result = await _mediator.Send(new CompletePreservationCommand(tagIds));
             return this.FromResult(result);
         }
 

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CompletePreservation/CompletePreservationCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CompletePreservation/CompletePreservationCommandHandlerTests.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Equinor.Procosys.Preservation.Command.TagCommands.StopPreservation;
+using Equinor.Procosys.Preservation.Command.TagCommands.CompletePreservation;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
@@ -8,13 +8,13 @@ using MediatR;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
-namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.StopPreservation
+namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CompletePreservation
 {
     [TestClass]
-    public class StopPreservationCommandHandlerTests : CommandHandlerTestsBase
+    public class CompletePreservationCommandHandlerTests : CommandHandlerTestsBase
     {
         private Mock<IProjectRepository> _tagRepoMock;
-        private StopPreservationCommand _command;
+        private CompletePreservationCommand _command;
         private Tag _tag1;
         private Tag _tag2;
         private TagRequirement _req1OnTag1;
@@ -32,7 +32,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.StopPreservati
         private int _stepId1 = 9;
         private int _stepId2 = 10;
 
-        private StopPreservationCommandHandler _dut;
+        private CompletePreservationCommandHandler _dut;
 
         [TestInitialize]
         public void Setup()
@@ -86,13 +86,13 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.StopPreservati
                 .Setup(r => r.GetJourneysByStepIdsAsync(new List<int> { _stepId2 }))
                 .Returns(Task.FromResult(new List<Journey> { journey }));
             
-            _command = new StopPreservationCommand(tagIds);
+            _command = new CompletePreservationCommand(tagIds);
 
-            _dut = new StopPreservationCommandHandler(_tagRepoMock.Object, journeyRepoMock.Object, UnitOfWorkMock.Object);
+            _dut = new CompletePreservationCommandHandler(_tagRepoMock.Object, journeyRepoMock.Object, UnitOfWorkMock.Object);
         }
 
         [TestMethod]
-        public async Task HandlingStopPreservationCommand_ShouldStopPreservationOnAllTags()
+        public async Task HandlingCompletePreservationCommand_ShouldCompletePreservationOnAllTags()
         {
             var result = await _dut.Handle(_command, default);
 
@@ -107,7 +107,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.StopPreservati
         }
 
         [TestMethod]
-        public async Task HandlingStopPreservationCommand_ShouldClearNextDueOnAllRequirementsOnAllTags()
+        public async Task HandlingCompletePreservationCommand_ShouldClearNextDueOnAllRequirementsOnAllTags()
         {
             await _dut.Handle(_command, default);
 
@@ -121,7 +121,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.StopPreservati
         }
 
         [TestMethod]
-        public async Task HandlingStopPreservationCommand_ShouldSave()
+        public async Task HandlingCompletePreservationCommand_ShouldSave()
         {
             await _dut.Handle(_command, default);
 

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CompletePreservation/CompletePreservationCommandTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CompletePreservation/CompletePreservationCommandTests.cs
@@ -1,17 +1,17 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Equinor.Procosys.Preservation.Command.TagCommands.StopPreservation;
+using Equinor.Procosys.Preservation.Command.TagCommands.CompletePreservation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.StopPreservation
+namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CompletePreservation
 {
     [TestClass]
-    public class StopPreservationCommandTests
+    public class CompletePreservationCommandTests
     {
         [TestMethod]
         public void Constructor_ShouldSetProperties()
         {
-            var dut = new StopPreservationCommand(new List<int>{17});
+            var dut = new CompletePreservationCommand(new List<int>{17});
 
             Assert.AreEqual(1, dut.TagIds.Count());
             Assert.AreEqual(17, dut.TagIds.First());

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CompletePreservation/CompletePreservationCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CompletePreservation/CompletePreservationCommandValidatorTests.cs
@@ -1,22 +1,22 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Equinor.Procosys.Preservation.Command.TagCommands.StopPreservation;
+using Equinor.Procosys.Preservation.Command.TagCommands.CompletePreservation;
 using Equinor.Procosys.Preservation.Command.Validators.ProjectValidators;
 using Equinor.Procosys.Preservation.Command.Validators.TagValidators;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
-namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.StopPreservation
+namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CompletePreservation
 {
     [TestClass]
-    public class StopPreservationCommandValidatorTests
+    public class CompletePreservationCommandValidatorTests
     {
-        private StopPreservationCommandValidator _dut;
+        private CompletePreservationCommandValidator _dut;
         private Mock<IProjectValidator> _projectValidatorMock;
         private Mock<ITagValidator> _tagValidatorMock;
-        private StopPreservationCommand _command;
+        private CompletePreservationCommand _command;
 
         private const int TagId1 = 7;
         private const int TagId2 = 8;
@@ -31,11 +31,11 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.StopPreservati
             _tagValidatorMock = new Mock<ITagValidator>();
             _tagValidatorMock.Setup(r => r.ExistsAsync(TagId1, default)).Returns(Task.FromResult(true));
             _tagValidatorMock.Setup(r => r.ExistsAsync(TagId2, default)).Returns(Task.FromResult(true));
-            _tagValidatorMock.Setup(r => r.IsReadyToBeStoppedAsync(TagId1, default)).Returns(Task.FromResult(true));
-            _tagValidatorMock.Setup(r => r.IsReadyToBeStoppedAsync(TagId2, default)).Returns(Task.FromResult(true));
-            _command = new StopPreservationCommand(_tagIds);
+            _tagValidatorMock.Setup(r => r.IsReadyToBeCompletedAsync(TagId1, default)).Returns(Task.FromResult(true));
+            _tagValidatorMock.Setup(r => r.IsReadyToBeCompletedAsync(TagId2, default)).Returns(Task.FromResult(true));
+            _command = new CompletePreservationCommand(_tagIds);
 
-            _dut = new StopPreservationCommandValidator(_projectValidatorMock.Object, _tagValidatorMock.Object);
+            _dut = new CompletePreservationCommandValidator(_projectValidatorMock.Object, _tagValidatorMock.Object);
         }
 
         [TestMethod]
@@ -49,7 +49,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.StopPreservati
         [TestMethod]
         public void Validate_ShouldFail_WhenNoTagsGiven()
         {
-            var command = new StopPreservationCommand(new List<int>());
+            var command = new CompletePreservationCommand(new List<int>());
             
             var result = _dut.Validate(command);
 
@@ -61,7 +61,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.StopPreservati
         [TestMethod]
         public void Validate_ShouldFail_WhenTagsNotUnique()
         {
-            var command = new StopPreservationCommand(new List<int>{1, 1});
+            var command = new CompletePreservationCommand(new List<int>{1, 1});
             
             var result = _dut.Validate(command);
 
@@ -119,15 +119,15 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.StopPreservati
         }
 
         [TestMethod]
-        public void Validate_ShouldFail_WhenNotReadyToBeStopped()
+        public void Validate_ShouldFail_WhenNotReadyToBeCompleted()
         {
-            _tagValidatorMock.Setup(r => r.IsReadyToBeStoppedAsync(TagId1, default)).Returns(Task.FromResult(false));
+            _tagValidatorMock.Setup(r => r.IsReadyToBeCompletedAsync(TagId1, default)).Returns(Task.FromResult(false));
             
             var result = _dut.Validate(_command);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith($"Preservation on tag can not be stopped!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith($"Preservation on tag can not be completed!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/TagValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/TagValidatorTests.cs
@@ -347,78 +347,78 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
  
         [TestMethod]
-        public async Task IsReadyToBeStoppedAsync_StandardTagNotStarted_ReturnsFalse()
+        public async Task IsReadyToBeCompletedAsync_StandardTagNotStarted_ReturnsFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new TagValidator(context);
-                var result = await dut.IsReadyToBeStoppedAsync(_standardTagNotStartedInFirstStepId, default);
+                var result = await dut.IsReadyToBeCompletedAsync(_standardTagNotStartedInFirstStepId, default);
                 Assert.IsFalse(result);
             }
         }
 
         [TestMethod]
-        public async Task IsReadyToBeStoppedAsync_StandardTagInLastStep_ReturnsTrue()
+        public async Task IsReadyToBeCompletedAsync_StandardTagInLastStep_ReturnsTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new TagValidator(context);
-                var result = await dut.IsReadyToBeStoppedAsync(_standardTagStartedAndInLastStepId, default);
+                var result = await dut.IsReadyToBeCompletedAsync(_standardTagStartedAndInLastStepId, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task IsReadyToBeStoppedAsync_PreAreaTagNotStarted_ReturnsFalse()
+        public async Task IsReadyToBeCompletedAsync_PreAreaTagNotStarted_ReturnsFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new TagValidator(context);
-                var result = await dut.IsReadyToBeStoppedAsync(_preAreaTagNotStartedInFirstStepId, default);
+                var result = await dut.IsReadyToBeCompletedAsync(_preAreaTagNotStartedInFirstStepId, default);
                 Assert.IsFalse(result);
             }
         }
 
         [TestMethod]
-        public async Task IsReadyToBeStoppedAsync_PreAreaTagInFirstStep_ReturnsFalse()
+        public async Task IsReadyToBeCompletedAsync_PreAreaTagInFirstStep_ReturnsFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new TagValidator(context);
-                var result = await dut.IsReadyToBeStoppedAsync(_preAreaTagStartedInFirstStepId, default);
+                var result = await dut.IsReadyToBeCompletedAsync(_preAreaTagStartedInFirstStepId, default);
                 Assert.IsFalse(result);
             }
         }
 
         [TestMethod]
-        public async Task IsReadyToBeStoppedAsync_SiteAreaTagInAnyStep_ReturnsTrue()
+        public async Task IsReadyToBeCompletedAsync_SiteAreaTagInAnyStep_ReturnsTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new TagValidator(context);
-                var result = await dut.IsReadyToBeStoppedAsync(_siteAreaTagStartedId, default);
+                var result = await dut.IsReadyToBeCompletedAsync(_siteAreaTagStartedId, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task IsReadyToBeStoppedAsync_PoAreaTagInAnyStep_ReturnsTrue()
+        public async Task IsReadyToBeCompletedAsync_PoAreaTagInAnyStep_ReturnsTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new TagValidator(context);
-                var result = await dut.IsReadyToBeStoppedAsync(_poAreaTagStartedId, default);
+                var result = await dut.IsReadyToBeCompletedAsync(_poAreaTagStartedId, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task IsReadyToBeStoppedAsync_UnknownTag_ReturnsFalse()
+        public async Task IsReadyToBeCompletedAsync_UnknownTag_ReturnsFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new TagValidator(context);
-                var result = await dut.IsReadyToBeStoppedAsync(0, default);
+                var result = await dut.IsReadyToBeCompletedAsync(0, default);
                 Assert.IsFalse(result);
             }
         }

--- a/src/tests/Equinor.Procosys.Preservation.Domain.Tests/AggregateModels/ProjectAggregate/PreservationPeriodTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Domain.Tests/AggregateModels/ProjectAggregate/PreservationPeriodTests.cs
@@ -59,11 +59,11 @@ namespace Equinor.Procosys.Preservation.Domain.Tests.AggregateModels.ProjectAggr
                 new PreservationPeriod(TestPlant, _dueUtc, PreservationPeriodStatus.Preserved)
             );
 
-        [TestMethod]
-        public void Constructor_ShouldThrowException_WhenStatusIsStopped()
-            => Assert.ThrowsException<ArgumentException>(() =>
-                new PreservationPeriod(TestPlant, _dueUtc, PreservationPeriodStatus.Stopped)
-            );
+        //[TestMethod]
+        //public void Constructor_ShouldThrowException_WhenStatusIsStopped()
+        //    => Assert.ThrowsException<ArgumentException>(() =>
+        //        new PreservationPeriod(TestPlant, _dueUtc, PreservationPeriodStatus.Stopped)
+        //    );
 
         [TestMethod]
         public void SetComment_ShouldSetComment()

--- a/src/tests/Equinor.Procosys.Preservation.Domain.Tests/AggregateModels/ProjectAggregate/RequirementTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Domain.Tests/AggregateModels/ProjectAggregate/RequirementTests.cs
@@ -235,10 +235,10 @@ namespace Equinor.Procosys.Preservation.Domain.Tests.AggregateModels.ProjectAggr
 
         #endregion
 
-        #region StopPreservation
+        #region CompletePreservation
 
         [TestMethod]
-        public void StopPreservation_ShouldSetNextDueDateToNull()
+        public void CompletePreservation_ShouldSetNextDueDateToNull()
         {
             // Arrange
             var dut = new TagRequirement(TestPlant, TwoWeeksInterval, _reqDefWithCheckBoxFieldMock.Object);
@@ -247,7 +247,7 @@ namespace Equinor.Procosys.Preservation.Domain.Tests.AggregateModels.ProjectAggr
             Assert.IsNotNull(dut.NextDueTimeUtc);
 
             // Act
-            dut.StopPreservation();
+            dut.CompletePreservation();
 
             // Assert
             Assert.IsNull(dut.NextDueTimeUtc);

--- a/src/tests/Equinor.Procosys.Preservation.Domain.Tests/AggregateModels/ProjectAggregate/TagTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Domain.Tests/AggregateModels/ProjectAggregate/TagTests.cs
@@ -778,35 +778,35 @@ namespace Equinor.Procosys.Preservation.Domain.Tests.AggregateModels.ProjectAggr
 
         #endregion
 
-        #region StopPreservation
+        #region CompletePreservation
 
         [TestMethod]
-        public void StopPreservation_ShouldSetStatusToCompleted_WhenInLastStepAndIsStandard()
+        public void CompletePreservation_ShouldSetStatusToCompleted_WhenInLastStepAndIsStandard()
         {
             var dut = new Tag(TestPlant, TagType.Standard, "", "", _step2Mock.Object, _oneReq_NotNeedInputTwoWeekInterval);
             dut.StartPreservation();
 
-            dut.StopPreservation(_journey);
+            dut.CompletePreservation(_journey);
 
             Assert.AreEqual(PreservationStatus.Completed, dut.Status);
         }
 
         [TestMethod]
-        public void StopPreservation_ShouldThrowException_WhenJourneyIsNull()
+        public void CompletePreservation_ShouldThrowException_WhenJourneyIsNull()
         {
             var dut = new Tag(TestPlant, TagType.Standard, "", "", _step1Mock.Object, _oneReq_NotNeedInputTwoWeekInterval);
             dut.StartPreservation();
 
-            Assert.ThrowsException<ArgumentNullException>(() => dut.StopPreservation(null));
+            Assert.ThrowsException<ArgumentNullException>(() => dut.CompletePreservation(null));
         }
 
         [TestMethod]
-        public void StopPreservation_ShouldSetStatusToCompleted_WhenNotInLastStepAndIsArea()
+        public void CompletePreservation_ShouldSetStatusToCompleted_WhenNotInLastStepAndIsArea()
         {
             var dut = new Tag(TestPlant, TagType.SiteArea, "", "", _step1Mock.Object, _oneReq_NotNeedInputTwoWeekInterval);
             dut.StartPreservation();
 
-            dut.StopPreservation(_journey);
+            dut.CompletePreservation(_journey);
 
             Assert.AreEqual(PreservationStatus.Completed, dut.Status);
         }
@@ -853,41 +853,41 @@ namespace Equinor.Procosys.Preservation.Domain.Tests.AggregateModels.ProjectAggr
 
         #endregion
         
-        #region IsReadyToBeStopped
+        #region IsReadyToBeCompleted
 
         [TestMethod]
-        public void IsReadyToBeStopped_ShouldBeFalse_BeforePreservationStarted()
+        public void IsReadyToBeCompleted_ShouldBeFalse_BeforePreservationStarted()
         {
             var dut = new Tag(TestPlant, TagType.Standard, "", "", _step2Mock.Object, _oneReq_NotNeedInputTwoWeekInterval);
 
-            Assert.IsFalse(dut.IsReadyToBeStopped(_journey));
+            Assert.IsFalse(dut.IsReadyToBeCompleted(_journey));
         }
 
         [TestMethod]
-        public void IsReadyToBeStopped_ShouldBeTrue_AfterPreservationStarted()
+        public void IsReadyToBeCompleted_ShouldBeTrue_AfterPreservationStarted()
         {
             var dut = new Tag(TestPlant, TagType.Standard, "", "", _step2Mock.Object, _oneReq_NotNeedInputTwoWeekInterval);
             dut.StartPreservation();
 
-            Assert.IsTrue(dut.IsReadyToBeStopped(_journey));
+            Assert.IsTrue(dut.IsReadyToBeCompleted(_journey));
         }
 
         [TestMethod]
-        public void IsReadyToBeStopped_ShouldBeFalse_WhenCurrentStepIsLastStepInJourney()
+        public void IsReadyToBeCompleted_ShouldBeFalse_WhenCurrentStepIsLastStepInJourney()
         {
             var dut = new Tag(TestPlant, TagType.Standard, "", "", _step1Mock.Object, _oneReq_NotNeedInputTwoWeekInterval);
             dut.StartPreservation();
 
-            Assert.IsFalse(dut.IsReadyToBeStopped(_journey));
+            Assert.IsFalse(dut.IsReadyToBeCompleted(_journey));
         }
 
         [TestMethod]
-        public void IsReadyToBeStopped_ShouldThrowException_WhenJourneyIsNull()
+        public void IsReadyToBeCompleted_ShouldThrowException_WhenJourneyIsNull()
         {
             var dut = new Tag(TestPlant, TagType.Standard, "", "", _step1Mock.Object, _oneReq_NotNeedInputTwoWeekInterval);
             dut.StartPreservation();
 
-            Assert.ThrowsException<ArgumentNullException>(() => dut.IsReadyToBeStopped(null));
+            Assert.ThrowsException<ArgumentNullException>(() => dut.IsReadyToBeCompleted(null));
         }
 
         #endregion

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Authorizations/AccessValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Authorizations/AccessValidatorTests.cs
@@ -7,7 +7,7 @@ using Equinor.Procosys.Preservation.Command.TagCommands.CreateAreaTag;
 using Equinor.Procosys.Preservation.Command.TagCommands.CreateTags;
 using Equinor.Procosys.Preservation.Command.TagCommands.Preserve;
 using Equinor.Procosys.Preservation.Command.TagCommands.StartPreservation;
-using Equinor.Procosys.Preservation.Command.TagCommands.StopPreservation;
+using Equinor.Procosys.Preservation.Command.TagCommands.CompletePreservation;
 using Equinor.Procosys.Preservation.Domain;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Equinor.Procosys.Preservation.Query.GetTagActionDetails;
@@ -432,12 +432,12 @@ namespace Equinor.Procosys.Preservation.WebApi.Tests.Authorizations
         }
         #endregion
 
-        #region StopPreservationCommand
+        #region CompletePreservationCommand
         [TestMethod]
-        public async Task ValidateAsync_OnStopPreservationCommand_ShouldReturnTrue_WhenAccessToBothProjectAndContent()
+        public async Task ValidateAsync_OnCompletePreservationCommand_ShouldReturnTrue_WhenAccessToBothProjectAndContent()
         {
             // Arrange
-            var command = new StopPreservationCommand(new List<int> { TagIdWithAccessToProject });
+            var command = new CompletePreservationCommand(new List<int> { TagIdWithAccessToProject });
 
             // act
             var result = await _dut.ValidateAsync(command);
@@ -447,10 +447,10 @@ namespace Equinor.Procosys.Preservation.WebApi.Tests.Authorizations
         }
 
         [TestMethod]
-        public async Task ValidateAsync_OnStopPreservationCommand_ShouldReturnFalse_WhenNoAccessToProject()
+        public async Task ValidateAsync_OnCompletePreservationCommand_ShouldReturnFalse_WhenNoAccessToProject()
         {
             // Arrange
-            var command = new StopPreservationCommand(new List<int> { TagIdWithoutAccessToProject });
+            var command = new CompletePreservationCommand(new List<int> { TagIdWithoutAccessToProject });
 
             // act
             var result = await _dut.ValidateAsync(command);
@@ -460,11 +460,11 @@ namespace Equinor.Procosys.Preservation.WebApi.Tests.Authorizations
         }
 
         [TestMethod]
-        public async Task ValidateAsync_OnStopPreservationCommand_ShouldReturnFalse_WhenNoAccessToContent()
+        public async Task ValidateAsync_OnCompletePreservationCommand_ShouldReturnFalse_WhenNoAccessToContent()
         {
             // Arrange
             _contentRestrictionsCheckerMock.Setup(c => c.HasCurrentUserExplicitNoRestrictions()).Returns(false);
-            var command = new StopPreservationCommand(new List<int> { TagIdWithAccessToProject });
+            var command = new CompletePreservationCommand(new List<int> { TagIdWithAccessToProject });
             
             // act
             var result = await _dut.ValidateAsync(command);
@@ -474,12 +474,12 @@ namespace Equinor.Procosys.Preservation.WebApi.Tests.Authorizations
         }
 
         [TestMethod]
-        public async Task ValidateAsync_OnStopPreservationCommand_ShouldReturnTrue_WhenExplicitAccessToContent()
+        public async Task ValidateAsync_OnCompletePreservationCommand_ShouldReturnTrue_WhenExplicitAccessToContent()
         {
             // Arrange
             _contentRestrictionsCheckerMock.Setup(c => c.HasCurrentUserExplicitNoRestrictions()).Returns(false);
             _contentRestrictionsCheckerMock.Setup(c => c.HasCurrentUserExplicitAccessToContent(RestrictedToContent)).Returns(true);
-            var command = new StopPreservationCommand(new List<int> { TagIdWithAccessToProject });
+            var command = new CompletePreservationCommand(new List<int> { TagIdWithAccessToProject });
             
             // act
             var result = await _dut.ValidateAsync(command);


### PR DESCRIPTION
Since domain logic say that we Complete the preservation rather than Stop, we rename stuff in code to reflect just this

Removed the enum PreservationPeriodStatus.Stopped (Do not need)
This caused a minor migration.