### PR TITLE
73443 delete attachment from tag

### DIFF
--- a/src/Equinor.Procosys.Preservation.Command/ActionAttachmentCommands/Upload/UploadActionAttachmentCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/ActionAttachmentCommands/Upload/UploadActionAttachmentCommandValidator.cs
@@ -23,7 +23,7 @@ namespace Equinor.Procosys.Preservation.Command.ActionAttachmentCommands.Upload
                 .WithMessage(command => $"Tag doesn't exist! Tag={command.TagId}")
                 .MustAsync((command, token) => NotBeAVoidedTagAsync(command.TagId, token))
                 .WithMessage(command => $"Tag is voided! Tag={command.TagId}")
-                .MustAsync((command, token) => BeAnExistingActionAsync(command.TagId, command.ActionId, token))
+                .MustAsync((command, token) => BeAnExistingActionAsync(command.ActionId, token))
                 .WithMessage(command => $"Action doesn't exist! Action={command.ActionId}")
                 .MustAsync((command, token) => NotBeAClosedActionAsync(command.ActionId, token))
                 .WithMessage(command => $"Action is closed! Action={command.ActionId}")
@@ -39,8 +39,8 @@ namespace Equinor.Procosys.Preservation.Command.ActionAttachmentCommands.Upload
                 => !await tagValidator.IsVoidedAsync(tagId, token);
             async Task<bool> NotHaveAttachmentWithFilenameAsync(int actionId, string fileName, CancellationToken token)
                 => !await actionValidator.AttachmentWithFilenameExistsAsync(actionId, fileName, token);
-            async Task<bool> BeAnExistingActionAsync(int tagId, int actionId, CancellationToken token)
-                => await actionValidator.ExistsAsync(tagId, actionId, token);
+            async Task<bool> BeAnExistingActionAsync(int actionId, CancellationToken token)
+                => await actionValidator.ExistsAsync(actionId, token);
             async Task<bool> NotBeAClosedActionAsync(int actionId, CancellationToken token)
                 => !await actionValidator.IsClosedAsync(actionId, token);
         }

--- a/src/Equinor.Procosys.Preservation.Command/ActionCommands/CloseAction/CloseActionCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/ActionCommands/CloseAction/CloseActionCommandValidator.cs
@@ -23,7 +23,7 @@ namespace Equinor.Procosys.Preservation.Command.ActionCommands.CloseAction
                 .WithMessage(command => $"Tag doesn't exist! Tag={command.TagId}")
                 .MustAsync((command, token) => NotBeAVoidedTagAsync(command.TagId, token))
                 .WithMessage(command => $"Tag is voided! Tag={command.TagId}")
-                .MustAsync((command, token) => BeAnExistingActionAsync(command.TagId, command.ActionId, token))
+                .MustAsync((command, token) => BeAnExistingActionAsync(command.ActionId, token))
                 .WithMessage(command => $"Action doesn't exist! Action={command.ActionId}")
                 .MustAsync((command, token) => NotBeAClosedActionAsync(command.ActionId, token))
                 .WithMessage(command => $"Action is closed! Action={command.ActionId}");
@@ -34,8 +34,8 @@ namespace Equinor.Procosys.Preservation.Command.ActionCommands.CloseAction
                 => await tagValidator.ExistsAsync(tagId, token);
             async Task<bool> NotBeAVoidedTagAsync(int tagId, CancellationToken token)
                 => !await tagValidator.IsVoidedAsync(tagId, token);
-            async Task<bool> BeAnExistingActionAsync(int tagId, int actionId, CancellationToken token)
-                => await actionValidator.ExistsAsync(tagId, actionId, token);
+            async Task<bool> BeAnExistingActionAsync(int actionId, CancellationToken token)
+                => await actionValidator.ExistsAsync(actionId, token);
             async Task<bool> NotBeAClosedActionAsync(int actionId, CancellationToken token)
                 => !await actionValidator.IsClosedAsync(actionId, token);
         }

--- a/src/Equinor.Procosys.Preservation.Command/ActionCommands/UpdateAction/UpdateActionCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/ActionCommands/UpdateAction/UpdateActionCommandValidator.cs
@@ -23,7 +23,7 @@ namespace Equinor.Procosys.Preservation.Command.ActionCommands.UpdateAction
                 .WithMessage(command => $"Tag doesn't exist! Tag={command.TagId}")
                 .MustAsync((command, token) => NotBeAVoidedTagAsync(command.TagId, token))
                 .WithMessage(command => $"Tag is voided! Tag={command.TagId}")
-                .MustAsync((command, token) => BeAnExistingActionAsync(command.TagId, command.ActionId, token))
+                .MustAsync((command, token) => BeAnExistingActionAsync(command.ActionId, token))
                 .WithMessage(command => $"Action doesn't exist! Action={command.ActionId}")
                 .MustAsync((command, token) => NotBeAClosedActionAsync(command.ActionId, token))
                 .WithMessage(command => $"Action is closed! Action={command.ActionId}");
@@ -34,8 +34,8 @@ namespace Equinor.Procosys.Preservation.Command.ActionCommands.UpdateAction
                 => await tagValidator.ExistsAsync(tagId, token);
             async Task<bool> NotBeAVoidedTagAsync(int tagId, CancellationToken token)
                 => !await tagValidator.IsVoidedAsync(tagId, token);
-            async Task<bool> BeAnExistingActionAsync(int tagId, int actionId, CancellationToken token)
-                => await actionValidator.ExistsAsync(tagId, actionId, token);
+            async Task<bool> BeAnExistingActionAsync(int actionId, CancellationToken token)
+                => await actionValidator.ExistsAsync(actionId, token);
             async Task<bool> NotBeAClosedActionAsync(int actionId, CancellationToken token)
                 => !await actionValidator.IsClosedAsync(actionId, token);
         }

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UpdateStep/UpdateStepCommand.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UpdateStep/UpdateStepCommand.cs
@@ -11,8 +11,8 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.UpdateStep
             Title = title;
             RowVersion = rowVersion;
         }
