### PR TITLE
70814 Cascade delete mode

### DIFF
--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/ProjectConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/ProjectConfiguration.cs
@@ -25,7 +25,8 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
             builder
                 .HasMany(x => x.Tags)
                 .WithOne()
-                .IsRequired();
+                .IsRequired()
+                .OnDelete(DeleteBehavior.NoAction);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/RequirementTypeConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/RequirementTypeConfiguration.cs
@@ -25,7 +25,8 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
             builder
                 .HasMany(x => x.RequirementDefinitions)
                 .WithOne()
-                .IsRequired();
+                .IsRequired()
+                .OnDelete(DeleteBehavior.NoAction);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/StepConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/StepConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿using Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.ModeAggregate;
-using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.ResponsibleAggregate;
 using Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations.Extensions;
 using Microsoft.EntityFrameworkCore;
@@ -19,7 +18,6 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
 
             builder.HasOne<Mode>();
             builder.HasOne<Responsible>();
-            builder.HasMany<Tag>();
 
             builder.Property(x => x.Title)
                 .HasMaxLength(Step.TitleLengthMax)

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/StepConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/StepConfiguration.cs
@@ -16,8 +16,13 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
             builder.ConfigureModificationAudit();
             builder.ConfigureConcurrencyToken();
 
-            builder.HasOne<Mode>();
-            builder.HasOne<Responsible>();
+            builder.HasOne<Mode>()
+                .WithMany()
+                .OnDelete(DeleteBehavior.NoAction);
+            
+            builder.HasOne<Responsible>()
+                .WithMany()
+                .OnDelete(DeleteBehavior.NoAction);
 
             builder.Property(x => x.Title)
                 .HasMaxLength(Step.TitleLengthMax)

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/TagConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/TagConfiguration.cs
@@ -59,7 +59,8 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
             builder
                 .HasMany(x => x.Actions)
                 .WithOne()
-                .IsRequired();
+                .IsRequired()
+                .OnDelete(DeleteBehavior.NoAction);
 
             builder
                 .HasMany(x => x.Attachments)

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/TagConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/TagConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations.Extensions;
 using Microsoft.EntityFrameworkCore;
@@ -44,6 +45,11 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
 
             builder.Property(x => x.DisciplineDescription)
                 .HasMaxLength(Tag.DisciplineDescriptionLengthMax);
+
+            builder.HasOne<Step>()
+                .WithMany()
+                .IsRequired()
+                .OnDelete(DeleteBehavior.NoAction);
 
             builder
                 .HasMany(x => x.Requirements)

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/TagFunctionRequirementConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/TagFunctionRequirementConfiguration.cs
@@ -15,7 +15,9 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
             builder.ConfigureModificationAudit();
             builder.ConfigureConcurrencyToken();
 
-            builder.HasOne<RequirementDefinition>();
+            builder.HasOne<RequirementDefinition>()
+                .WithMany()
+                .OnDelete(DeleteBehavior.NoAction);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/TagRequirementConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/TagRequirementConfiguration.cs
@@ -20,12 +20,15 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
             builder.Property(x => x.NextDueTimeUtc)
                 .HasConversion(PreservationContext.NullableDateTimeKindConverter);
 
-            builder.HasOne<RequirementDefinition>();
+            builder.HasOne<RequirementDefinition>()
+                .WithMany()
+                .OnDelete(DeleteBehavior.NoAction);
 
             builder
                 .HasMany(x => x.PreservationPeriods)
                 .WithOne()
