### PR TITLE
73431 first put endpoints for oc

### DIFF
--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UpdateJourney/UpdateJourneyCommand.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UpdateJourney/UpdateJourneyCommand.cs
@@ -5,7 +5,7 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.UpdateJourney
 {
     public class UpdateJourneyCommand : IRequest<Result<Unit>>
     {
-        public UpdateJourneyCommand(int journeyId, string title, ulong rowVersion)
+        public UpdateJourneyCommand(int journeyId, string title, string rowVersion)
         {
             JourneyId = journeyId;
             Title = title;
@@ -13,6 +13,6 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.UpdateJourney
         }
         public int JourneyId { get; }
         public string Title { get; }
-        public ulong RowVersion { get; }
+        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UpdateJourney/UpdateJourneyCommand.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UpdateJourney/UpdateJourneyCommand.cs
@@ -5,12 +5,14 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.UpdateJourney
 {
     public class UpdateJourneyCommand : IRequest<Result<Unit>>
     {
-        public UpdateJourneyCommand(int journeyId, string title)
+        public UpdateJourneyCommand(int journeyId, string title, ulong rowVersion)
         {
             JourneyId = journeyId;
             Title = title;
+            RowVersion = rowVersion;
         }
-        public int JourneyId { get; set;}
-        public string Title { get; set; }
+        public int JourneyId { get; }
+        public string Title { get; }
+        public ulong RowVersion { get; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UpdateJourney/UpdateJourneyCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UpdateJourney/UpdateJourneyCommandHandler.cs
@@ -23,6 +23,7 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.UpdateJourney
             var journey = await _journeyRepository.GetByIdAsync(request.JourneyId);
 
             journey.Title = request.Title;
+            journey.SetRowVersion(request.RowVersion);
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             return new SuccessResult<Unit>(Unit.Value);

--- a/src/Equinor.Procosys.Preservation.Command/ModeCommands/UpdateMode/UpdateModeCommand.cs
+++ b/src/Equinor.Procosys.Preservation.Command/ModeCommands/UpdateMode/UpdateModeCommand.cs
@@ -5,7 +5,7 @@ namespace Equinor.Procosys.Preservation.Command.ModeCommands.UpdateMode
 {
     public class UpdateModeCommand : IRequest<Result<Unit>>
     {
-        public UpdateModeCommand(int modeId, string title, ulong rowVersion)
+        public UpdateModeCommand(int modeId, string title, string rowVersion)
         {
             ModeId = modeId;
             Title = title;
@@ -13,6 +13,6 @@ namespace Equinor.Procosys.Preservation.Command.ModeCommands.UpdateMode
         }
         public int ModeId { get; }
         public string Title { get; }
-        public ulong RowVersion { get; }
+        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/ModeCommands/UpdateMode/UpdateModeCommand.cs
+++ b/src/Equinor.Procosys.Preservation.Command/ModeCommands/UpdateMode/UpdateModeCommand.cs
@@ -5,12 +5,14 @@ namespace Equinor.Procosys.Preservation.Command.ModeCommands.UpdateMode
 {
     public class UpdateModeCommand : IRequest<Result<Unit>>
     {
-        public UpdateModeCommand(int modeId, string title)
+        public UpdateModeCommand(int modeId, string title, ulong rowVersion)
         {
             ModeId = modeId;
             Title = title;
+            RowVersion = rowVersion;
         }
-        public int ModeId { get; set; }
-        public string Title { get; set; }
+        public int ModeId { get; }
+        public string Title { get; }
+        public ulong RowVersion { get; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/ModeCommands/UpdateMode/UpdateModeCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/ModeCommands/UpdateMode/UpdateModeCommandHandler.cs
@@ -23,6 +23,7 @@ namespace Equinor.Procosys.Preservation.Command.ModeCommands.UpdateMode
             var mode = await _modeRepository.GetByIdAsync(request.ModeId);
 
             mode.Title = request.Title;
+            mode.SetRowVersion(request.RowVersion);
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             return new SuccessResult<Unit>(Unit.Value);

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTag/UpdateTagCommand.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTag/UpdateTagCommand.cs
@@ -8,15 +8,18 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.UpdateTag
         public UpdateTagCommand(
             int tagId,
             string remark,
-            string storageArea)
+            string storageArea,
+            ulong rowVersion)
         {
             TagId = tagId;
             Remark = remark;
             StorageArea = storageArea;
+            RowVersion = rowVersion;
         }
 
         public int TagId { get; }
         public string Remark { get; }
         public string StorageArea { get; }
+        public ulong RowVersion { get; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTag/UpdateTagCommand.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTag/UpdateTagCommand.cs
@@ -9,7 +9,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.UpdateTag
             int tagId,
             string remark,
             string storageArea,
-            ulong rowVersion)
+            string rowVersion)
         {
             TagId = tagId;
             Remark = remark;
@@ -20,6 +20,6 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.UpdateTag
         public int TagId { get; }
         public string Remark { get; }
         public string StorageArea { get; }
-        public ulong RowVersion { get; }
+        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTag/UpdateTagCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTag/UpdateTagCommandHandler.cs
@@ -25,6 +25,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.UpdateTag
 
             tag.StorageArea = request.StorageArea;
             tag.Remark = request.Remark;
+            tag.SetRowVersion(request.RowVersion);
 
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/src/Equinor.Procosys.Preservation.Domain/ByteArrayExtentions.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/ByteArrayExtentions.cs
@@ -4,6 +4,6 @@ namespace Equinor.Procosys.Preservation.Domain
 {
     public static class ByteArrayExtensions
     {
-        public static ulong ToULong(this byte[] bytes) => (ulong)BitConverter.ToInt64(bytes);
+        public static string ConvertToString(this byte[] bytes) => Convert.ToBase64String(bytes);
     }
 }

--- a/src/Equinor.Procosys.Preservation.Domain/EntityBase.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/EntityBase.cs
@@ -23,7 +23,7 @@ namespace Equinor.Procosys.Preservation.Domain
             _domainEvents.Add(eventItem);
         }
 
-        public void SetRowVersion(string value)
+        public virtual void SetRowVersion(string value)
         {
             var newRowVersion = Convert.FromBase64String(value);
             for (var index = 0; index < newRowVersion.Length; index++)

--- a/src/Equinor.Procosys.Preservation.Domain/EntityBase.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/EntityBase.cs
@@ -23,9 +23,9 @@ namespace Equinor.Procosys.Preservation.Domain
             _domainEvents.Add(eventItem);
         }
 
-        public void SetRowVersion(ulong value)
+        public void SetRowVersion(string value)
         {
-            var newRowVersion = BitConverter.GetBytes(value);
+            var newRowVersion = Convert.FromBase64String(value);
             for (var index = 0; index < newRowVersion.Length; index++)
             {
                 RowVersion[index] = newRowVersion[index];

--- a/src/Equinor.Procosys.Preservation.Query/GetTagActionDetails/ActionDetailsDto.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetTagActionDetails/ActionDetailsDto.cs
@@ -14,7 +14,7 @@ namespace Equinor.Procosys.Preservation.Query.GetTagActionDetails
             bool isClosed,
             PersonDto closedBy,
             DateTime? closedAtUtc,
-            ulong rowVersion)
+            string rowVersion)
         {
             Id = id;
             CreatedBy = createdBy;
@@ -38,6 +38,6 @@ namespace Equinor.Procosys.Preservation.Query.GetTagActionDetails
         public bool IsClosed { get; }
         public PersonDto ClosedBy { get; }
         public DateTime? ClosedAtUtc { get; }
-        public ulong RowVersion { get; }
+        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Query/GetTagActionDetails/GetActionDetailsQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetTagActionDetails/GetActionDetailsQueryHandler.cs
@@ -58,7 +58,7 @@ namespace Equinor.Procosys.Preservation.Query.GetTagActionDetails
                 dto.Action.IsClosed,
                 closedBy,
                 dto.Action.ClosedAtUtc,
-                dto.Action.RowVersion.ToULong());
+                dto.Action.RowVersion.ConvertToString());
             
             return new SuccessResult<ActionDetailsDto>(action);
         }

--- a/src/Equinor.Procosys.Preservation.Query/GetTagActions/ActionDto.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetTagActions/ActionDto.cs
@@ -9,7 +9,7 @@ namespace Equinor.Procosys.Preservation.Query.GetTagActions
             string title,
             DateTime? dueTimeUtc,
             bool isClosed,
-            ulong rowVersion)
+            string rowVersion)
         {
             Id = id;
             Title = title;
@@ -22,6 +22,6 @@ namespace Equinor.Procosys.Preservation.Query.GetTagActions
         public string Title { get; }
         public DateTime? DueTimeUtc { get; }
         public bool IsClosed { get; }
-        public ulong RowVersion { get; }
+        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Query/GetTagActions/GetTagActionsQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetTagActions/GetTagActionsQueryHandler.cs
@@ -38,7 +38,7 @@ namespace Equinor.Procosys.Preservation.Query.GetTagActions
                     action.Title,
                     action.DueTimeUtc,
                     action.IsClosed,
-                    action.RowVersion.ToULong())).ToList();
+                    action.RowVersion.ConvertToString())).ToList();
             return new SuccessResult<List<ActionDto>>(actions);
         }
     }

