### PR TITLE
Uniform more row version tests

### DIFF
--- a/src/Equinor.Procosys.Preservation.Command/ActionCommands/CloseAction/CloseActionCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/ActionCommands/CloseAction/CloseActionCommandHandler.cs
@@ -33,13 +33,15 @@ namespace Equinor.Procosys.Preservation.Command.ActionCommands.CloseAction
         {
             var tag = await _projectRepository.GetTagByTagIdAsync(request.TagId);
             var action = tag.Actions.Single(a => a.Id == request.ActionId);
-            var currentUserOid = _currentUserProvider.GetCurrentUserOid();
-            var currentUser = await _personRepository.GetByOidAsync(currentUserOid);
+
+            var currentUser = await _personRepository.GetByOidAsync(_currentUserProvider.GetCurrentUserOid());
+            
             action.Close(TimeService.UtcNow, currentUser);
             action.SetRowVersion(request.RowVersion);
+            
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 
-            return new SuccessResult<string>(action.RowVersion.ToString());
+            return new SuccessResult<string>(action.RowVersion.ConvertToString());
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/ActionCommands/UpdateAction/UpdateActionCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/ActionCommands/UpdateAction/UpdateActionCommandHandler.cs
@@ -31,7 +31,7 @@ namespace Equinor.Procosys.Preservation.Command.ActionCommands.UpdateAction
 
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 
-            return new SuccessResult<string>(action.RowVersion.ToString());
+            return new SuccessResult<string>(action.RowVersion.ConvertToString());
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/TagFunctionCommands/UpdateRequirements/UpdateRequirementsCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagFunctionCommands/UpdateRequirements/UpdateRequirementsCommandHandler.cs
@@ -56,7 +56,7 @@ namespace Equinor.Procosys.Preservation.Command.TagFunctionCommands.UpdateRequir
 
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 
-            return new SuccessResult<string>(tagFunction.RowVersion.ToString());
+            return new SuccessResult<string>(tagFunction.RowVersion.ConvertToString());
         }
 
         private async Task<TagFunction> CreateNewTagFunctionAsync(string tagFunctionCode, string registerCode)

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionCommands/CloseAction/CloseActionCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionCommands/CloseAction/CloseActionCommandHandlerTests.cs
@@ -14,8 +14,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionCommands.CloseAction
     [TestClass]
     public class CloseActionCommandHandlerTests : CommandHandlerTestsBase
     {
-        private readonly int _tagId = 2;
-        private readonly int _actionId = 12;
         private readonly int _personId = 16;
         private readonly string _rowVersion = "AAAAAAAAABA=";
 
@@ -37,18 +35,20 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionCommands.CloseAction
             _currentUserProviderMock = new Mock<ICurrentUserProvider>();
             _personRepositoryMock = new Mock<IPersonRepository>();
 
+            var tagId = 2;
             var tagMock = new Mock<Tag>();
             tagMock.SetupGet(t => t.Plant).Returns(TestPlant);
-            tagMock.SetupGet(t => t.Id).Returns(_tagId);
+            tagMock.SetupGet(t => t.Id).Returns(tagId);
             _action = new Action(TestPlant, "T", "D", null);
-            _action.SetProtectedIdForTesting(_actionId);
+            var actionId = 12;
+            _action.SetProtectedIdForTesting(actionId);
             tagMock.Object.AddAction(_action);
 
             _personMock = new Mock<Person>();
             _personMock.SetupGet(p => p.Id).Returns(_personId);
 
             _projectRepositoryMock
-                .Setup(r => r.GetTagByTagIdAsync(_tagId))
+                .Setup(r => r.GetTagByTagIdAsync(tagId))
                 .Returns(Task.FromResult(tagMock.Object));
 
             _currentUserProviderMock
@@ -59,7 +59,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionCommands.CloseAction
                 .Setup(p => p.GetByOidAsync(It.Is<Guid>(x => x == _currentUserOid)))
                 .Returns(Task.FromResult(_personMock.Object));
 
-            _command = new CloseActionCommand(_tagId, _actionId, _rowVersion);
+            _command = new CloseActionCommand(tagId, actionId, _rowVersion);
 
             _dut = new CloseActionCommandHandler(
                 _projectRepositoryMock.Object,

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionCommands/UpdateAction/UpdateActionCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionCommands/UpdateAction/UpdateActionCommandHandlerTests.cs
@@ -13,8 +13,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionCommands.UpdateActio
     [TestClass]
     public class UpdateActionCommandHandlerTests : CommandHandlerTestsBase
     {
-        private const int TagId = 2;
-        private const int ActionId = 12;
         private readonly string _oldTitle = "ActionTitleOld";
         private readonly string _newTitle = "ActionTitleNew";
         private readonly string _oldDescription = "ActionDescriptionOld";
@@ -34,18 +32,20 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionCommands.UpdateActio
         {
             _projectRepositoryMock = new Mock<IProjectRepository>();
 
+            var tagId = 2;
             var tagMock = new Mock<Tag>();
             tagMock.SetupGet(t => t.Plant).Returns(TestPlant);
-            tagMock.SetupGet(t => t.Id).Returns(TagId);
+            tagMock.SetupGet(t => t.Id).Returns(tagId);
+            var actionId = 12;
             _action = new Action(TestPlant, _oldTitle, _oldDescription, _oldDueTimeUtc);
-            _action.SetProtectedIdForTesting(ActionId);
+            _action.SetProtectedIdForTesting(actionId);
             tagMock.Object.AddAction(_action);
 
             _projectRepositoryMock
-                .Setup(r => r.GetTagByTagIdAsync(TagId))
+                .Setup(r => r.GetTagByTagIdAsync(tagId))
                 .Returns(Task.FromResult(tagMock.Object));
 
-            _command = new UpdateActionCommand(TagId, ActionId, _newTitle, _newDescription, _newDueTimeUtc, _rowVersion);
+            _command = new UpdateActionCommand(tagId, actionId, _newTitle, _newDescription, _newDueTimeUtc, _rowVersion);
 
             _dut = new UpdateActionCommandHandler(
                 _projectRepositoryMock.Object,

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.JourneyCommands.UpdateJourney;
+using Equinor.Procosys.Preservation.Domain;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate;
 using Equinor.Procosys.Preservation.Test.Common.ExtensionMethods;
 using MediatR;
@@ -47,8 +48,20 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UpdateJour
 
             // Assert
             Assert.AreEqual(0, result.Errors.Count);
+            Assert.AreEqual(_newTitle, _journey.Title);
+        }
+
+        [TestMethod]
+        public async Task HandlingUpdateJourneyCommand_ShouldSetAndReturnRowVersion()
+        {
+            // Act
+            var result = await _dut.Handle(_command, default);
+
+            // Assert
+            // In real life EF Core will create a new RowVersion when save.
+            // Since UnitOfWorkMock is a Mock this will not happen here, so we assert that RowVersion is set from command
             Assert.AreEqual(_rowVersion, result.Data);
-            Assert.AreEqual(_journey.Title, _newTitle);
+            Assert.AreEqual(_rowVersion, _journey.RowVersion.ConvertToString());
         }
 
         [TestMethod]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandHandlerTests.cs
@@ -27,7 +27,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UpdateJour
             var testJourneyId = 1;
             var journeyRepositoryMock = new Mock<IJourneyRepository>();
             _journey = new Journey(TestPlant, _oldTitle);
-            _journey.SetProtectedIdForTesting(testJourneyId);
             journeyRepositoryMock.Setup(j => j.GetByIdAsync(testJourneyId))
                 .Returns(Task.FromResult(_journey));
             _command = new UpdateJourneyCommand(testJourneyId, _newTitle, _rowVersion);

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateStep/UpdateStepCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateStep/UpdateStepCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.JourneyCommands.UpdateStep;
+using Equinor.Procosys.Preservation.Domain;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.ModeAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.ResponsibleAggregate;
@@ -54,8 +55,20 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UpdateStep
 
             // Assert
             Assert.AreEqual(0, result.Errors.Count);
-            Assert.AreEqual(_rowVersion, result.Data);
             Assert.AreEqual(_newTitle, _step.Title);
+        }
+        
+        [TestMethod]
+        public async Task HandlingUpdateStepCommand_ShouldSetAndReturnRowVersion()
+        {
+            // Act
+            var result = await _dut.Handle(_command, default);
+
+            // Assert
+            // In real life EF Core will create a new RowVersion when save.
+            // Since UnitOfWorkMock is a Mock this will not happen here, so we assert that RowVersion is set from command
+            Assert.AreEqual(_rowVersion, result.Data);
+            Assert.AreEqual(_rowVersion, _step.RowVersion.ConvertToString());
         }
 
         [TestMethod]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateStep/UpdateStepCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateStep/UpdateStepCommandHandlerTests.cs
@@ -13,7 +13,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UpdateStep
     [TestClass]
     public class UpdateStepCommandHandlerTests : CommandHandlerTestsBase
     {
-        private readonly int _id = 1;
         private readonly string _rowVersion = "AAAAAAAAABA=";
 
         private readonly string _oldTitle = "StepTitleOld";
@@ -33,11 +32,11 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UpdateStep
             var responsibleMock = new Mock<Responsible>();
             responsibleMock.SetupGet(s => s.Plant).Returns(TestPlant);
 
+            var stepId = 1;
             _step = new Step(TestPlant, _oldTitle, modeMock.Object, responsibleMock.Object);
-            _step.SetProtectedIdForTesting(_id);
-            journeyRepositoryMock.Setup(s => s.GetStepByStepIdAsync(_step.Id))
+            journeyRepositoryMock.Setup(s => s.GetStepByStepIdAsync(stepId))
                 .Returns(Task.FromResult(_step));
-            _command = new UpdateStepCommand(_id, _newTitle, _rowVersion);
+            _command = new UpdateStepCommand(stepId, _newTitle, _rowVersion);
 
             _dut = new UpdateStepCommandHandler(
                 journeyRepositoryMock.Object,

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandHandlerTests.cs
@@ -2,8 +2,6 @@
 using Equinor.Procosys.Preservation.Command.ModeCommands.UpdateMode;
 using Equinor.Procosys.Preservation.Domain;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.ModeAggregate;
-using Equinor.Procosys.Preservation.Test.Common.ExtensionMethods;
-using MediatR;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
@@ -24,13 +22,12 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.UpdateMode
         public void Setup()
         {
             // Arrange
-            var testModeId = 1;
+            var modeId = 1;
             var modeRepositoryMock = new Mock<IModeRepository>();
             _mode = new Mode(TestPlant, _oldTitle);
-            _mode.SetProtectedIdForTesting(testModeId);
-            modeRepositoryMock.Setup(m => m.GetByIdAsync(testModeId))
+            modeRepositoryMock.Setup(m => m.GetByIdAsync(modeId))
                 .Returns(Task.FromResult(_mode));
-            _command = new UpdateModeCommand(testModeId, _newTitle, _rowVersion);
+            _command = new UpdateModeCommand(modeId, _newTitle, _rowVersion);
 
             _dut = new UpdateModeCommandHandler(
                 modeRepositoryMock.Object,
@@ -47,7 +44,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.UpdateMode
             await _dut.Handle(_command, default);
 
             // Assert
-            Assert.AreEqual(_mode.Title, _newTitle);
+            Assert.AreEqual(_newTitle, _mode.Title);
         }
                 
         [TestMethod]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.ModeCommands.UpdateMode;
+using Equinor.Procosys.Preservation.Domain;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.ModeAggregate;
 using Equinor.Procosys.Preservation.Test.Common.ExtensionMethods;
 using MediatR;
@@ -43,12 +44,24 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.UpdateMode
             Assert.AreEqual(_oldTitle, _mode.Title);
 
             // Act
+            await _dut.Handle(_command, default);
+
+            // Assert
+            Assert.AreEqual(_mode.Title, _newTitle);
+        }
+                
+        [TestMethod]
+        public async Task HandlingUpdateModeCommand_ShouldSetAndReturnRowVersion()
+        {
+            // Act
             var result = await _dut.Handle(_command, default);
 
             // Assert
             Assert.AreEqual(0, result.Errors.Count);
+            // In real life EF Core will create a new RowVersion when save.
+            // Since UnitOfWorkMock is a Mock this will not happen here, so we assert that RowVersion is set from command
             Assert.AreEqual(_rowVersion, result.Data);
-            Assert.AreEqual(_mode.Title, _newTitle);
+            Assert.AreEqual(_rowVersion, _mode.RowVersion.ConvertToString());
         }
 
         [TestMethod]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementCommands/Preserve/PreserveCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementCommands/Preserve/PreserveCommandHandlerTests.cs
@@ -80,7 +80,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementCommands.Preser
             Assert.IsNotNull(_initialPreservationPeriod.PreservationRecord);
         }
 
-
         [TestMethod]
         public async Task HandlingPreserveCommand_ShouldSave()
         {

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CompletePreservation/CompletePreservationCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CompletePreservation/CompletePreservationCommandHandlerTests.cs
@@ -138,18 +138,17 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CompletePreser
         }
 
         [TestMethod]
-        public async Task HandlingCompletePreservationCommand_ShouldSetRowVersion()
+        public async Task HandlingCompletePreservationCommand_ShouldSetAndReturnRowVersion()
         {
-            // Arrange
-            var rowVersion = _command.Tags.First().RowVersion;
-
             // Act
-            Assert.AreNotEqual(rowVersion, _tag1.RowVersion.ConvertToString());
-            await _dut.Handle(_command, default);
+            var result = await _dut.Handle(_command, default);
 
             // Assert
-            var updatedRowVersion = _tag1.RowVersion.ConvertToString();
-            Assert.AreEqual(rowVersion, updatedRowVersion);
+            Assert.AreEqual(0, result.Errors.Count);
+            // In real life EF Core will create a new RowVersion when save.
+            // Since UnitOfWorkMock is a Mock this will not happen here, so we assert that RowVersion is set from command
+            Assert.AreEqual(_rowVersion1, result.Data.First().RowVersion);
+            Assert.AreEqual(_rowVersion1, _tag1.RowVersion.ConvertToString());
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CompletePreservation/CompletePreservationCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CompletePreservation/CompletePreservationCommandHandlerTests.cs
@@ -27,38 +27,38 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CompletePreser
         private Mock<RequirementDefinition> _rd1Mock;
         private Mock<RequirementDefinition> _rd2Mock;
 
-        private int _rdId1 = 17;
-        private int _rdId2 = 18;
-        private int _tagId1 = 7;
-        private int _tagId2 = 8;
         private const string _rowVersion1 = "AAAAAAAAABA=";
         private const string _rowVersion2 = "AAAAAAAABBA=";
-
-        private int _stepId1 = 9;
-        private int _stepId2 = 10;
 
         private CompletePreservationCommandHandler _dut;
 
         [TestInitialize]
         public void Setup()
         {
+            var rdId1 = 17;
+            var rdId2 = 18;
+            var tagId1 = 7;
+            var tagId2 = 8;
+            var stepId1 = 9;
+            var stepId2 = 10;
+
             var step1Mock = new Mock<Step>();
             step1Mock.SetupGet(s => s.Plant).Returns(TestPlant);
-            step1Mock.SetupGet(s => s.Id).Returns(_stepId1);
+            step1Mock.SetupGet(s => s.Id).Returns(stepId1);
             
             var step2Mock = new Mock<Step>();
             step2Mock.SetupGet(s => s.Plant).Returns(TestPlant);
-            step2Mock.SetupGet(s => s.Id).Returns(_stepId2);
+            step2Mock.SetupGet(s => s.Id).Returns(stepId2);
 
-            var journey = new Journey(TestPlant, "Demissie");
+            var journey = new Journey(TestPlant, "D");
             journey.AddStep(step1Mock.Object);
             journey.AddStep(step2Mock.Object);
 
             _rd1Mock = new Mock<RequirementDefinition>();
-            _rd1Mock.SetupGet(rd => rd.Id).Returns(_rdId1);
+            _rd1Mock.SetupGet(rd => rd.Id).Returns(rdId1);
             _rd1Mock.SetupGet(rd => rd.Plant).Returns(TestPlant);
             _rd2Mock = new Mock<RequirementDefinition>();
-            _rd2Mock.SetupGet(rd => rd.Id).Returns(_rdId2);
+            _rd2Mock.SetupGet(rd => rd.Id).Returns(rdId2);
             _rd2Mock.SetupGet(rd => rd.Plant).Returns(TestPlant);
 
             _req1OnTag1 = new TagRequirement(TestPlant, 2, _rd1Mock.Object);
@@ -70,29 +70,29 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CompletePreser
                 _req1OnTag1, _req2OnTag1
             });
             _tag1.StartPreservation();
-            _tag1.SetProtectedIdForTesting(_tagId1);
+            _tag1.SetProtectedIdForTesting(tagId1);
 
             _tag2 = new Tag(TestPlant, TagType.Standard, "", "", step2Mock.Object, new List<TagRequirement>
             {
                 _req1OnTag2, _req2OnTag2
             });
             _tag2.StartPreservation();
-            _tag2.SetProtectedIdForTesting(_tagId2);
+            _tag2.SetProtectedIdForTesting(tagId2);
 
             var tags = new List<Tag>
             {
                 _tag1, _tag2
             };
             
-            var tagIds = new List<int> { _tagId1, _tagId2 };
-            var tagIdsWithRowVersion = new List<IdAndRowVersion> { new IdAndRowVersion(_tagId1, _rowVersion1), new IdAndRowVersion(_tagId2, _rowVersion2) };
+            var tagIds = new List<int> { tagId1, tagId2 };
+            var tagIdsWithRowVersion = new List<IdAndRowVersion> { new IdAndRowVersion(tagId1, _rowVersion1), new IdAndRowVersion(tagId2, _rowVersion2) };
 
             _tagRepoMock = new Mock<IProjectRepository>();
             _tagRepoMock.Setup(r => r.GetTagsByTagIdsAsync(tagIds)).Returns(Task.FromResult(tags));
 
             var journeyRepoMock = new Mock<IJourneyRepository>();
             journeyRepoMock
-                .Setup(r => r.GetJourneysByStepIdsAsync(new List<int> { _stepId2 }))
+                .Setup(r => r.GetJourneysByStepIdsAsync(new List<int> { stepId2 }))
                 .Returns(Task.FromResult(new List<Journey> { journey }));
             
             _command = new CompletePreservationCommand(tagIdsWithRowVersion);

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/Transfer/TransferCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/Transfer/TransferCommandHandlerTests.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.TagCommands.Transfer;
+using Equinor.Procosys.Preservation.Domain;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
+using Equinor.Procosys.Preservation.Test.Common.ExtensionMethods;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
@@ -26,8 +28,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.Transfer
         private TransferCommand _command;
 
         private TransferCommandHandler _dut;
-        private Mock<Tag> _tag1Mock;
-        private Mock<Tag> _tag2Mock;
+        private Tag _tag1;
+        private Tag _tag2;
 
         [TestInitialize]
         public void Setup()
@@ -61,20 +63,18 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.Transfer
 
             var reqMock1 = new Mock<TagRequirement>();
             reqMock1.SetupGet(r => r.Plant).Returns(TestPlant);
-            _tag1Mock = new Mock<Tag>(TestPlant, TagType.Standard, "", "", step1OnJourney1Mock.Object,
+            _tag1 = new Tag(TestPlant, TagType.Standard, "", "", step1OnJourney1Mock.Object,
                 new List<TagRequirement> {reqMock1.Object});
-            _tag1Mock.SetupGet(t => t.Id).Returns(TagId1);
-            _tag1Mock.SetupGet(t => t.Plant).Returns(TestPlant);
+            _tag1.SetProtectedIdForTesting(TagId1);
 
             var reqMock2 = new Mock<TagRequirement>();
             reqMock2.SetupGet(r => r.Plant).Returns(TestPlant);
-            _tag2Mock = new Mock<Tag>(TestPlant, TagType.Standard, "", "", step1OnJourney2Mock.Object,
+            _tag2 = new Tag(TestPlant, TagType.Standard, "", "", step1OnJourney2Mock.Object,
                 new List<TagRequirement> {reqMock2.Object});
-            _tag2Mock.SetupGet(t => t.Id).Returns(TagId2);
-            _tag2Mock.SetupGet(t => t.Plant).Returns(TestPlant);
+            _tag2.SetProtectedIdForTesting(TagId2);
 
-            _tag1Mock.Object.StartPreservation();
-            _tag2Mock.Object.StartPreservation();
+            _tag1.StartPreservation();
+            _tag2.StartPreservation();
 
             var projectRepoMock = new Mock<IProjectRepository>();
             
@@ -82,7 +82,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.Transfer
             var tagIdsWithRowVersion = new List<IdAndRowVersion> {new IdAndRowVersion(TagId1, RowVersion1), new IdAndRowVersion(TagId2, RowVersion2)};
             projectRepoMock
                 .Setup(r => r.GetTagsByTagIdsAsync(tagIds))
-                .Returns(Task.FromResult(new List<Tag> {_tag1Mock.Object, _tag2Mock.Object}));
+                .Returns(Task.FromResult(new List<Tag> {_tag1, _tag2}));
 
             _command = new TransferCommand(tagIdsWithRowVersion);
 
@@ -94,8 +94,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.Transfer
         {
             await _dut.Handle(_command, default);
 
-            Assert.AreEqual(Step2OnJourney1Id, _tag1Mock.Object.StepId);
-            Assert.AreEqual(Step2OnJourney2Id, _tag2Mock.Object.StepId);
+            Assert.AreEqual(Step2OnJourney1Id, _tag1.StepId);
+            Assert.AreEqual(Step2OnJourney2Id, _tag2.StepId);
         }
 
         [TestMethod]
@@ -118,16 +118,17 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.Transfer
         }
 
         [TestMethod]
-        public async Task HandlingTransferCommand_ShouldSetRowVersion()
+        public async Task HandlingTransferCommand_ShouldSetAndReturnRowVersion()
         {
-            // Arrange
-            var updatedRowVersion = _command.Tags.First().RowVersion;
-
             // Act
-            await _dut.Handle(_command, default);
+            var result = await _dut.Handle(_command, default);
 
             // Assert
-            _tag1Mock.Verify(t => t.SetRowVersion(updatedRowVersion), Times.Once);
+            Assert.AreEqual(0, result.Errors.Count);
+            // In real life EF Core will create a new RowVersion when save.
+            // Since UnitOfWorkMock is a Mock this will not happen here, so we assert that RowVersion is set from command
+            Assert.AreEqual(RowVersion1, result.Data.First().RowVersion);
+            Assert.AreEqual(RowVersion1, _tag1.RowVersion.ConvertToString());
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/Transfer/TransferCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/Transfer/TransferCommandHandlerTests.cs
@@ -20,10 +20,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.Transfer
         private const int Step1OnJourney2Id = 3;
         private const int Step2OnJourney2Id = 4;
 
-        private const int TagId1 = 7;
-        private const int TagId2 = 8;
-        private const string RowVersion1 = "AAAAAAAAABA=";
-        private const string RowVersion2 = "AAAAAAAABBA=";
+        private const string _rowVersion1 = "AAAAAAAAABA=";
+        private const string _rowVersion2 = "AAAAAAAABBA=";
 
         private TransferCommand _command;
 
@@ -63,23 +61,26 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.Transfer
 
             var reqMock1 = new Mock<TagRequirement>();
             reqMock1.SetupGet(r => r.Plant).Returns(TestPlant);
+            
+            var tagId1 = 7;
+            var tagId2 = 8;
             _tag1 = new Tag(TestPlant, TagType.Standard, "", "", step1OnJourney1Mock.Object,
                 new List<TagRequirement> {reqMock1.Object});
-            _tag1.SetProtectedIdForTesting(TagId1);
+            _tag1.SetProtectedIdForTesting(tagId1);
 
             var reqMock2 = new Mock<TagRequirement>();
             reqMock2.SetupGet(r => r.Plant).Returns(TestPlant);
             _tag2 = new Tag(TestPlant, TagType.Standard, "", "", step1OnJourney2Mock.Object,
                 new List<TagRequirement> {reqMock2.Object});
-            _tag2.SetProtectedIdForTesting(TagId2);
+            _tag2.SetProtectedIdForTesting(tagId2);
 
             _tag1.StartPreservation();
             _tag2.StartPreservation();
 
             var projectRepoMock = new Mock<IProjectRepository>();
             
-            var tagIds = new List<int> {TagId1, TagId2};
-            var tagIdsWithRowVersion = new List<IdAndRowVersion> {new IdAndRowVersion(TagId1, RowVersion1), new IdAndRowVersion(TagId2, RowVersion2)};
+            var tagIds = new List<int> {tagId1, tagId2};
+            var tagIdsWithRowVersion = new List<IdAndRowVersion> {new IdAndRowVersion(tagId1, _rowVersion1), new IdAndRowVersion(tagId2, _rowVersion2)};
             projectRepoMock
                 .Setup(r => r.GetTagsByTagIdsAsync(tagIds))
                 .Returns(Task.FromResult(new List<Tag> {_tag1, _tag2}));
@@ -127,8 +128,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.Transfer
             Assert.AreEqual(0, result.Errors.Count);
             // In real life EF Core will create a new RowVersion when save.
             // Since UnitOfWorkMock is a Mock this will not happen here, so we assert that RowVersion is set from command
-            Assert.AreEqual(RowVersion1, result.Data.First().RowVersion);
-            Assert.AreEqual(RowVersion1, _tag1.RowVersion.ConvertToString());
+            Assert.AreEqual(_rowVersion1, result.Data.First().RowVersion);
+            Assert.AreEqual(_rowVersion1, _tag1.RowVersion.ConvertToString());
         }
     }
 }


### PR DESCRIPTION
Yesterday we found a better way to test RowVersion flow in Handlers.
This PR is to uniform these tests even more.

**PS: Writing these tests, I also found bug in both CloseActionCommandHandler.cs and UpdateActionCommandHandler.cs. They returned RowVersion.ToString(), which is "System.Byte[]"**