### PR TITLE
Returning updated row version

### DIFF
--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UpdateJourney/UpdateJourneyCommand.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UpdateJourney/UpdateJourneyCommand.cs
@@ -3,7 +3,7 @@ using ServiceResult;
 
 namespace Equinor.Procosys.Preservation.Command.JourneyCommands.UpdateJourney
 {
-    public class UpdateJourneyCommand : IRequest<Result<Unit>>
+    public class UpdateJourneyCommand : IRequest<Result<string>>
     {
         public UpdateJourneyCommand(int journeyId, string title, string rowVersion)
         {

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UpdateJourney/UpdateJourneyCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UpdateJourney/UpdateJourneyCommandHandler.cs
@@ -7,7 +7,7 @@ using ServiceResult;
 
 namespace Equinor.Procosys.Preservation.Command.JourneyCommands.UpdateJourney
 {
-    public class UpdateJourneyCommandHandler : IRequestHandler<UpdateJourneyCommand, Result<Unit>>
+    public class UpdateJourneyCommandHandler : IRequestHandler<UpdateJourneyCommand, Result<string>>
     {
         private readonly IJourneyRepository _journeyRepository;
         private readonly IUnitOfWork _unitOfWork;
@@ -18,7 +18,7 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.UpdateJourney
             _unitOfWork = unitOfWork;
         }
 
-        public async Task<Result<Unit>> Handle(UpdateJourneyCommand request, CancellationToken cancellationToken)
+        public async Task<Result<string>> Handle(UpdateJourneyCommand request, CancellationToken cancellationToken)
         {
             var journey = await _journeyRepository.GetByIdAsync(request.JourneyId);
 
@@ -26,7 +26,7 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.UpdateJourney
             journey.SetRowVersion(request.RowVersion);
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 
-            return new SuccessResult<Unit>(Unit.Value);
+            return new SuccessResult<string>(journey.RowVersion.ConvertToString());
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/ModeCommands/UpdateMode/UpdateModeCommand.cs
+++ b/src/Equinor.Procosys.Preservation.Command/ModeCommands/UpdateMode/UpdateModeCommand.cs
@@ -3,7 +3,7 @@ using ServiceResult;
 
 namespace Equinor.Procosys.Preservation.Command.ModeCommands.UpdateMode
 {
-    public class UpdateModeCommand : IRequest<Result<Unit>>
+    public class UpdateModeCommand : IRequest<Result<string>>
     {
         public UpdateModeCommand(int modeId, string title, string rowVersion)
         {

--- a/src/Equinor.Procosys.Preservation.Command/ModeCommands/UpdateMode/UpdateModeCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/ModeCommands/UpdateMode/UpdateModeCommandHandler.cs
@@ -7,7 +7,7 @@ using ServiceResult;
 
 namespace Equinor.Procosys.Preservation.Command.ModeCommands.UpdateMode
 {
-    public class UpdateModeCommandHandler : IRequestHandler<UpdateModeCommand, Result<Unit>>
+    public class UpdateModeCommandHandler : IRequestHandler<UpdateModeCommand, Result<string>>
     {
         private readonly IModeRepository _modeRepository;
         private readonly IUnitOfWork _unitOfWork;
@@ -18,7 +18,7 @@ namespace Equinor.Procosys.Preservation.Command.ModeCommands.UpdateMode
             _unitOfWork = unitOfWork;
         }
 
-        public async Task<Result<Unit>> Handle(UpdateModeCommand request, CancellationToken cancellationToken)
+        public async Task<Result<string>> Handle(UpdateModeCommand request, CancellationToken cancellationToken)
         {
             var mode = await _modeRepository.GetByIdAsync(request.ModeId);
 
@@ -26,7 +26,7 @@ namespace Equinor.Procosys.Preservation.Command.ModeCommands.UpdateMode
             mode.SetRowVersion(request.RowVersion);
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 
-            return new SuccessResult<Unit>(Unit.Value);
+            return new SuccessResult<string>(mode.RowVersion.ConvertToString());
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTag/UpdateTagCommand.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTag/UpdateTagCommand.cs
@@ -3,7 +3,7 @@ using ServiceResult;
 
 namespace Equinor.Procosys.Preservation.Command.TagCommands.UpdateTag
 {
-    public class UpdateTagCommand : IRequest<Result<Unit>>, ITagCommandRequest
+    public class UpdateTagCommand : IRequest<Result<string>>, ITagCommandRequest
     {
         public UpdateTagCommand(
             int tagId,

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTag/UpdateTagCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTag/UpdateTagCommandHandler.cs
@@ -8,7 +8,7 @@ using ServiceResult;
 namespace Equinor.Procosys.Preservation.Command.TagCommands.UpdateTag
 {
 
-    public class UpdateTagCommandHandler : IRequestHandler<UpdateTagCommand, Result<Unit>>
+    public class UpdateTagCommandHandler : IRequestHandler<UpdateTagCommand, Result<string>>
     {
         private readonly IProjectRepository _projectRepository;
         private readonly IUnitOfWork _unitOfWork;
@@ -19,7 +19,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.UpdateTag
             _unitOfWork = unitOfWork;
         }
 
-        public async Task<Result<Unit>> Handle(UpdateTagCommand request, CancellationToken cancellationToken)
+        public async Task<Result<string>> Handle(UpdateTagCommand request, CancellationToken cancellationToken)
         {
             var tag = await _projectRepository.GetTagByTagIdAsync(request.TagId);
 
@@ -29,7 +29,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.UpdateTag
 
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 
-            return new SuccessResult<Unit>(Unit.Value);
+            return new SuccessResult<string>(tag.RowVersion.ConvertToString());
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandHandlerTests.cs
@@ -46,7 +46,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UpdateJour
 
             // Assert
             Assert.AreEqual(0, result.Errors.Count);
-            Assert.AreEqual(Unit.Value, result.Data);
+            Assert.AreEqual("AAAAAAAAAAA=", result.Data);
             Assert.AreEqual(_journeyMock.Object.Title, _newTitle);
         }
 

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandHandlerTests.cs
@@ -46,7 +46,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.UpdateMode
 
             // Assert
             Assert.AreEqual(0, result.Errors.Count);
-            Assert.AreEqual(Unit.Value, result.Data);
+            Assert.AreEqual("AAAAAAAAAAA=", result.Data);
             Assert.AreEqual(_modeMock.Object.Title, _newTitle);
         }
 


### PR DESCRIPTION
Small update to backend to make front-end be able to do multiple puts without refresh, as the updated row version must be returned.