--- a/src/Equinor.Procosys.Preservation.Query/GetTagDetails/GetTagDetailsQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetTagDetails/GetTagDetailsQueryHandler.cs
@@ -45,7 +45,7 @@ namespace Equinor.Procosys.Preservation.Query.GetTagDetails
                                         TagNo = tag.TagNo,
                                         TagType = tag.TagType,
                                         ReadyToBePreserved = tag.IsReadyToBePreserved(),
-                                        RowVersion = tag.RowVersion.ToULong()
+                                        RowVersion = tag.RowVersion.ConvertToString()
                                     }).SingleOrDefaultAsync(cancellationToken);
 
             if (tagDetails == null)

--- a/src/Equinor.Procosys.Preservation.Query/GetTagDetails/TagDetailsDto.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetTagDetails/TagDetailsDto.cs
@@ -19,6 +19,6 @@ namespace Equinor.Procosys.Preservation.Query.GetTagDetails
         public bool ReadyToBePreserved { get; set; }
         public string Remark { get; set; }
         public string StorageArea { get; set; }
-        public ulong RowVersion { get; set; }
+        public string RowVersion { get; set; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Query/GetTagFunctionDetails/GetTagFunctionDetailsQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetTagFunctionDetails/GetTagFunctionDetailsQueryHandler.cs
@@ -27,7 +27,7 @@ namespace Equinor.Procosys.Preservation.Query.GetTagFunctionDetails
                         tagFunction.RegisterCode,
                         tagFunction.IsVoided,
                         tagFunction.Requirements.Select(s => new RequirementDto(s.Id, s.RequirementDefinitionId)),
-                        tagFunction.RowVersion.ToULong()))
+                        tagFunction.RowVersion.ConvertToString()))
                 .SingleOrDefaultAsync(cancellationToken);
             
             if (tagFunctionDto == null)

--- a/src/Equinor.Procosys.Preservation.Query/GetTagFunctionDetails/TagFunctionDetailsDto.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetTagFunctionDetails/TagFunctionDetailsDto.cs
@@ -11,7 +11,7 @@ namespace Equinor.Procosys.Preservation.Query.GetTagFunctionDetails
             string registerCode,
             bool isVoided,
             IEnumerable<RequirementDto> requirements,
-            ulong rowVersion)
+            string rowVersion)
         {
             Id = id;
             Code = code;
@@ -28,6 +28,6 @@ namespace Equinor.Procosys.Preservation.Query.GetTagFunctionDetails
         public string RegisterCode { get; }
         public bool IsVoided { get; }
         public IEnumerable<RequirementDto> Requirements { get; }
-        public ulong RowVersion { get; }
+        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Query/GetTagRequirements/GetTagRequirementsQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetTagRequirements/GetTagRequirementsQueryHandler.cs
@@ -79,7 +79,7 @@ namespace Equinor.Procosys.Preservation.Query.GetTagRequirements
                         requirement.ReadyToBePreserved,
                         fields,
                         requirement.GetCurrentComment(),
-                        requirement.RowVersion.ToULong());
+                        requirement.RowVersion.ConvertToString());
                 }).ToList();
             
             return new SuccessResult<List<RequirementDto>>(requirements);

--- a/src/Equinor.Procosys.Preservation.Query/GetTagRequirements/RequirementDto.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetTagRequirements/RequirementDto.cs
@@ -17,7 +17,7 @@ namespace Equinor.Procosys.Preservation.Query.GetTagRequirements
             bool readyToBePreserved,
             List<FieldDto> fields,
             string comment,
-            ulong rowVersion)
+            string rowVersion)
         {
             Id = id;
             NextDueTimeUtc = nextDueTimeUtc;
@@ -47,6 +47,6 @@ namespace Equinor.Procosys.Preservation.Query.GetTagRequirements
         public bool ReadyToBePreserved { get; }
         public List<FieldDto> Fields { get; }
         public string Comment { get; }
-        public ulong RowVersion { get; }
+        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Query/GetTags/GetTagsQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetTags/GetTagsQueryHandler.cs
@@ -167,7 +167,7 @@ namespace Equinor.Procosys.Preservation.Query.GetTags
                     dto.Description,
                     dto.TagNo,
                     dto.TagType,
-                    dto.RowVersion.ToULong());
+                    dto.RowVersion.ConvertToString());
             });
             var result = new TagsResult(maxAvailable, tags);
             return result;

--- a/src/Equinor.Procosys.Preservation.Query/GetTags/TagDto.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetTags/TagDto.cs
@@ -31,7 +31,7 @@ namespace Equinor.Procosys.Preservation.Query.GetTags
             string tagDescription,
             string tagNo,
             TagType tagType,
-            ulong rowVersion)
+            string rowVersion)
         {
             Id = id;
             ActionStatus = actionStatus;
@@ -84,6 +84,6 @@ namespace Equinor.Procosys.Preservation.Query.GetTags
         public string TagFunctionCode { get; }
         public string TagNo { get; }
         public TagType TagType { get; }
-        public ulong RowVersion { get; }
+        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Query/JourneyAggregate/GetAllJourneysQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/JourneyAggregate/GetAllJourneysQueryHandler.cs
@@ -48,16 +48,16 @@ namespace Equinor.Procosys.Preservation.Query.JourneyAggregate
                             {
                                 var modeDto = modes
                                     .Where(m => m.Id == s.ModeId)
-                                    .Select(m => new ModeDto(m.Id, m.Title, m.RowVersion.ToULong()))
+                                    .Select(m => new ModeDto(m.Id, m.Title, m.RowVersion.ConvertToString()))
                                     .Single();
                                 var responsibleDto = responsibles
                                     .Where(r => r.Id == s.ResponsibleId)
                                     .Select(r => new ResponsibleDto(r.Id, r.Code, r.Title,
-                                        r.RowVersion.ToULong()))
+                                        r.RowVersion.ConvertToString()))
                                     .Single();
                                 return new StepDto(s.Id, s.Title, s.IsVoided, modeDto, responsibleDto);
                             }),