-        public int StepId { get; set; }
-        public string Title { get; set; }
-        public string RowVersion { get; set; }
+        public int StepId { get; }
+        public string Title { get; }
+        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/TagAttachmentCommands/Delete/DeleteTagAttachmentCommand.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagAttachmentCommands/Delete/DeleteTagAttachmentCommand.cs
@@ -1,0 +1,19 @@
+﻿using MediatR;
+using ServiceResult;
+
+namespace Equinor.Procosys.Preservation.Command.TagAttachmentCommands.Delete
+{
+    public class DeleteTagAttachmentCommand : IRequest<Result<Unit>>, ITagCommandRequest
+    {
+        public DeleteTagAttachmentCommand(int tagId, int attachmentId, string rowVersion)
+        {
+            TagId = tagId;
+            AttachmentId = attachmentId;
+            RowVersion = rowVersion;
+        }
+
+        public int TagId { get; }
+        public int AttachmentId { get; }
+        public string RowVersion { get; }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Command/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandHandler.cs
@@ -14,19 +14,16 @@ namespace Equinor.Procosys.Preservation.Command.TagAttachmentCommands.Delete
     {
         private readonly IProjectRepository _projectRepository;
         private readonly IUnitOfWork _unitOfWork;
-        private readonly IPlantProvider _plantProvider;
         private readonly IBlobStorage _blobStorage;
         private readonly IOptionsMonitor<AttachmentOptions> _attachmentOptions;
 
         public DeleteTagAttachmentCommandHandler(
             IProjectRepository projectRepository,
             IUnitOfWork unitOfWork,
-            IPlantProvider plantProvider,
             IBlobStorage blobStorage, IOptionsMonitor<AttachmentOptions> attachmentOptions)
         {
             _projectRepository = projectRepository;
             _unitOfWork = unitOfWork;
-            _plantProvider = plantProvider;
             _blobStorage = blobStorage;
             _attachmentOptions = attachmentOptions;
         }

--- a/src/Equinor.Procosys.Preservation.Command/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandHandler.cs
@@ -1,0 +1,52 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.BlobStorage;
+using Equinor.Procosys.Preservation.Domain;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
+using MediatR;
+using Microsoft.Extensions.Options;
+using ServiceResult;
+
+namespace Equinor.Procosys.Preservation.Command.TagAttachmentCommands.Delete
+{
+    public class DeleteTagAttachmentCommandHandler : IRequestHandler<DeleteTagAttachmentCommand, Result<Unit>>
+    {
+        private readonly IProjectRepository _projectRepository;
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly IPlantProvider _plantProvider;
+        private readonly IBlobStorage _blobStorage;
+        private readonly IOptionsMonitor<AttachmentOptions> _attachmentOptions;
+
+        public DeleteTagAttachmentCommandHandler(
+            IProjectRepository projectRepository,
+            IUnitOfWork unitOfWork,
+            IPlantProvider plantProvider,
+            IBlobStorage blobStorage, IOptionsMonitor<AttachmentOptions> attachmentOptions)
+        {
+            _projectRepository = projectRepository;
+            _unitOfWork = unitOfWork;
+            _plantProvider = plantProvider;
+            _blobStorage = blobStorage;
+            _attachmentOptions = attachmentOptions;
+        }
+
+        public async Task<Result<Unit>> Handle(DeleteTagAttachmentCommand request, CancellationToken cancellationToken)
+        {
+            var tag = await _projectRepository.GetTagByTagIdAsync(request.TagId);
+
+            var attachment = tag.Attachments.Single(a => a.Id == request.AttachmentId);
+            attachment.SetRowVersion(request.RowVersion);
+
+            var fullBlobPath = attachment.GetFullBlobPath(_attachmentOptions.CurrentValue.BlobContainer);
+
+            await _blobStorage.DeleteAsync(fullBlobPath, cancellationToken);
+            
+            tag.RemoveAttachment(attachment);
+
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+            return new SuccessResult<Unit>(Unit.Value);
+        }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Command/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandValidator.cs
@@ -1,0 +1,39 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.Validators.AttachmentValidators;
+using Equinor.Procosys.Preservation.Command.Validators.ProjectValidators;
+using Equinor.Procosys.Preservation.Command.Validators.TagValidators;
+using FluentValidation;
+
+namespace Equinor.Procosys.Preservation.Command.TagAttachmentCommands.Delete
+{
+    public class DeleteTagAttachmentCommandValidator : AbstractValidator<DeleteTagAttachmentCommand>
+    {
+        public DeleteTagAttachmentCommandValidator(
+            IProjectValidator projectValidator,
+            ITagValidator tagValidator,
+            IAttachmentValidator attachmentValidator)
+        {
+            CascadeMode = CascadeMode.StopOnFirstFailure;
+
+            RuleFor(command => command)
+                .MustAsync((command, token) => NotBeAClosedProjectForTagAsync(command.TagId, token))
+                .WithMessage(command => $"Project for tag is closed! Tag={command.TagId}")
+                .MustAsync((command, token) => BeAnExistingTagAsync(command.TagId, token))
+                .WithMessage(command => $"Tag doesn't exist! Tag={command.TagId}")
+                .MustAsync((command, token) => NotBeAVoidedTagAsync(command.TagId, token))
+                .WithMessage(command => $"Tag is voided! Tag={command.TagId}")
+                .MustAsync((command, token) => BeAnExistingAttachmentAsync(command.AttachmentId, token))
+                .WithMessage(command => $"Attachment doesn't exist! Attachment={command.AttachmentId}");
+
+            async Task<bool> NotBeAClosedProjectForTagAsync(int tagId, CancellationToken token)
+                => !await projectValidator.IsClosedForTagAsync(tagId, token);
+            async Task<bool> BeAnExistingTagAsync(int tagId, CancellationToken token)
+                => await tagValidator.ExistsAsync(tagId, token);
+            async Task<bool> NotBeAVoidedTagAsync(int tagId, CancellationToken token)
+                => !await tagValidator.IsVoidedAsync(tagId, token);
+            async Task<bool> BeAnExistingAttachmentAsync(int attachmentId, CancellationToken token)
+                => await attachmentValidator.AttachmentExistsAsync(attachmentId, token);
+        }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Command/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandValidator.cs
@@ -33,7 +33,7 @@ namespace Equinor.Procosys.Preservation.Command.TagAttachmentCommands.Delete
             async Task<bool> NotBeAVoidedTagAsync(int tagId, CancellationToken token)
                 => !await tagValidator.IsVoidedAsync(tagId, token);
             async Task<bool> BeAnExistingAttachmentAsync(int attachmentId, CancellationToken token)
-                => await attachmentValidator.AttachmentExistsAsync(attachmentId, token);
+                => await attachmentValidator.ExistsAsync(attachmentId, token);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/Validators/ActionValidators/ActionValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/ActionValidators/ActionValidator.cs
@@ -13,10 +13,9 @@ namespace Equinor.Procosys.Preservation.Command.Validators.ActionValidators
 
         public ActionValidator(IReadOnlyContext context) => _context = context;
 
-        public async Task<bool> ExistsAsync(int tagId, int actionId, CancellationToken token) =>
+        public async Task<bool> ExistsAsync(int actionId, CancellationToken token) =>
             await (from a in _context.QuerySet<Action>()
-                join t in _context.QuerySet<Tag>() on EF.Property<int>(a, "TagId") equals t.Id
-                where a.Id == actionId && t.Id == tagId
+                where a.Id == actionId
                 select a).AnyAsync(token);
 
         public async Task<bool> IsClosedAsync(int actionId, CancellationToken token)
@@ -24,7 +23,7 @@ namespace Equinor.Procosys.Preservation.Command.Validators.ActionValidators
             var action = await (from a in _context.QuerySet<Action>()
                           where a.Id == actionId
                           select a).SingleOrDefaultAsync(token);
-            return action?.ClosedAtUtc != null;
+            return action != null && action.IsClosed;
         }
 
         public async Task<bool> AttachmentWithFilenameExistsAsync(int actionId, string fileName, CancellationToken token)

--- a/src/Equinor.Procosys.Preservation.Command/Validators/ActionValidators/IActionValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/ActionValidators/IActionValidator.cs
@@ -5,7 +5,7 @@ namespace Equinor.Procosys.Preservation.Command.Validators.ActionValidators
 {
     public interface IActionValidator
     {
-        Task<bool> ExistsAsync(int tagId, int actionId, CancellationToken token);
+        Task<bool> ExistsAsync(int actionId, CancellationToken token);
         Task<bool> IsClosedAsync(int actionId, CancellationToken token);
         Task<bool> AttachmentWithFilenameExistsAsync(int actionId, string fileName, CancellationToken token);
     }

--- a/src/Equinor.Procosys.Preservation.Command/Validators/AttachmentValidators/AttachmentValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/AttachmentValidators/AttachmentValidator.cs
@@ -1,0 +1,21 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equinor.Procosys.Preservation.Command.Validators.AttachmentValidators
+{
+    public class AttachmentValidator : IAttachmentValidator
+    {
+        private readonly IReadOnlyContext _context;
+
+        public AttachmentValidator(IReadOnlyContext context) => _context = context;
+
+        // unit tests
+        public async Task<bool> AttachmentExistsAsync(int attachmentId, CancellationToken token) =>
+            await (from a in _context.QuerySet<Attachment>()
+                where a.Id == attachmentId
+                select a).AnyAsync(token);
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Command/Validators/AttachmentValidators/AttachmentValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/AttachmentValidators/AttachmentValidator.cs
@@ -12,8 +12,8 @@ namespace Equinor.Procosys.Preservation.Command.Validators.AttachmentValidators
 
         public AttachmentValidator(IReadOnlyContext context) => _context = context;
 
-        // unit tests
-        public async Task<bool> AttachmentExistsAsync(int attachmentId, CancellationToken token) =>
+        // todo unit tests
+        public async Task<bool> ExistsAsync(int attachmentId, CancellationToken token) =>
             await (from a in _context.QuerySet<Attachment>()
                 where a.Id == attachmentId
                 select a).AnyAsync(token);

--- a/src/Equinor.Procosys.Preservation.Command/Validators/AttachmentValidators/AttachmentValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/AttachmentValidators/AttachmentValidator.cs
@@ -12,7 +12,6 @@ namespace Equinor.Procosys.Preservation.Command.Validators.AttachmentValidators
 
         public AttachmentValidator(IReadOnlyContext context) => _context = context;
 
-        // todo unit tests
         public async Task<bool> ExistsAsync(int attachmentId, CancellationToken token) =>
             await (from a in _context.QuerySet<Attachment>()
                 where a.Id == attachmentId

--- a/src/Equinor.Procosys.Preservation.Command/Validators/AttachmentValidators/IAttachmentValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/AttachmentValidators/IAttachmentValidator.cs
@@ -5,6 +5,6 @@ namespace Equinor.Procosys.Preservation.Command.Validators.AttachmentValidators
 {
     public interface IAttachmentValidator
     {
-        Task<bool> AttachmentExistsAsync(int attachmentId, CancellationToken token);
+        Task<bool> ExistsAsync(int attachmentId, CancellationToken token);
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/Validators/AttachmentValidators/IAttachmentValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/AttachmentValidators/IAttachmentValidator.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Equinor.Procosys.Preservation.Command.Validators.AttachmentValidators
+{
+    public interface IAttachmentValidator
+    {
+        Task<bool> AttachmentExistsAsync(int attachmentId, CancellationToken token);
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/Tag.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/Tag.cs
@@ -176,6 +176,22 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate
 
             _attachments.Add(attachment);
         }
+        
+        // todo unit test
+        public void RemoveAttachment(TagAttachment attachment)
+        {
+            if (attachment == null)
+            {
+                throw new ArgumentNullException(nameof(attachment));
+            }
+            
+            if (attachment.Plant != Plant)
+            {
+                throw new ArgumentException($"Can't remove item in {attachment.Plant} from item in {Plant}");
+            }
+
+            _attachments.Remove(attachment);
+        }
 
         public void StartPreservation()
         {

--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/Tag.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/Tag.cs
@@ -177,7 +177,6 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate
             _attachments.Add(attachment);
         }
         
-        // todo unit test
         public void RemoveAttachment(TagAttachment attachment)
         {
             if (attachment == null)

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/ActionConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/ActionConfiguration.cs
@@ -37,8 +37,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
             builder
                 .HasMany(x => x.Attachments)
                 .WithOne()
-                .IsRequired()
-                .OnDelete(DeleteBehavior.NoAction);
+                .IsRequired();
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/TagConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/TagConfiguration.cs
@@ -77,8 +77,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
             builder
                 .HasMany(x => x.Attachments)
                 .WithOne()
-                .IsRequired()
-                .OnDelete(DeleteBehavior.NoAction);
+                .IsRequired();
 
             builder.Property(f => f.Status)
                 .HasConversion<string>()

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200513192113_CascadeModeDeleteOnAttachments.Designer.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200513192113_CascadeModeDeleteOnAttachments.Designer.cs
@@ -4,14 +4,16 @@ using Equinor.Procosys.Preservation.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Equinor.Procosys.Preservation.Infrastructure.Migrations
 {
     [DbContext(typeof(PreservationContext))]
-    partial class PreservationContextModelSnapshot : ModelSnapshot
+    [Migration("20200513192113_CascadeModeDeleteOnAttachments")]
+    partial class CascadeModeDeleteOnAttachments
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200513192113_CascadeModeDeleteOnAttachments.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200513192113_CascadeModeDeleteOnAttachments.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Equinor.Procosys.Preservation.Infrastructure.Migrations
+{
+    public partial class CascadeModeDeleteOnAttachments : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Attachments_Actions_ActionId",
+                table: "Attachments");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Attachments_Tags_TagId",
+                table: "Attachments");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Attachments_Actions_ActionId",
+                table: "Attachments",
+                column: "ActionId",
+                principalTable: "Actions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Attachments_Tags_TagId",
+                table: "Attachments",
+                column: "TagId",
+                principalTable: "Tags",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Attachments_Actions_ActionId",
+                table: "Attachments");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Attachments_Tags_TagId",
+                table: "Attachments");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Attachments_Actions_ActionId",
+                table: "Attachments",
+                column: "ActionId",
+                principalTable: "Actions",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Attachments_Tags_TagId",
+                table: "Attachments",
+                column: "TagId",
+                principalTable: "Tags",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Query/GetActionAttachments/ActionAttachmentDto.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetActionAttachments/ActionAttachmentDto.cs
@@ -2,13 +2,15 @@
 {
     public class ActionAttachmentDto
     {
-        public ActionAttachmentDto(int id, string fileName)
+        public ActionAttachmentDto(int id, string fileName, string rowVersion)
         {
             Id = id;
             FileName = fileName;
+            RowVersion = rowVersion;
         }
 
         public int Id { get; }
         public string FileName { get; }
+        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Query/GetActionAttachments/GetActionAttachmentsQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetActionAttachments/GetActionAttachmentsQueryHandler.cs
@@ -36,7 +36,8 @@ namespace Equinor.Procosys.Preservation.Query.GetActionAttachments
                 .Attachments
                 .Select(attachment => new ActionAttachmentDto(
                     attachment.Id,
-                    attachment.FileName)).ToList();
+                    attachment.FileName,
+                    attachment.RowVersion.ConvertToString())).ToList();
             
             return new SuccessResult<List<ActionAttachmentDto>>(attachments);
         }

--- a/src/Equinor.Procosys.Preservation.Query/GetTagAttachments/GetTagAttachmentsQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetTagAttachments/GetTagAttachmentsQueryHandler.cs
@@ -32,7 +32,11 @@ namespace Equinor.Procosys.Preservation.Query.GetTagAttachments
 
             var attachments = tag
                 .Attachments
-                .Select(attachment => new TagAttachmentDto(attachment.Id, attachment.FileName)).ToList();
+                .Select(attachment 
+                    => new TagAttachmentDto(
+                        attachment.Id,
+                        attachment.FileName,
+                        attachment.RowVersion.ConvertToString())).ToList();
             
             return new SuccessResult<List<TagAttachmentDto>>(attachments);
         }

--- a/src/Equinor.Procosys.Preservation.Query/GetTagAttachments/TagAttachmentDto.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetTagAttachments/TagAttachmentDto.cs
@@ -2,13 +2,15 @@
 {
     public class TagAttachmentDto
     {
-        public TagAttachmentDto(int id, string fileName)
+        public TagAttachmentDto(int id, string fileName, string rowVersion)
         {
             Id = id;
             FileName = fileName;
+            RowVersion = rowVersion;
         }
 
         public int Id { get; }
         public string FileName { get; }
+        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Tags/DeleteTagAttachmentDto.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Tags/DeleteTagAttachmentDto.cs
@@ -1,0 +1,7 @@
+﻿namespace Equinor.Procosys.Preservation.WebApi.Controllers.Tags
+{
+    public class DeleteTagAttachmentDto
+    {
+        public string RowVersion { get; set; }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Tags/TagsController.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Tags/TagsController.cs
@@ -38,6 +38,7 @@ using ServiceResult.ApiExtensions;
 using RequirementDto = Equinor.Procosys.Preservation.Query.GetTagRequirements.RequirementDto;
 using RequirementPreserveCommand = Equinor.Procosys.Preservation.Command.RequirementCommands.Preserve.PreserveCommand;
 using Equinor.Procosys.Preservation.Command.ActionCommands.CloseAction;
+using Equinor.Procosys.Preservation.Command.TagAttachmentCommands.Delete;
 
 namespace Equinor.Procosys.Preservation.WebApi.Controllers.Tags
 {
@@ -132,13 +133,13 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Tags
             [FromRoute] int id,
             [FromBody] CreateActionDto dto)
         {
-            var actionCommand = new CreateActionCommand(
+            var command = new CreateActionCommand(
                     id,
                     dto.Title,
                     dto.Description,
                     dto.DueTimeUtc);
 
-            var result = await _mediator.Send(actionCommand);
+            var result = await _mediator.Send(command);
 
             return this.FromResult(result);
         }
@@ -154,7 +155,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Tags
             [FromRoute] int actionId,
             [FromBody] UpdateActionDto dto)
         {
-                var actionCommand = new UpdateActionCommand(
+                var command = new UpdateActionCommand(
                                   id,
                                   actionId,
                                   dto.Title,
@@ -162,7 +163,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Tags
                                   dto.DueTimeUtc,
                                   dto.RowVersion);
 
-                var result = await _mediator.Send(actionCommand);
+                var result = await _mediator.Send(command);
 
                 return this.FromResult(result);
         }
@@ -178,12 +179,12 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Tags
             [FromRoute] int actionId,
             [FromBody] CloseActionDto dto)
         {
-            var actionCommand = new CloseActionCommand(
+            var command = new CloseActionCommand(
                 id,
                 actionId,
                 dto.RowVersion);
 
-            var result = await _mediator.Send(actionCommand);
+            var result = await _mediator.Send(command);
 
             return this.FromResult(result);
         }
@@ -202,7 +203,6 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Tags
             return this.FromResult(result);
         }
 
-        
         [Authorize(Roles = Permissions.PRESERVATION_ATTACHFILE)]
         [HttpPost("{id}/Actions/{actionId}/Attachments")]
         public async Task<ActionResult<int>> UploadActionAttachment(
@@ -216,14 +216,14 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Tags
         {
             await using var stream = dto.File.OpenReadStream();
 
-            var actionCommand = new UploadActionAttachmentCommand(
+            var command = new UploadActionAttachmentCommand(
                 id,
                 actionId,
                 dto.File.FileName,
                 dto.OverwriteIfExists,
                 stream);
 
-            var result = await _mediator.Send(actionCommand);
+            var result = await _mediator.Send(command);
             return this.FromResult(result);
         }
 
@@ -504,6 +504,26 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Tags
                 dto.File.FileName,
                 dto.OverwriteIfExists,
                 stream);
+
+            var result = await _mediator.Send(actionCommand);
+            return this.FromResult(result);
+        }
+
+        [Authorize(Roles = Permissions.PRESERVATION_DETACHFILE)]
+        [HttpDelete("{id}/Attachments/{attachmentId}")]
+        public async Task<ActionResult<int>> DeleteTagAttachment(
+            [FromHeader(Name = PlantProvider.PlantHeader)]
+            [Required]
+            [StringLength(PlantEntityBase.PlantLengthMax, MinimumLength = PlantEntityBase.PlantLengthMin)]
+            string plant,
+            [FromRoute] int id,
+            [FromRoute] int attachmentId,
+            [FromBody] DeleteTagAttachmentDto dto)
+        {
+            var actionCommand = new DeleteTagAttachmentCommand(
+                id,
+                attachmentId,
+                dto.RowVersion);
 
             var result = await _mediator.Send(actionCommand);
             return this.FromResult(result);

--- a/src/Equinor.Procosys.Preservation.WebApi/DiModules/ApplicationModule.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/DiModules/ApplicationModule.cs
@@ -1,6 +1,7 @@
 ﻿using Equinor.Procosys.Preservation.BlobStorage;
 using Equinor.Procosys.Preservation.Command.EventHandlers;
 using Equinor.Procosys.Preservation.Command.Validators.ActionValidators;
+using Equinor.Procosys.Preservation.Command.Validators.AttachmentValidators;
 using Equinor.Procosys.Preservation.Command.Validators.FieldValidators;
 using Equinor.Procosys.Preservation.Command.Validators.JourneyValidators;
 using Equinor.Procosys.Preservation.Command.Validators.ModeValidators;
@@ -106,6 +107,7 @@ namespace Equinor.Procosys.Preservation.WebApi.DIModules
             services.AddScoped<IResponsibleValidator, ResponsibleValidator>();
             services.AddScoped<IFieldValidator, FieldValidator>();
             services.AddScoped<IActionValidator, ActionValidator>();
+            services.AddScoped<IAttachmentValidator, AttachmentValidator>();
 
             // Singleton - Created the first time they are requested
             services.AddSingleton<ICacheManager, CacheManager>();

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionAttachmentCommands/Upload/UploadActionAttachmentCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionAttachmentCommands/Upload/UploadActionAttachmentCommandValidatorTests.cs
@@ -18,9 +18,9 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionAttachmentCommands.U
         private Mock<IActionValidator> _actionValidatorMock;
         private UploadActionAttachmentCommand _commandWithoutOverwrite;
 
-        private const int TagId = 2;
-        private const int ActionId = 3;
-        private const string FileName = "A.txt";
+        private readonly int _tagId = 2;
+        private readonly int _actionId = 3;
+        private readonly string _fileName = "A.txt";
 
         [TestInitialize]
         public void Setup_OkState()
@@ -28,12 +28,12 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionAttachmentCommands.U
             _projectValidatorMock = new Mock<IProjectValidator>();
 
             _tagValidatorMock = new Mock<ITagValidator>();
-            _tagValidatorMock.Setup(r => r.ExistsAsync(TagId, default)).Returns(Task.FromResult(true));
+            _tagValidatorMock.Setup(r => r.ExistsAsync(_tagId, default)).Returns(Task.FromResult(true));
 
             _actionValidatorMock = new Mock<IActionValidator>();
-            _actionValidatorMock.Setup(r => r.ExistsAsync(TagId, ActionId, default)).Returns(Task.FromResult(true));
+            _actionValidatorMock.Setup(r => r.ExistsAsync(_actionId, default)).Returns(Task.FromResult(true));
 
-            _commandWithoutOverwrite = new UploadActionAttachmentCommand(TagId, ActionId, FileName, false, new MemoryStream());
+            _commandWithoutOverwrite = new UploadActionAttachmentCommand(_tagId, _actionId, _fileName, false, new MemoryStream());
 
             _dut = new UploadActionAttachmentCommandValidator(_projectValidatorMock.Object, _tagValidatorMock.Object, _actionValidatorMock.Object);
         }
@@ -98,7 +98,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionAttachmentCommands.U
         [TestMethod]
         public void Validate_ShouldBeValid_WhenFilenameExistsAndOverwrite()
         {
-            var commandWithOverwrite = new UploadActionAttachmentCommand(TagId, ActionId, FileName, true, new MemoryStream());
+            var commandWithOverwrite = new UploadActionAttachmentCommand(_tagId, _actionId, _fileName, true, new MemoryStream());
             _tagValidatorMock.Setup(r => r.AttachmentWithFilenameExistsAsync(commandWithOverwrite.TagId, commandWithOverwrite.FileName, default))
                 .Returns(Task.FromResult(true));
 
@@ -110,7 +110,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionAttachmentCommands.U
         [TestMethod]
         public void Validate_ShouldFail_WhenActionIsClosed()
         {
-            _actionValidatorMock.Setup(r => r.IsClosedAsync(ActionId, default)).Returns(Task.FromResult(true));
+            _actionValidatorMock.Setup(r => r.IsClosedAsync(_actionId, default)).Returns(Task.FromResult(true));
 
             var result = _dut.Validate(_commandWithoutOverwrite);
 
@@ -122,7 +122,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionAttachmentCommands.U
         [TestMethod]
         public void Validate_ShouldFail_WhenActionNotExists()
         {
-            _actionValidatorMock.Setup(r => r.ExistsAsync(TagId, ActionId, default)).Returns(Task.FromResult(false));
+            _actionValidatorMock.Setup(r => r.ExistsAsync(_actionId, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_commandWithoutOverwrite);
 

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionCommands/CloseAction/CloseActionCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionCommands/CloseAction/CloseActionCommandValidatorTests.cs
@@ -29,7 +29,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionCommands.CloseAction
             _tagValidatorMock.Setup(r => r.ExistsAsync(_tagId, default)).Returns(Task.FromResult(true));
 
             _actionValidatorMock = new Mock<IActionValidator>();
-            _actionValidatorMock.Setup(r => r.ExistsAsync(_tagId, _actionId, default)).Returns(Task.FromResult(true));
+            _actionValidatorMock.Setup(r => r.ExistsAsync(_actionId, default)).Returns(Task.FromResult(true));
 
             _command = new CloseActionCommand(_tagId, _actionId, null);
 
@@ -99,7 +99,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionCommands.CloseAction
         [TestMethod]
         public void Validate_ShouldFail_WhenActionNotExists()
         {
-            _actionValidatorMock.Setup(r => r.ExistsAsync(_tagId, _actionId, default)).Returns(Task.FromResult(false));
+            _actionValidatorMock.Setup(r => r.ExistsAsync(_actionId, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionCommands/CreateAction/CreateActionCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionCommands/CreateAction/CreateActionCommandHandlerTests.cs
@@ -18,7 +18,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionCommands.CreateActio
         private readonly string _description = "ActionDescription";
         private readonly DateTime _dueTimeUtc = new DateTime(2020, 1, 1, 1, 1, 1, DateTimeKind.Utc);
 
-        private TagRequirement _requirement;
         private Tag _tag;
         private CreateActionCommand _command;
         private CreateActionCommandHandler _dut;
@@ -39,8 +38,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionCommands.CreateActio
             _rdMock.SetupGet(rd => rd.Id).Returns(_rdId1);
             _rdMock.SetupGet(rd => rd.Plant).Returns(TestPlant);
 
-            _requirement = new TagRequirement(TestPlant, _intervalWeeks, _rdMock.Object);
-            _tag = new Tag(TestPlant, TagType.Standard, "", "", stepMock.Object, new List<TagRequirement> { _requirement });
+            var requirement = new TagRequirement(TestPlant, _intervalWeeks, _rdMock.Object);
+            _tag = new Tag(TestPlant, TagType.Standard, "", "", stepMock.Object, new List<TagRequirement> { requirement });
 
             _projectRepositoryMock
                 .Setup(r => r.GetTagByTagIdAsync(_tagId))

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionCommands/UpdateAction/UpdateActionCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionCommands/UpdateAction/UpdateActionCommandValidatorTests.cs
@@ -29,7 +29,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionCommands.UpdateActio
             _tagValidatorMock.Setup(r => r.ExistsAsync(_tagId, default)).Returns(Task.FromResult(true));
 
             _actionValidatorMock = new Mock<IActionValidator>();
-            _actionValidatorMock.Setup(r => r.ExistsAsync(_tagId, _actionId, default)).Returns(Task.FromResult(true));
+            _actionValidatorMock.Setup(r => r.ExistsAsync(_actionId, default)).Returns(Task.FromResult(true));
 
             _command = new UpdateActionCommand(
                 _tagId,
@@ -105,7 +105,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionCommands.UpdateActio
         [TestMethod]
         public void Validate_ShouldFail_WhenActionNotExists()
         {
-            _actionValidatorMock.Setup(r => r.ExistsAsync(_tagId, _actionId, default)).Returns(Task.FromResult(false));
+            _actionValidatorMock.Setup(r => r.ExistsAsync(_actionId, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandHandlerTests.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.BlobStorage;
+using Equinor.Procosys.Preservation.Command.TagAttachmentCommands.Delete;
+using Equinor.Procosys.Preservation.Domain;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
+using Equinor.Procosys.Preservation.Test.Common.ExtensionMethods;
+using MediatR;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Equinor.Procosys.Preservation.Command.Tests.TagAttachmentCommands.Delete
+{
+    [TestClass]
+    public class DeleteTagAttachmentCommandHandlerTests : CommandHandlerTestsBase
+    {
+        private const string BlobContainer = "bc";
+        private readonly string _rowVersion = "AAAAAAAAABA=";
+
+        private DeleteTagAttachmentCommand _command;
+        private DeleteTagAttachmentCommandHandler _dut;
+
+        private Mock<IProjectRepository> _projectRepositoryMock;
+        private Mock<IBlobStorage> _blobStorageMock;
+        private Tag _tag;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _command = new DeleteTagAttachmentCommand(1, 3, _rowVersion);
+
+            _projectRepositoryMock = new Mock<IProjectRepository>();
+            _blobStorageMock = new Mock<IBlobStorage>();
+
+            var attachmentOptionsMock = new Mock<IOptionsMonitor<AttachmentOptions>>();
+            var options = new AttachmentOptions
+            {
+                MaxSizeKb = 2,
+                BlobContainer = BlobContainer,
+                ValidFileSuffixes = new[] {".gif", ".jpg"}
+            };
+            attachmentOptionsMock
+                .Setup(x => x.CurrentValue)
+                .Returns(options);
+
+            var stepMock = new Mock<Step>();
+            stepMock.SetupGet(s => s.Plant).Returns(TestPlant);
+
+            var reqMock = new Mock<TagRequirement>();
+            reqMock.SetupGet(s => s.Plant).Returns(TestPlant);
+
+            _tag = new Tag(TestPlant, TagType.Standard, "", "", stepMock.Object, new List<TagRequirement> { reqMock.Object });
+
+            var attachment = new TagAttachment(TestPlant, Guid.Empty, "Fil.txt");
+            attachment.SetProtectedIdForTesting(_command.AttachmentId);
+            _tag.AddAttachment(attachment);
+
+            _projectRepositoryMock
+                .Setup(r => r.GetTagByTagIdAsync(_command.TagId))
+                .Returns(Task.FromResult(_tag));
+
+            _dut = new DeleteTagAttachmentCommandHandler(
+                _projectRepositoryMock.Object,
+                UnitOfWorkMock.Object,
+                _blobStorageMock.Object,
+                attachmentOptionsMock.Object);
+        }
+
+        [TestMethod]
+        public async Task HandlingDeleteTagAttachmentCommand_ShouldDeleteAttachmentFromTag_WhenExists()
+        {
+            // Arrange
+            Assert.AreEqual(1, _tag.Attachments.Count);
+
+            // Act
+            var result = await _dut.Handle(_command, default);
+
+            // Assert
+            Assert.AreEqual(0, result.Errors.Count);
+            Assert.AreEqual(Unit.Value, result.Data);
+            Assert.AreEqual(0, _tag.Attachments.Count);
+        }
+
+        [TestMethod]
+        public async Task HandlingDeleteTagAttachmentCommand_ShouldSave()
+        {
+            // Act
+            await _dut.Handle(_command, default);
+
+            // Assert
+            UnitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task HandlingDeleteTagAttachmentCommand_ShouldDeleteFromBlobStorage()
+        {
+            // Arrange
+            var attachment = _tag.Attachments.Single();
+            var p = attachment.GetFullBlobPath(BlobContainer);
+
+            // Act
+            await _dut.Handle(_command, default);
+
+            // Assert
+            _blobStorageMock.Verify(b  => b.DeleteAsync(p, default), Times.Once);
+        }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandValidatorTests.cs
@@ -1,0 +1,95 @@
+﻿using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.TagAttachmentCommands.Delete;
+using Equinor.Procosys.Preservation.Command.Validators.AttachmentValidators;
+using Equinor.Procosys.Preservation.Command.Validators.ProjectValidators;
+using Equinor.Procosys.Preservation.Command.Validators.TagValidators;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Equinor.Procosys.Preservation.Command.Tests.TagAttachmentCommands.Delete
+{
+    [TestClass]
+    public class DeleteTagAttachmentCommandValidatorTests
+    {
+        private DeleteTagAttachmentCommandValidator _dut;
+        private Mock<IProjectValidator> _projectValidatorMock;
+        private Mock<ITagValidator> _tagValidatorMock;
+        private Mock<IAttachmentValidator> _attachmentValidatorMock;
+        private DeleteTagAttachmentCommand _command;
+
+        [TestInitialize]
+        public void Setup_OkState()
+        {
+            _projectValidatorMock = new Mock<IProjectValidator>();
+
+            _command = new DeleteTagAttachmentCommand(2, 3, "AAAAAAAAABA=");
+
+            _tagValidatorMock = new Mock<ITagValidator>();
+            _tagValidatorMock.Setup(r => r.ExistsAsync(_command.TagId, default)).Returns(Task.FromResult(true));
+
+            _attachmentValidatorMock = new Mock<IAttachmentValidator>();
+            _attachmentValidatorMock.Setup(r => r.ExistsAsync(_command.AttachmentId, default)).Returns(Task.FromResult(true));
+
+            _dut = new DeleteTagAttachmentCommandValidator(
+                _projectValidatorMock.Object,
+                _tagValidatorMock.Object,
+                _attachmentValidatorMock.Object);
+        }
+
+        [TestMethod]
+        public void Validate_ShouldBeValid_WhenOkState()
+        {
+            var result = _dut.Validate(_command); 
+
+            Assert.IsTrue(result.IsValid);
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenProjectForTagIsClosed()
+        {
+            _projectValidatorMock.Setup(r => r.IsClosedForTagAsync(_command.TagId, default)).Returns(Task.FromResult(true));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Project for tag is closed!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenTagNotExists()
+        {
+            _tagValidatorMock.Setup(r => r.ExistsAsync(_command.TagId, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Tag doesn't exist!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenAttachmentNotExists()
+        {
+            _attachmentValidatorMock.Setup(r => r.ExistsAsync(_command.AttachmentId, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Attachment doesn't exist!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenTagIsVoided()
+        {
+            _tagValidatorMock.Setup(r => r.IsVoidedAsync(_command.TagId, default)).Returns(Task.FromResult(true));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Tag is voided!"));
+        }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandValidatorTests.cs
@@ -22,7 +22,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagAttachmentCommands.Dele
         {
             _projectValidatorMock = new Mock<IProjectValidator>();
 
-            _command = new DeleteTagAttachmentCommand(2, 3, "AAAAAAAAABA=");
+            _command = new DeleteTagAttachmentCommand(2, 3, null);
 
             _tagValidatorMock = new Mock<ITagValidator>();
             _tagValidatorMock.Setup(r => r.ExistsAsync(_command.TagId, default)).Returns(Task.FromResult(true));

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagAttachmentCommands/Upload/UploadTagAttachmentCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagAttachmentCommands/Upload/UploadTagAttachmentCommandValidatorTests.cs
@@ -16,18 +16,17 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagAttachmentCommands.Uplo
         private Mock<ITagValidator> _tagValidatorMock;
         private UploadTagAttachmentCommand _commandWithoutOverwrite;
 
-        private const int TagId = 2;
         private const string FileName = "A.txt";
 
         [TestInitialize]
         public void Setup_OkState()
         {
+            _commandWithoutOverwrite = new UploadTagAttachmentCommand(2, FileName, false, new MemoryStream());
+
             _projectValidatorMock = new Mock<IProjectValidator>();
 
             _tagValidatorMock = new Mock<ITagValidator>();
-            _tagValidatorMock.Setup(r => r.ExistsAsync(TagId, default)).Returns(Task.FromResult(true));
-
-            _commandWithoutOverwrite = new UploadTagAttachmentCommand(TagId, FileName, false, new MemoryStream());
+            _tagValidatorMock.Setup(r => r.ExistsAsync(_commandWithoutOverwrite.TagId, default)).Returns(Task.FromResult(true));
 
             _dut = new UploadTagAttachmentCommandValidator(_projectValidatorMock.Object, _tagValidatorMock.Object);
         }
@@ -92,7 +91,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagAttachmentCommands.Uplo
         [TestMethod]
         public void Validate_ShouldBeValid_WhenFilenameExistsAndOverwrite()
         {
-            var commandWithOverwrite = new UploadTagAttachmentCommand(TagId, FileName, true, new MemoryStream());
+            var commandWithOverwrite = new UploadTagAttachmentCommand(2, FileName, true, new MemoryStream());
             _tagValidatorMock.Setup(r => r.AttachmentWithFilenameExistsAsync(commandWithOverwrite.TagId, commandWithOverwrite.FileName, default))
                 .Returns(Task.FromResult(true));
 

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagAttachmentCommands/Upload/UploadTagAttachmentCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagAttachmentCommands/Upload/UploadTagAttachmentCommandValidatorTests.cs
@@ -16,12 +16,12 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagAttachmentCommands.Uplo
         private Mock<ITagValidator> _tagValidatorMock;
         private UploadTagAttachmentCommand _commandWithoutOverwrite;
 
-        private const string FileName = "A.txt";
+        private readonly string _fileName = "A.txt";
 
         [TestInitialize]
         public void Setup_OkState()
         {
-            _commandWithoutOverwrite = new UploadTagAttachmentCommand(2, FileName, false, new MemoryStream());
+            _commandWithoutOverwrite = new UploadTagAttachmentCommand(2, _fileName, false, new MemoryStream());
 
             _projectValidatorMock = new Mock<IProjectValidator>();
 
@@ -91,7 +91,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagAttachmentCommands.Uplo
         [TestMethod]
         public void Validate_ShouldBeValid_WhenFilenameExistsAndOverwrite()
         {
-            var commandWithOverwrite = new UploadTagAttachmentCommand(2, FileName, true, new MemoryStream());
+            var commandWithOverwrite = new UploadTagAttachmentCommand(2, _fileName, true, new MemoryStream());
             _tagValidatorMock.Setup(r => r.AttachmentWithFilenameExistsAsync(commandWithOverwrite.TagId, commandWithOverwrite.FileName, default))
                 .Returns(Task.FromResult(true));
 

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/ActionValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/ActionValidatorTests.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.Validators.ActionValidators;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
+using Equinor.Procosys.Preservation.Infrastructure;
+using Equinor.Procosys.Preservation.Test.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Action = Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate.Action;
+
+namespace Equinor.Procosys.Preservation.Command.Tests.Validators
+{
+    [TestClass]
+    public class ActionValidatorTests : ReadOnlyTestsBase
+    {
+        private int _actionId;
+        private readonly string _filename = "fil.txt";
+
+        protected override void SetupNewDatabase(DbContextOptions<PreservationContext> dbContextOptions)
+        {
+            using (var context = new PreservationContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var project = AddProject(context, "P", "Project description");
+                var journey = AddJourneyWithStep(context, "J", "S1", AddMode(context, "M1"), AddResponsible(context, "R1"));
+                var rd = AddRequirementTypeWith1DefWithoutField(context, "Rot", "D").RequirementDefinitions.First();
+
+                var tag = AddTag(context, project, TagType.Standard, "TagNo", "Tag description", journey.Steps.First(),
+                    new List<TagRequirement> {new TagRequirement(TestPlant, 2, rd)});
+
+                var action = new Action(TestPlant, "A", "D", null);
+                tag.AddAction(action);
+
+                var attachment = new ActionAttachment(TestPlant, Guid.Empty, _filename);
+                action.AddAttachment(attachment);
+
+                context.SaveChangesAsync().Wait();
+
+                _actionId = action.Id;
+            }
+        }
+
+        [TestMethod]
+        public async Task ExistsAsync_KnownIds_ReturnsTrue()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new ActionValidator(context);
+                var result = await dut.ExistsAsync(_actionId, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task ExistsAsync_UnknownActionId_ReturnsFalse()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new ActionValidator(context);
+                var result = await dut.ExistsAsync(123456, default);
+                Assert.IsFalse(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task IsClosedAsync_KnownId_ReturnsFalse_WhenNotClosed()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new ActionValidator(context);
+                var result = await dut.IsClosedAsync(_actionId, default);
+                Assert.IsFalse(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task IsClosedAsync_KnownId_ReturnsTrue_WhenClosed()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var action = context.Actions.Single(a => a.Id == _actionId);
+                action.Close(DateTime.UtcNow, context.Persons.Single(p => p.Oid == _currentUserOid));
+                context.SaveChangesAsync().Wait();
+            }
+
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new ActionValidator(context);
+                var result = await dut.IsClosedAsync(_actionId, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task IsClosedAsync_UnknownActionId_ReturnsFalse()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new ActionValidator(context);
+                var result = await dut.IsClosedAsync(123456, default);
+                Assert.IsFalse(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task AttachmentWithFilenameExistsAsync_KnownFile_ReturnsTrue()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new ActionValidator(context);
+                var result = await dut.AttachmentWithFilenameExistsAsync(_actionId, _filename, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task AttachmentWithFilenameExistsAsync_UnknownFile_ReturnsFalse()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new ActionValidator(context);
+                var result = await dut.AttachmentWithFilenameExistsAsync(_actionId, "X", default);
+                Assert.IsFalse(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task AttachmentWithFilenameExistsAsync_UnknownActionId_ReturnsFalse()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new ActionValidator(context);
+                var result = await dut.AttachmentWithFilenameExistsAsync(123456, _filename, default);
+                Assert.IsFalse(result);
+            }
+        }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/AttachmentValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/AttachmentValidatorTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.Validators.AttachmentValidators;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
+using Equinor.Procosys.Preservation.Infrastructure;
+using Equinor.Procosys.Preservation.Test.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.Procosys.Preservation.Command.Tests.Validators
+{
+    [TestClass]
+    public class AttachmentValidatorTests : ReadOnlyTestsBase
+    {
+        private int _attachmentId;
+                
+        protected override void SetupNewDatabase(DbContextOptions<PreservationContext> dbContextOptions)
+        {
+            using (var context = new PreservationContext(dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var project = AddProject(context, "P", "Project description");
+                var journey = AddJourneyWithStep(context, "J", "S1", AddMode(context, "M1"), AddResponsible(context, "R1"));
+                var rd = AddRequirementTypeWith1DefWithoutField(context, "Rot", "D").RequirementDefinitions.First();
+
+                var tag = AddTag(context, project, TagType.Standard, "TagNo", "Tag description", journey.Steps.First(),
+                    new List<TagRequirement> {new TagRequirement(TestPlant, 2, rd)});
+
+                var attachment = new TagAttachment(TestPlant, Guid.Empty, "F");
+                tag.AddAttachment(attachment);
+                context.SaveChangesAsync().Wait();
+
+                _attachmentId = attachment.Id;
+            }
+        }
+
+        [TestMethod]
+        public async Task ExistsAsync_KnownId_ReturnsTrue()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new AttachmentValidator(context);
+                var result = await dut.ExistsAsync(_attachmentId, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task ExistsAsync_UnknownId_ReturnsFalse()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new AttachmentValidator(context);
+                var result = await dut.ExistsAsync(126234, default);
+                Assert.IsFalse(result);
+            }
+        }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.Domain.Tests/AggregateModels/ProjectAggregate/TagTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Domain.Tests/AggregateModels/ProjectAggregate/TagTests.cs
@@ -973,6 +973,27 @@ namespace Equinor.Procosys.Preservation.Domain.Tests.AggregateModels.ProjectAggr
 
         #endregion
         
+        #region RemoveAttachment
+
+        [TestMethod]
+        public void RemoveAttachment_ShouldRemoveAttachment()
+        {
+            var attachment = new TagAttachment(TestPlant, Guid.Empty, "A.txt");
+            _dutWithOneReqNotNeedInputTwoWeekInterval.AddAttachment(attachment);
+            Assert.AreEqual(1, _dutWithOneReqNotNeedInputTwoWeekInterval.Attachments.Count);
+
+            // Act
+            _dutWithOneReqNotNeedInputTwoWeekInterval.RemoveAttachment(attachment);
+
+            Assert.AreEqual(0, _dutWithOneReqNotNeedInputTwoWeekInterval.Attachments.Count);
+        }
+
+        [TestMethod]
+        public void RemoveAttachment_ShouldThrowException_WhenAttachmentNotGiven()
+            => Assert.ThrowsException<ArgumentNullException>(() => _dutWithOneReqNotNeedInputTwoWeekInterval.RemoveAttachment(null));
+
+        #endregion
+        
         #region GetAttachmentByFileName
 
         [TestMethod]

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetActionAttachments/GetActionAttachmentsQueryTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetActionAttachments/GetActionAttachmentsQueryTests.cs
@@ -1,5 +1,4 @@
 ﻿using Equinor.Procosys.Preservation.Query.GetActionAttachments;
-using Equinor.Procosys.Preservation.Query.GetActions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Equinor.Procosys.Preservation.Query.Tests.GetActionAttachments


### PR DESCRIPTION
Also found that ActionValidator missed unit tests, which again lead to a bug in ActionValidator: No need to merge Tag to check for exists on Action by its id. Fixed