-                .IsRequired();
+                .IsRequired()
+                .OnDelete(DeleteBehavior.NoAction);
 
             builder.Property(InitialPreservationPeriodStatusPropertyName)
                 .HasMaxLength(TagRequirement.InitialPreservationPeriodStatusMax)

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200504125235_MovedStepConfigToTag.Designer.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200504125235_MovedStepConfigToTag.Designer.cs
@@ -4,14 +4,16 @@ using Equinor.Procosys.Preservation.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Equinor.Procosys.Preservation.Infrastructure.Migrations
 {
     [DbContext(typeof(PreservationContext))]
-    partial class PreservationContextModelSnapshot : ModelSnapshot
+    [Migration("20200504125235_MovedStepConfigToTag")]
+    partial class MovedStepConfigToTag
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200504125235_MovedStepConfigToTag.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200504125235_MovedStepConfigToTag.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Equinor.Procosys.Preservation.Infrastructure.Migrations
+{
+    public partial class MovedStepConfigToTag : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Tags_Steps_StepId",
+                table: "Tags");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Tags_Steps_StepId",
+                table: "Tags",
+                column: "StepId",
+                principalTable: "Steps",
+                principalColumn: "Id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Tags_Steps_StepId",
+                table: "Tags");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Tags_Steps_StepId",
+                table: "Tags",
+                column: "StepId",
+                principalTable: "Steps",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200504132707_ChangedSomeDeleteBehaviorCascadeToNoAction.Designer.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200504132707_ChangedSomeDeleteBehaviorCascadeToNoAction.Designer.cs
@@ -4,14 +4,16 @@ using Equinor.Procosys.Preservation.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Equinor.Procosys.Preservation.Infrastructure.Migrations
 {
     [DbContext(typeof(PreservationContext))]
-    partial class PreservationContextModelSnapshot : ModelSnapshot
+    [Migration("20200504132707_ChangedSomeDeleteBehaviorCascadeToNoAction")]
+    partial class ChangedSomeDeleteBehaviorCascadeToNoAction
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200504132707_ChangedSomeDeleteBehaviorCascadeToNoAction.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200504132707_ChangedSomeDeleteBehaviorCascadeToNoAction.cs
@@ -1,0 +1,197 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Equinor.Procosys.Preservation.Infrastructure.Migrations
+{
+    public partial class ChangedSomeDeleteBehaviorCascadeToNoAction : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Actions_Tags_TagId",
+                table: "Actions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_PreservationPeriods_TagRequirements_TagRequirementId",
+                table: "PreservationPeriods");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_RequirementDefinitions_RequirementTypes_RequirementTypeId",
+                table: "RequirementDefinitions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Steps_Modes_ModeId",
+                table: "Steps");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Steps_Responsibles_ResponsibleId",
+                table: "Steps");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_TagFunctionRequirements_RequirementDefinitions_RequirementDefinitionId",
+                table: "TagFunctionRequirements");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_TagRequirements_RequirementDefinitions_RequirementDefinitionId",
+                table: "TagRequirements");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Tags_Projects_ProjectId",
+                table: "Tags");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Actions_Tags_TagId",
+                table: "Actions",
+                column: "TagId",
+                principalTable: "Tags",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PreservationPeriods_TagRequirements_TagRequirementId",
+                table: "PreservationPeriods",
+                column: "TagRequirementId",
+                principalTable: "TagRequirements",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_RequirementDefinitions_RequirementTypes_RequirementTypeId",
+                table: "RequirementDefinitions",
+                column: "RequirementTypeId",
+                principalTable: "RequirementTypes",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Steps_Modes_ModeId",
+                table: "Steps",
+                column: "ModeId",
+                principalTable: "Modes",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Steps_Responsibles_ResponsibleId",
+                table: "Steps",
+                column: "ResponsibleId",
+                principalTable: "Responsibles",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_TagFunctionRequirements_RequirementDefinitions_RequirementDefinitionId",
+                table: "TagFunctionRequirements",
+                column: "RequirementDefinitionId",
+                principalTable: "RequirementDefinitions",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_TagRequirements_RequirementDefinitions_RequirementDefinitionId",
+                table: "TagRequirements",
+                column: "RequirementDefinitionId",
+                principalTable: "RequirementDefinitions",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Tags_Projects_ProjectId",
+                table: "Tags",
+                column: "ProjectId",
+                principalTable: "Projects",
+                principalColumn: "Id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Actions_Tags_TagId",
+                table: "Actions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_PreservationPeriods_TagRequirements_TagRequirementId",
+                table: "PreservationPeriods");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_RequirementDefinitions_RequirementTypes_RequirementTypeId",
+                table: "RequirementDefinitions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Steps_Modes_ModeId",
+                table: "Steps");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Steps_Responsibles_ResponsibleId",
+                table: "Steps");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_TagFunctionRequirements_RequirementDefinitions_RequirementDefinitionId",
+                table: "TagFunctionRequirements");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_TagRequirements_RequirementDefinitions_RequirementDefinitionId",
+                table: "TagRequirements");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Tags_Projects_ProjectId",
+                table: "Tags");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Actions_Tags_TagId",
+                table: "Actions",
+                column: "TagId",
+                principalTable: "Tags",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PreservationPeriods_TagRequirements_TagRequirementId",
+                table: "PreservationPeriods",
+                column: "TagRequirementId",
+                principalTable: "TagRequirements",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_RequirementDefinitions_RequirementTypes_RequirementTypeId",
+                table: "RequirementDefinitions",
+                column: "RequirementTypeId",
+                principalTable: "RequirementTypes",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Steps_Modes_ModeId",
+                table: "Steps",
+                column: "ModeId",
+                principalTable: "Modes",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Steps_Responsibles_ResponsibleId",
+                table: "Steps",
+                column: "ResponsibleId",
+                principalTable: "Responsibles",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_TagFunctionRequirements_RequirementDefinitions_RequirementDefinitionId",
+                table: "TagFunctionRequirements",
+                column: "RequirementDefinitionId",
+                principalTable: "RequirementDefinitions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_TagRequirements_RequirementDefinitions_RequirementDefinitionId",
+                table: "TagRequirements",
+                column: "RequirementDefinitionId",
+                principalTable: "RequirementDefinitions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Tags_Projects_ProjectId",
+                table: "Tags",
+                column: "ProjectId",
+                principalTable: "Projects",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}


### PR DESCRIPTION
Changed some .OnDelete(DeleteBehavior.Cascade) which has been made as default configuration to explicit .OnDelete(DeleteBehavior.NoAction).

We will pragmatically implement delete if needed. This to prevent accidental cascade deletes in database


Also "moved" builder.HasMany<Tag>(); from StepConfiguration to builder.HasOne<Step>() in TagConfiguration. (Generated code inside snapshot not changed due to this particular change)