-                        j.RowVersion.ToULong()));
+                        j.RowVersion.ConvertToString()));
 
             return new SuccessResult<IEnumerable<JourneyDto>>(journeyDtos);
         }

--- a/src/Equinor.Procosys.Preservation.Query/JourneyAggregate/GetJourneyByIdQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/JourneyAggregate/GetJourneyByIdQueryHandler.cs
@@ -34,11 +34,11 @@ namespace Equinor.Procosys.Preservation.Query.JourneyAggregate
 
             var modes = await (from m in _context.QuerySet<Mode>()
                     where modeIds.Contains(m.Id)
-                    select new ModeDto(m.Id, m.Title, m.RowVersion.ToULong()))
+                    select new ModeDto(m.Id, m.Title, m.RowVersion.ConvertToString()))
                 .ToListAsync(cancellationToken);
             var responsibles = await (from r in _context.QuerySet<Responsible>()
                     where responsibleIds.Contains(r.Id)
-                    select new ResponsibleDto(r.Id, r.Code, r.Title, r.RowVersion.ToULong()))
+                    select new ResponsibleDto(r.Id, r.Code, r.Title, r.RowVersion.ConvertToString()))
                 .ToListAsync(cancellationToken);
 
             var journeyDto = new JourneyDto(
@@ -54,7 +54,7 @@ namespace Equinor.Procosys.Preservation.Query.JourneyAggregate
                         responsibles.FirstOrDefault(x => x.Id == step.ResponsibleId)
                     )
                 ),
-                journey.RowVersion.ToULong());
+                journey.RowVersion.ConvertToString());
             return new SuccessResult<JourneyDto>(journeyDto);
         }
     }

--- a/src/Equinor.Procosys.Preservation.Query/JourneyAggregate/JourneyDto.cs
+++ b/src/Equinor.Procosys.Preservation.Query/JourneyAggregate/JourneyDto.cs
@@ -4,7 +4,7 @@ namespace Equinor.Procosys.Preservation.Query.JourneyAggregate
 {
     public class JourneyDto
     {
-        public JourneyDto(int id, string title, bool isVoided, IEnumerable<StepDto> steps, ulong rowVersion)
+        public JourneyDto(int id, string title, bool isVoided, IEnumerable<StepDto> steps, string rowVersion)
         {
             Id = id;
             Title = title;
@@ -17,6 +17,6 @@ namespace Equinor.Procosys.Preservation.Query.JourneyAggregate
         public string Title { get; }
         public bool IsVoided { get; }
         public IEnumerable<StepDto> Steps { get; }
-        public ulong RowVersion { get; }
+        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Query/ModeAggregate/GetAllModesQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/ModeAggregate/GetAllModesQueryHandler.cs
@@ -20,7 +20,7 @@ namespace Equinor.Procosys.Preservation.Query.ModeAggregate
         {
             var modes = await (from m in _context.QuerySet<Mode>()
                 select m).ToListAsync(cancellationToken);
-            return new SuccessResult<IEnumerable<ModeDto>>(modes.Select(mode => new ModeDto(mode.Id, mode.Title, mode.RowVersion.ToULong())));
+            return new SuccessResult<IEnumerable<ModeDto>>(modes.Select(mode => new ModeDto(mode.Id, mode.Title, mode.RowVersion.ConvertToString())));
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Query/ModeAggregate/GetModeByIdQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/ModeAggregate/GetModeByIdQueryHandler.cs
@@ -26,7 +26,7 @@ namespace Equinor.Procosys.Preservation.Query.ModeAggregate
                 return new NotFoundResult<ModeDto>(Strings.EntityNotFound(nameof(Mode), request.Id));
             }
 
-            return new SuccessResult<ModeDto>(new ModeDto(mode.Id, mode.Title, mode.RowVersion.ToULong()));
+            return new SuccessResult<ModeDto>(new ModeDto(mode.Id, mode.Title, mode.RowVersion.ConvertToString()));
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Query/ModeAggregate/ModeDto.cs
+++ b/src/Equinor.Procosys.Preservation.Query/ModeAggregate/ModeDto.cs
@@ -2,7 +2,7 @@
 {
     public class ModeDto
     {
-        public ModeDto(int id, string title, ulong rowVersion)
+        public ModeDto(int id, string title, string rowVersion)
         {
             Id = id;
             Title = title;
@@ -11,6 +11,6 @@
 
         public int Id { get; }
         public string Title { get; }
-        public ulong RowVersion { get; }
+        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Query/RequirementTypeAggregate/GetAllRequirementTypesQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/RequirementTypeAggregate/GetAllRequirementTypesQueryHandler.cs
@@ -45,7 +45,7 @@ namespace Equinor.Procosys.Preservation.Query.RequirementTypeAggregate
                                         f.SortKey,
                                         f.Unit,
                                         f.ShowPrevious)))),
-                        rt.RowVersion.ToULong()))
+                        rt.RowVersion.ConvertToString()))
                     .OrderBy(rt => rt.SortKey);
 
             return new SuccessResult<IEnumerable<RequirementTypeDto>>(dtos);

--- a/src/Equinor.Procosys.Preservation.Query/RequirementTypeAggregate/GetRequirementTypeByIdQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/RequirementTypeAggregate/GetRequirementTypeByIdQueryHandler.cs
@@ -49,7 +49,7 @@ namespace Equinor.Procosys.Preservation.Query.RequirementTypeAggregate
                             f.SortKey,
                             f.Unit,
                             f.ShowPrevious)))),
-                reqType.RowVersion.ToULong());
+                reqType.RowVersion.ConvertToString());
 
             return new SuccessResult<RequirementTypeDto>(dto);
         }

--- a/src/Equinor.Procosys.Preservation.Query/RequirementTypeAggregate/RequirementTypeDto.cs
+++ b/src/Equinor.Procosys.Preservation.Query/RequirementTypeAggregate/RequirementTypeDto.cs
@@ -13,7 +13,7 @@ namespace Equinor.Procosys.Preservation.Query.RequirementTypeAggregate
             bool isVoided,
             int sortKey,
             IEnumerable<RequirementDefinitionDto> requirementDefinitions,
-            ulong rowVersion)
+            string rowVersion)
         {
             if (requirementDefinitions == null)
             {
@@ -33,7 +33,7 @@ namespace Equinor.Procosys.Preservation.Query.RequirementTypeAggregate
         public string Title { get; }
         public bool IsVoided { get; }
         public int SortKey { get; }
-        public ulong RowVersion { get; }
+        public string RowVersion { get; }
         public IEnumerable<RequirementDefinitionDto> RequirementDefinitions { get; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Query/ResponsibleAggregate/GetAllResponsiblesQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/ResponsibleAggregate/GetAllResponsiblesQueryHandler.cs
@@ -25,7 +25,7 @@ namespace Equinor.Procosys.Preservation.Query.ResponsibleAggregate
                     responsible.Id,
                     responsible.Code,
                     responsible.Title,
-                    responsible.RowVersion.ToULong())));
+                    responsible.RowVersion.ConvertToString())));
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Query/ResponsibleAggregate/ResponsibleDto.cs
+++ b/src/Equinor.Procosys.Preservation.Query/ResponsibleAggregate/ResponsibleDto.cs
@@ -2,7 +2,7 @@
 {
     public class ResponsibleDto
     {
-        public ResponsibleDto(int id, string code, string title, ulong rowVersion)
+        public ResponsibleDto(int id, string code, string title, string rowVersion)
         {
             Id = id;
             Code = code;
@@ -13,6 +13,6 @@
         public int Id { get; }
         public string Code { get; }
         public string Title { get; }
-        public ulong RowVersion { get; }
+        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Journeys/JourneysController.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Journeys/JourneysController.cs
@@ -86,7 +86,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Journeys
             [FromRoute] int id,
             [FromBody] UpdateJourneyDto dto)
         {
-            var result = await _mediator.Send(new UpdateJourneyCommand(journeyId:id, dto.Title));
+            var result = await _mediator.Send(new UpdateJourneyCommand(id, dto.Title, dto.RowVersion));
             return this.FromResult(result);
         }
 
@@ -100,7 +100,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Journeys
             [FromRoute] int id,
             [FromBody] UpdateStepDto dto)
         {
-            var result = await _mediator.Send(new UpdateStepCommand(stepId:id, dto.Title));
+            var result = await _mediator.Send(new UpdateStepCommand(id, dto.Title));
             return this.FromResult(result);
         }
     }

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Journeys/UpdateJourneyDto.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Journeys/UpdateJourneyDto.cs
@@ -3,5 +3,6 @@
     public class UpdateJourneyDto
     {
        public string Title { get; set; }
+       public ulong RowVersion { get; set; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Journeys/UpdateJourneyDto.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Journeys/UpdateJourneyDto.cs
@@ -3,6 +3,6 @@
     public class UpdateJourneyDto
     {
        public string Title { get; set; }
-       public ulong RowVersion { get; set; }
+       public string RowVersion { get; set; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Journeys/UpdateJourneyDtoValidator.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Journeys/UpdateJourneyDtoValidator.cs
@@ -5,8 +5,8 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Journeys
 {
     public class UpdateJourneyDtoValidator : AbstractValidator<UpdateJourneyDto>
     {
-        public UpdateJourneyDtoValidator() =>
-            RuleFor(x => x.Title)
+        public UpdateJourneyDtoValidator()
+            => RuleFor(x => x.Title)
                 .NotNull()
                 .MinimumLength(Journey.TitleLengthMin)
                 .MaximumLength(Journey.TitleLengthMax);

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Journeys/UpdateJourneyDtoValidator.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Journeys/UpdateJourneyDtoValidator.cs
@@ -5,14 +5,10 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Journeys
 {
     public class UpdateJourneyDtoValidator : AbstractValidator<UpdateJourneyDto>
     {
-        public UpdateJourneyDtoValidator()
-        {
-            RuleFor(x => x.RowVersion).NotNull();
-
+        public UpdateJourneyDtoValidator() =>
             RuleFor(x => x.Title)
                 .NotNull()
                 .MinimumLength(Journey.TitleLengthMin)
                 .MaximumLength(Journey.TitleLengthMax);
-        }
     }
 }

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Journeys/UpdateJourneyDtoValidator.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Journeys/UpdateJourneyDtoValidator.cs
@@ -6,9 +6,13 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Journeys
     public class UpdateJourneyDtoValidator : AbstractValidator<UpdateJourneyDto>
     {
         public UpdateJourneyDtoValidator()
-            => RuleFor(x => x.Title)
+        {
+            RuleFor(x => x.RowVersion).NotNull();
+
+            RuleFor(x => x.Title)
                 .NotNull()
                 .MinimumLength(Journey.TitleLengthMin)
                 .MaximumLength(Journey.TitleLengthMax);
+        }
     }
 }

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Modes/ModesController.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Modes/ModesController.cs
@@ -82,7 +82,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Modes
             [FromRoute] int id,
             [FromBody] UpdateModeDto dto)
         {
-            var result = await _mediator.Send(new UpdateModeCommand(id, dto.Title));
+            var result = await _mediator.Send(new UpdateModeCommand(id, dto.Title, dto.RowVersion));
             return this.FromResult(result);
         }
     }

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Modes/UpdateModeDto.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Modes/UpdateModeDto.cs
@@ -3,6 +3,6 @@
     public class UpdateModeDto
     {
         public string Title { get; set; }
-        public ulong RowVersion { get; set; }
+        public string RowVersion { get; set; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Modes/UpdateModeDto.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Modes/UpdateModeDto.cs
@@ -3,5 +3,6 @@
     public class UpdateModeDto
     {
         public string Title { get; set; }
+        public ulong RowVersion { get; set; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Tags/TagsController.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Tags/TagsController.cs
@@ -174,7 +174,8 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Tags
             var result = await _mediator.Send(
                 new UpdateTagCommand(id,
                     dto.Remark,
-                    dto.StorageArea));
+                    dto.StorageArea,
+                    dto.RowVersion));
             return this.FromResult(result);
         }
 

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Tags/UpdateTagDto.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Tags/UpdateTagDto.cs
@@ -4,6 +4,6 @@
     {
         public string Remark { get; set; }
         public string StorageArea { get; set; }
-        public ulong RowVersion { get; set; }
+        public string RowVersion { get; set; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Tags/UpdateTagDto.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Tags/UpdateTagDto.cs
@@ -4,5 +4,6 @@
     {
         public string Remark { get; set; }
         public string StorageArea { get; set; }
+        public ulong RowVersion { get; set; }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandHandlerTests.cs
@@ -22,14 +22,14 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UpdateJour
         {
             // Arrange
             var testJourneyId = 1;
-            const ulong rowVersion = 12345;
+            const string RowVersion = "AAAAAAAAABA=";
             var journeyRepositoryMock = new Mock<IJourneyRepository>();
             _journeyMock = new Mock<Journey>(TestPlant, _oldTitle);
             _journeyMock.SetupGet(j => j.Plant).Returns(TestPlant);
             _journeyMock.SetupGet(j => j.Id).Returns(testJourneyId);
             journeyRepositoryMock.Setup(j => j.GetByIdAsync(testJourneyId))
                 .Returns(Task.FromResult(_journeyMock.Object));
-            _command = new UpdateJourneyCommand(testJourneyId, _newTitle, rowVersion);
+            _command = new UpdateJourneyCommand(testJourneyId, _newTitle, RowVersion);
 
             _dut = new UpdateJourneyCommandHandler(
                 journeyRepositoryMock.Object,

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandHandlerTests.cs
@@ -28,7 +28,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UpdateJour
             _journeyMock.SetupGet(j => j.Id).Returns(testJourneyId);
             journeyRepositoryMock.Setup(j => j.GetByIdAsync(testJourneyId))
                 .Returns(Task.FromResult(_journeyMock.Object));
-            _command = new UpdateJourneyCommand(testJourneyId, _newTitle);
+            _command = new UpdateJourneyCommand(testJourneyId, _newTitle, 123456);
 
             _dut = new UpdateJourneyCommandHandler(
                 journeyRepositoryMock.Object,

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandHandlerTests.cs
@@ -22,13 +22,14 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UpdateJour
         {
             // Arrange
             var testJourneyId = 1;
+            const ulong rowVersion = 12345;
             var journeyRepositoryMock = new Mock<IJourneyRepository>();
             _journeyMock = new Mock<Journey>(TestPlant, _oldTitle);
             _journeyMock.SetupGet(j => j.Plant).Returns(TestPlant);
             _journeyMock.SetupGet(j => j.Id).Returns(testJourneyId);
             journeyRepositoryMock.Setup(j => j.GetByIdAsync(testJourneyId))
                 .Returns(Task.FromResult(_journeyMock.Object));
-            _command = new UpdateJourneyCommand(testJourneyId, _newTitle, 123456);
+            _command = new UpdateJourneyCommand(testJourneyId, _newTitle, rowVersion);
 
             _dut = new UpdateJourneyCommandHandler(
                 journeyRepositoryMock.Object,

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandHandlerTests.cs
@@ -22,14 +22,13 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UpdateJour
         {
             // Arrange
             var testJourneyId = 1;
-            const string RowVersion = "AAAAAAAAABA=";
             var journeyRepositoryMock = new Mock<IJourneyRepository>();
             _journeyMock = new Mock<Journey>(TestPlant, _oldTitle);
             _journeyMock.SetupGet(j => j.Plant).Returns(TestPlant);
             _journeyMock.SetupGet(j => j.Id).Returns(testJourneyId);
             journeyRepositoryMock.Setup(j => j.GetByIdAsync(testJourneyId))
                 .Returns(Task.FromResult(_journeyMock.Object));
-            _command = new UpdateJourneyCommand(testJourneyId, _newTitle, RowVersion);
+            _command = new UpdateJourneyCommand(testJourneyId, _newTitle, null);
 
             _dut = new UpdateJourneyCommandHandler(
                 journeyRepositoryMock.Object,
@@ -59,6 +58,16 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UpdateJour
 
             // Assert
             UnitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task HandlingUpdateJourneyCommand_ShouldSetRowVersion()
+        {
+            // Act
+            await _dut.Handle(_command, default);
+
+            // Assert
+            _journeyMock.Verify(u => u.SetRowVersion(_command.RowVersion), Times.Once);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandTests.cs
@@ -12,6 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UpdateJour
             var dut = new UpdateJourneyCommand(1, "TitleA", "AAAAAAAAABA=");
             Assert.AreEqual(1, dut.JourneyId);
             Assert.AreEqual("TitleA", dut.Title);
+            Assert.AreEqual("AAAAAAAAABA=", dut.RowVersion);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandTests.cs
@@ -9,7 +9,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UpdateJour
         [TestMethod]
         public void Constructor_ShouldSetProperties()
         {
-            var dut = new UpdateJourneyCommand(1, "TitleA", 12345);
+            var dut = new UpdateJourneyCommand(1, "TitleA", "AAAAAAAAABA=");
             Assert.AreEqual(1, dut.JourneyId);
             Assert.AreEqual("TitleA", dut.Title);
         }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandTests.cs
@@ -9,7 +9,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UpdateJour
         [TestMethod]
         public void Constructor_ShouldSetProperties()
         {
-            var dut = new UpdateJourneyCommand(1, "TitleA");
+            var dut = new UpdateJourneyCommand(1, "TitleA", 12345);
             Assert.AreEqual(1, dut.JourneyId);
             Assert.AreEqual("TitleA", dut.Title);
         }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandValidatorTests.cs
@@ -21,7 +21,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UpdateJour
         {
             _journeyValidatorMock = new Mock<IJourneyValidator>();
             _journeyValidatorMock.Setup(r => r.ExistsAsync(_id, default)).Returns(Task.FromResult(true));
-            _command = new UpdateJourneyCommand(_id, _title);
+            _command = new UpdateJourneyCommand(_id, _title, 12345);
 
             _dut = new UpdateJourneyCommandValidator(_journeyValidatorMock.Object);
         }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandValidatorTests.cs
@@ -19,10 +19,10 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UpdateJour
         [TestInitialize]
         public void Setup_OkState()
         {
-            const ulong rowVersion = 12345;
+            const string RowVersion = "AAAAAAAAABA=";
             _journeyValidatorMock = new Mock<IJourneyValidator>();
             _journeyValidatorMock.Setup(r => r.ExistsAsync(_id, default)).Returns(Task.FromResult(true));
-            _command = new UpdateJourneyCommand(_id, _title, rowVersion);
+            _command = new UpdateJourneyCommand(_id, _title, RowVersion);
 
             _dut = new UpdateJourneyCommandValidator(_journeyValidatorMock.Object);
         }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandValidatorTests.cs
@@ -19,9 +19,10 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UpdateJour
         [TestInitialize]
         public void Setup_OkState()
         {
+            const ulong rowVersion = 12345;
             _journeyValidatorMock = new Mock<IJourneyValidator>();
             _journeyValidatorMock.Setup(r => r.ExistsAsync(_id, default)).Returns(Task.FromResult(true));
-            _command = new UpdateJourneyCommand(_id, _title, 12345);
+            _command = new UpdateJourneyCommand(_id, _title, rowVersion);
 
             _dut = new UpdateJourneyCommandValidator(_journeyValidatorMock.Object);
         }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandValidatorTests.cs
@@ -19,10 +19,9 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UpdateJour
         [TestInitialize]
         public void Setup_OkState()
         {
-            const string RowVersion = "AAAAAAAAABA=";
             _journeyValidatorMock = new Mock<IJourneyValidator>();
             _journeyValidatorMock.Setup(r => r.ExistsAsync(_id, default)).Returns(Task.FromResult(true));
-            _command = new UpdateJourneyCommand(_id, _title, RowVersion);
+            _command = new UpdateJourneyCommand(_id, _title, null);
 
             _dut = new UpdateJourneyCommandValidator(_journeyValidatorMock.Object);
         }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandHandlerTests.cs
@@ -22,7 +22,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.UpdateMode
         {
             // Arrange
             var testModeId = 1;
-            const ulong rowVersion = 12345;
+            const string rowVersion = "AAAAAAAAABA=";
             var modeRepositoryMock = new Mock<IModeRepository>();
             _modeMock = new Mock<Mode>(TestPlant, _oldTitle);
             _modeMock.SetupGet(m => m.Plant).Returns(TestPlant);

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandHandlerTests.cs
@@ -22,14 +22,13 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.UpdateMode
         {
             // Arrange
             var testModeId = 1;
-            const string rowVersion = "AAAAAAAAABA=";
             var modeRepositoryMock = new Mock<IModeRepository>();
             _modeMock = new Mock<Mode>(TestPlant, _oldTitle);
             _modeMock.SetupGet(m => m.Plant).Returns(TestPlant);
             _modeMock.SetupGet(m => m.Id).Returns(testModeId);
             modeRepositoryMock.Setup(m => m.GetByIdAsync(testModeId))
                 .Returns(Task.FromResult(_modeMock.Object));
-            _command = new UpdateModeCommand(testModeId, _newTitle, rowVersion);
+            _command = new UpdateModeCommand(testModeId, _newTitle, null);
 
             _dut = new UpdateModeCommandHandler(
                 modeRepositoryMock.Object,
@@ -59,6 +58,16 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.UpdateMode
 
             // Assert
             UnitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task HandlingUpdateModeCommand_ShouldSetRowVersion()
+        {
+            // Act
+            await _dut.Handle(_command, default);
+
+            // Assert
+            _modeMock.Verify(u => u.SetRowVersion(_command.RowVersion), Times.Once);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandHandlerTests.cs
@@ -22,13 +22,14 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.UpdateMode
         {
             // Arrange
             var testModeId = 1;
+            const ulong rowVersion = 12345;
             var modeRepositoryMock = new Mock<IModeRepository>();
             _modeMock = new Mock<Mode>(TestPlant, _oldTitle);
             _modeMock.SetupGet(m => m.Plant).Returns(TestPlant);
             _modeMock.SetupGet(m => m.Id).Returns(testModeId);
             modeRepositoryMock.Setup(m => m.GetByIdAsync(testModeId))
                 .Returns(Task.FromResult(_modeMock.Object));
-            _command = new UpdateModeCommand(testModeId, _newTitle);
+            _command = new UpdateModeCommand(testModeId, _newTitle, rowVersion);
 
             _dut = new UpdateModeCommandHandler(
                 modeRepositoryMock.Object,

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandTests.cs
@@ -9,7 +9,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.UpdateMode
         [TestMethod]
         public void Constructor_ShouldSetProperties()
         {
-            var dut = new UpdateModeCommand(1, "ModeTitle");
+            var dut = new UpdateModeCommand(1, "ModeTitle", 12345);
             Assert.AreEqual(1, dut.ModeId);
             Assert.AreEqual("ModeTitle", dut.Title);
         }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandTests.cs
@@ -12,6 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.UpdateMode
             var dut = new UpdateModeCommand(1, "ModeTitle", "AAAAAAAAABA=");
             Assert.AreEqual(1, dut.ModeId);
             Assert.AreEqual("ModeTitle", dut.Title);
+            Assert.AreEqual("AAAAAAAAABA=", dut.RowVersion);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandTests.cs
@@ -9,7 +9,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.UpdateMode
         [TestMethod]
         public void Constructor_ShouldSetProperties()
         {
-            var dut = new UpdateModeCommand(1, "ModeTitle", 12345);
+            var dut = new UpdateModeCommand(1, "ModeTitle", "AAAAAAAAABA=");
             Assert.AreEqual(1, dut.ModeId);
             Assert.AreEqual("ModeTitle", dut.Title);
         }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandValidatorTests.cs
@@ -19,11 +19,9 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.UpdateMode
         [TestInitialize]
         public void Setup_OkState()
         {
-            const string RowVersion = "AAAAAAAAABA=";
-
             _modeValidatorMock = new Mock<IModeValidator>();
             _modeValidatorMock.Setup(r => r.ExistsAsync(_id, default)).Returns(Task.FromResult(true));
-            _command = new UpdateModeCommand(_id, _title, RowVersion);
+            _command = new UpdateModeCommand(_id, _title, null);
 
             _dut = new UpdateModeCommandValidator(_modeValidatorMock.Object);
         }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandValidatorTests.cs
@@ -19,9 +19,11 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.UpdateMode
         [TestInitialize]
         public void Setup_OkState()
         {
+            const ulong RowVersion = 12345;
+
             _modeValidatorMock = new Mock<IModeValidator>();
             _modeValidatorMock.Setup(r => r.ExistsAsync(_id, default)).Returns(Task.FromResult(true));
-            _command = new UpdateModeCommand(_id, _title);
+            _command = new UpdateModeCommand(_id, _title, RowVersion);
 
             _dut = new UpdateModeCommandValidator(_modeValidatorMock.Object);
         }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandValidatorTests.cs
@@ -19,7 +19,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.UpdateMode
         [TestInitialize]
         public void Setup_OkState()
         {
-            const ulong RowVersion = 12345;
+            const string RowVersion = "AAAAAAAAABA=";
 
             _modeValidatorMock = new Mock<IModeValidator>();
             _modeValidatorMock.Setup(r => r.ExistsAsync(_id, default)).Returns(Task.FromResult(true));

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandHandlerTests.cs
@@ -79,11 +79,12 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTag
         public async Task HandlingUpdateTagCommand_ShouldSetRowVersion()
         {
             // Act
+            Assert.AreNotEqual(_command.RowVersion, _tag.RowVersion.ConvertToString());
             await _dut.Handle(_command, default);
 
             // Assert
             var updatedRowVersion = _tag.RowVersion.ConvertToString();
-            Assert.AreEqual(updatedRowVersion, _command.RowVersion);
+            Assert.AreEqual(_command.RowVersion, updatedRowVersion);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandHandlerTests.cs
@@ -50,7 +50,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTag
                 .Setup(r => r.GetTagByTagIdAsync(_tagId))
                 .Returns(Task.FromResult(_tag));
 
-            _command = new UpdateTagCommand(_tagId, _newRemark, _newStorageArea);
+            _command = new UpdateTagCommand(_tagId, _newRemark, _newStorageArea, 12345);
 
             _dut = new UpdateTagCommandHandler(
                 _projectRepositoryMock.Object,

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandHandlerTests.cs
@@ -50,7 +50,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTag
                 .Setup(r => r.GetTagByTagIdAsync(_tagId))
                 .Returns(Task.FromResult(_tag));
 
-            _command = new UpdateTagCommand(_tagId, _newRemark, _newStorageArea, 12345);
+            _command = new UpdateTagCommand(_tagId, _newRemark, _newStorageArea, "AAAAAAAAABA=");
 
             _dut = new UpdateTagCommandHandler(
                 _projectRepositoryMock.Object,

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.TagCommands.UpdateTag;
+using Equinor.Procosys.Preservation.Domain;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
@@ -46,6 +47,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTag
                 Remark = _oldRemark
             };
 
+            _tag.SetRowVersion("AAAAAAAAAAA=");
             _projectRepositoryMock
                 .Setup(r => r.GetTagByTagIdAsync(_tagId))
                 .Returns(Task.FromResult(_tag));
@@ -71,6 +73,17 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTag
         {
             await _dut.Handle(_command, default);
             UnitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task HandlingUpdateTagCommand_ShouldSetRowVersion()
+        {
+            // Act
+            await _dut.Handle(_command, default);
+
+            // Assert
+            var updatedRowVersion = _tag.RowVersion.ConvertToString();
+            Assert.AreEqual(updatedRowVersion, _command.RowVersion);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandTests.cs
@@ -9,7 +9,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTag
         [TestMethod]
         public void Constructor_ShouldSetProperties()
         {
-            var dut = new UpdateTagCommand(2, "Remark", "StorageArea");
+            var dut = new UpdateTagCommand(2, "Remark", "StorageArea", 12345);
 
             Assert.AreEqual(2, dut.TagId);
             Assert.AreEqual("Remark", dut.Remark);

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandTests.cs
@@ -9,7 +9,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTag
         [TestMethod]
         public void Constructor_ShouldSetProperties()
         {
-            var dut = new UpdateTagCommand(2, "Remark", "StorageArea", 12345);
+            var dut = new UpdateTagCommand(2, "Remark", "StorageArea", "AAAAAAAAABA=");
 
             Assert.AreEqual(2, dut.TagId);
             Assert.AreEqual("Remark", dut.Remark);

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandTests.cs
@@ -14,6 +14,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTag
             Assert.AreEqual(2, dut.TagId);
             Assert.AreEqual("Remark", dut.Remark);
             Assert.AreEqual("StorageArea", dut.StorageArea);
+            Assert.AreEqual("AAAAAAAAABA=", dut.RowVersion);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandValidatorTests.cs
@@ -27,7 +27,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTag
             _tagValidatorMock = new Mock<ITagValidator>();
             _tagValidatorMock.Setup(r => r.ExistsAsync(_tagId, default)).Returns(Task.FromResult(true));
 
-            _command = new UpdateTagCommand(_tagId, _remark, _storageArea);
+            const int rowVersion = 12345;
+            _command = new UpdateTagCommand(_tagId, _remark, _storageArea, rowVersion);
             _dut = new UpdateTagCommandValidator(_projectValidatorMock.Object, _tagValidatorMock.Object);
         }
 

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandValidatorTests.cs
@@ -27,8 +27,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTag
             _tagValidatorMock = new Mock<ITagValidator>();
             _tagValidatorMock.Setup(r => r.ExistsAsync(_tagId, default)).Returns(Task.FromResult(true));
 
-            const int rowVersion = 12345;
-            _command = new UpdateTagCommand(_tagId, _remark, _storageArea, rowVersion);
+            const string RowVersion = "AAAAAAAAABA=";
+            _command = new UpdateTagCommand(_tagId, _remark, _storageArea, RowVersion);
             _dut = new UpdateTagCommandValidator(_projectValidatorMock.Object, _tagValidatorMock.Object);
         }
 

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandValidatorTests.cs
@@ -27,8 +27,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTag
             _tagValidatorMock = new Mock<ITagValidator>();
             _tagValidatorMock.Setup(r => r.ExistsAsync(_tagId, default)).Returns(Task.FromResult(true));
 
-            const string RowVersion = "AAAAAAAAABA=";
-            _command = new UpdateTagCommand(_tagId, _remark, _storageArea, RowVersion);
+            _command = new UpdateTagCommand(_tagId, _remark, _storageArea, null);
             _dut = new UpdateTagCommandValidator(_projectValidatorMock.Object, _tagValidatorMock.Object);
         }
 

--- a/src/tests/Equinor.Procosys.Preservation.Domain.Tests/EntityBaseTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Domain.Tests/EntityBaseTests.cs
@@ -54,13 +54,6 @@ namespace Equinor.Procosys.Preservation.Domain.Tests
         }
 
         [TestMethod]
-        public void SetRowVersion_ShouldSucceed()
-        {
-            var dut = new TestableEntityBase();
-            dut.SetRowVersion(RowVersion);
-        }
-
-        [TestMethod]
         public void GetRowVersion_ShouldReturnLastSetRowVersion()
         {
             var dut = new TestableEntityBase();

--- a/src/tests/Equinor.Procosys.Preservation.Domain.Tests/EntityBaseTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Domain.Tests/EntityBaseTests.cs
@@ -8,8 +8,8 @@ namespace Equinor.Procosys.Preservation.Domain.Tests
     [TestClass]
     public class EntityBaseTests
     {
-        private readonly byte[] ConvertedRowVersion = {123, 0, 0, 0, 0, 0, 0, 0};
-        private const ulong RowVersion = 123;
+        private readonly byte[] ConvertedRowVersion = {0, 0, 0, 0, 0, 0, 0, 16};
+        private const string RowVersion = "AAAAAAAAABA=";
 
         [TestMethod]
         public void ReturningEmptyDomainEventsListTest()

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagFunctionDetails/GetTagFunctionDetailsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagFunctionDetails/GetTagFunctionDetailsQueryHandlerTests.cs
@@ -28,7 +28,6 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagFunctionDetails
                 
 
                 _tfWithoutRequirement = AddTagFunction(context, "TFC1", "RC1");
-                _tfWithRequirement.SetRowVersion("AAAAAAAAABA=");
                 context.SaveChangesAsync().Wait();
             }
         }

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagFunctionDetails/GetTagFunctionDetailsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagFunctionDetails/GetTagFunctionDetailsQueryHandlerTests.cs
@@ -28,7 +28,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagFunctionDetails
                 
 
                 _tfWithoutRequirement = AddTagFunction(context, "TFC1", "RC1");
-                _tfWithRequirement.SetRowVersion(12345);
+                _tfWithRequirement.SetRowVersion("AAAAAAAAABA=");
                 context.SaveChangesAsync().Wait();
             }
         }

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagFunctionDetails/TagFunctionDetailsDtoTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagFunctionDetails/TagFunctionDetailsDtoTests.cs
@@ -20,7 +20,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagFunctionDetails
                 "RC",
                 true,
                 new List<RequirementDto>{reqDto},
-                12345);
+                "AAAAAAAAABA=");
 
             Assert.AreEqual(1, dut.Id);
             Assert.AreEqual("TFC", dut.Code);

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagFunctionDetails/TagFunctionDetailsDtoTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagFunctionDetails/TagFunctionDetailsDtoTests.cs
@@ -29,6 +29,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagFunctionDetails
             Assert.IsTrue(dut.IsVoided);
             Assert.AreEqual(1, dut.Requirements.Count());
             Assert.AreEqual(reqDto, dut.Requirements.First());
+            Assert.AreEqual("AAAAAAAAABA=", dut.RowVersion);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTags/TagDtoTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTags/TagDtoTests.cs
@@ -37,7 +37,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTags
             "TagDesc",
             "TagNo",
             TagType.Standard,
-            123456);
+            "AAAAAAAAABA=");
 
         [TestMethod]
         public void Constructor_SetsProperties()

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTags/TagDtoTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTags/TagDtoTests.cs
@@ -67,6 +67,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTags
             Assert.AreEqual("TagFunctionCode", _dut.TagFunctionCode);
             Assert.AreEqual("TagNo", _dut.TagNo);
             Assert.AreEqual(TagType.Standard, _dut.TagType);
+            Assert.AreEqual("AAAAAAAAABA=", _dut.RowVersion);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTags/TagsResultTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTags/TagsResultTests.cs
@@ -37,8 +37,8 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTags
                 "TagDesc",
                 "TagNo",
                 TagType.Standard,
-                123456);
-            var dut = new TagsResult(10, new List<TagDto>{ tagDto });
+                "AAAAAAAAABA=");
+            var dut = new TagsResult(10, new List<TagDto> {tagDto});
             Assert.AreEqual(10, dut.MaxAvailable);
             Assert.IsNotNull(dut.Tags);
             Assert.AreEqual(1, dut.Tags.Count());

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/JourneyAggregate/JourneyDtoTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/JourneyAggregate/JourneyDtoTests.cs
@@ -13,11 +13,12 @@ namespace Equinor.Procosys.Preservation.Query.Tests.JourneyAggregate
         [TestMethod]
         public void Constructor_ShouldSetProperties()
         {
+            const string RowVersion = "AAAAAAAAABA=";
             var stepDto = new StepDto(2,
                 "S",
                 true,
-                new ModeDto(3, "M", 12345),
-                new ResponsibleDto(4, "RC", "RT", 1234));
+                new ModeDto(3, "M", RowVersion),
+                new ResponsibleDto(4, "RC", "RT", RowVersion));
             var dut = new JourneyDto(
                 1,
                 "J",
@@ -26,14 +27,13 @@ namespace Equinor.Procosys.Preservation.Query.Tests.JourneyAggregate
                 {
                     stepDto
                 },
-                12345);
+                RowVersion);
 
             Assert.AreEqual(1, dut.Id);
             Assert.AreEqual("J", dut.Title);
             Assert.IsTrue(dut.IsVoided);
             Assert.AreEqual(1, dut.Steps.Count());
             Assert.AreEqual(stepDto, dut.Steps.First());
-
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/JourneyAggregate/StepDtoTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/JourneyAggregate/StepDtoTests.cs
@@ -11,9 +11,8 @@ namespace Equinor.Procosys.Preservation.Query.Tests.JourneyAggregate
         [TestMethod]
         public void Constructor_ShouldSetProperties()
         {
-            const string RowVersion = "AAAAAAAAABA=";
-            var modeDto = new ModeDto(3, "M", RowVersion);
-            var responsibleDto = new ResponsibleDto(4, "RC", "RT", RowVersion);
+            var modeDto = new ModeDto(3, "M", null);
+            var responsibleDto = new ResponsibleDto(4, "RC", "RT", null);
 
             var dut = new StepDto(2, "S", true, modeDto, responsibleDto);
 

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/JourneyAggregate/StepDtoTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/JourneyAggregate/StepDtoTests.cs
@@ -11,8 +11,9 @@ namespace Equinor.Procosys.Preservation.Query.Tests.JourneyAggregate
         [TestMethod]
         public void Constructor_ShouldSetProperties()
         {
-            var modeDto = new ModeDto(3, "M", 12345);
-            var responsibleDto = new ResponsibleDto(4, "RC", "RT", 12345);
+            const string RowVersion = "AAAAAAAAABA=";
+            var modeDto = new ModeDto(3, "M", RowVersion);
+            var responsibleDto = new ResponsibleDto(4, "RC", "RT", RowVersion);
 
             var dut = new StepDto(2, "S", true, modeDto, responsibleDto);
 

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/ModeAggregate/ModeDtoTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/ModeAggregate/ModeDtoTests.cs
@@ -13,6 +13,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.ModeAggregate
 
             Assert.AreEqual(3, dut.Id);
             Assert.AreEqual("M", dut.Title);
+            Assert.AreEqual("AAAAAAAAABA=", dut.RowVersion);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/ModeAggregate/ModeDtoTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/ModeAggregate/ModeDtoTests.cs
@@ -9,7 +9,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.ModeAggregate
         [TestMethod]
         public void Constructor_ShouldSetProperties()
         {
-            var dut = new ModeDto(3, "M", 12345);
+            var dut = new ModeDto(3, "M", "AAAAAAAAABA=");
 
             Assert.AreEqual(3, dut.Id);
             Assert.AreEqual("M", dut.Title);

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/RequirementTypeAggregate/RequirementTypeDtoTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/RequirementTypeAggregate/RequirementTypeDtoTests.cs
@@ -10,11 +10,12 @@ namespace Equinor.Procosys.Preservation.Query.Tests.RequirementTypeAggregate
     public class RequirementTypeDtoTests
     {
         private readonly List<FieldDto> _fieldsDtos = new List<FieldDto>();
+        private const string _rowVersion = "AAAAAAAAABA=";
 
         [TestMethod]
         public void Constructor_ShouldSetProperties()
         {
-            var dut = new RequirementTypeDto(1, "CodeA", "TitleA", true, 10, new List<RequirementDefinitionDto>(), 12345);
+            var dut = new RequirementTypeDto(1, "CodeA", "TitleA", true, 10, new List<RequirementDefinitionDto>(), _rowVersion);
 
             Assert.AreEqual(1, dut.Id);
             Assert.AreEqual("CodeA", dut.Code);
@@ -27,7 +28,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.RequirementTypeAggregate
         [TestMethod]
         public void Constructor_ShouldThrowException_WhenDefinitionsNotGiven()
             => Assert.ThrowsException<ArgumentNullException>(() =>
-                new RequirementTypeDto(1, "CodeA", "TitleA", true, 10, null, 12345)
+                new RequirementTypeDto(1, "CodeA", "TitleA", true, 10, null, _rowVersion)
             );
 
         [TestMethod]
@@ -40,7 +41,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.RequirementTypeAggregate
                 new RequirementDefinitionDto(3, "", false, 4, 500, false, _fieldsDtos),
                 new RequirementDefinitionDto(4, "", false, 4, 10, false, _fieldsDtos),
             },
-                12345);
+                _rowVersion);
 
             var requirementDefinitions = dut.RequirementDefinitions.ToList();
             Assert.AreEqual(4, requirementDefinitions.Count);
@@ -60,7 +61,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.RequirementTypeAggregate
                 new RequirementDefinitionDto(3, "", false, 4, 500, true, _fieldsDtos),
                 new RequirementDefinitionDto(4, "", false, 4, 10, true, _fieldsDtos),
             },
-                12346);
+                _rowVersion);
 
             var requirementDefinitions = dut.RequirementDefinitions.ToList();
             Assert.AreEqual(4, requirementDefinitions.Count);
@@ -84,7 +85,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.RequirementTypeAggregate
                 new RequirementDefinitionDto(7, "", false, 4, 500, false, _fieldsDtos),
                 new RequirementDefinitionDto(8, "", false, 4, 10, false, _fieldsDtos),
             },
-                123457);
+                _rowVersion);
 
             var requirementDefinitions = dut.RequirementDefinitions.ToList();
             Assert.AreEqual(8, requirementDefinitions.Count);

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/RequirementTypeAggregate/RequirementTypeDtoTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/RequirementTypeAggregate/RequirementTypeDtoTests.cs
@@ -23,6 +23,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.RequirementTypeAggregate
             Assert.AreEqual(10, dut.SortKey);
             Assert.IsTrue(dut.IsVoided);
             Assert.AreEqual(0, dut.RequirementDefinitions.Count());
+            Assert.AreEqual(_rowVersion, dut.RowVersion);
         }
 
         [TestMethod]

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/ResponsibleAggregate/ResponsibleDtoTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/ResponsibleAggregate/ResponsibleDtoTests.cs
@@ -9,7 +9,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.ResponsibleAggregate
         [TestMethod]
         public void Constructor_ShouldSetProperties()
         {
-            var dut = new ResponsibleDto(3, "RC", "RT", 12345);
+            var dut = new ResponsibleDto(3, "RC", "RT", "AAAAAAAAABA=");
 
             Assert.AreEqual(3, dut.Id);
             Assert.AreEqual("RC", dut.Code);

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/ResponsibleAggregate/ResponsibleDtoTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/ResponsibleAggregate/ResponsibleDtoTests.cs
@@ -14,6 +14,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.ResponsibleAggregate
             Assert.AreEqual(3, dut.Id);
             Assert.AreEqual("RC", dut.Code);
             Assert.AreEqual("RT", dut.Title);
+            Assert.AreEqual("AAAAAAAAABA=", dut.RowVersion);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Controllers/Tags/UpdateTagDtoValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Controllers/Tags/UpdateTagDtoValidatorTests.cs
@@ -11,12 +11,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Tests.Controllers.Tags
         public void Validate_OK()
         {
             var dut = new UpdateTagDtoValidator();
-            var validUpdateTagDto = new UpdateTagDto()
-            {
-                Remark = "Remark",
-                StorageArea = "StorageArea",
-                RowVersion = "AAAAAAAAABA="
-            };
+            var validUpdateTagDto = new UpdateTagDto();
 
             var result = dut.Validate(validUpdateTagDto);
 

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Controllers/Tags/UpdateTagDtoValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Controllers/Tags/UpdateTagDtoValidatorTests.cs
@@ -15,7 +15,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Tests.Controllers.Tags
             {
                 Remark = "Remark",
                 StorageArea = "StorageArea",
-                RowVersion = 12345
+                RowVersion = "AAAAAAAAABA="
             };
 
             var result = dut.Validate(validUpdateTagDto);

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Controllers/Tags/UpdateTagDtoValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Controllers/Tags/UpdateTagDtoValidatorTests.cs
@@ -14,7 +14,8 @@ namespace Equinor.Procosys.Preservation.WebApi.Tests.Controllers.Tags
             var validUpdateTagDto = new UpdateTagDto()
             {
                 Remark = "Remark",
-                StorageArea = "StorageArea"
+                StorageArea = "StorageArea",
+                RowVersion = 12345
             };
 
             var result = dut.Validate(validUpdateTagDto);


### PR DESCRIPTION
Convert RowVersion byte array to string instead of ulong (necessary because of size limitation on JavaScript number datatype)

Add OC to PUT endpoints:
PUT​/Journeys​/{id}​/UpdateJourney
PUT /Modes/{id}/UpdateMode
PUT /Tags/{id}