### PR TITLE
73869 - First part of converting Tag.Status

### DIFF
--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/Tag.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/Tag.cs
@@ -67,14 +67,15 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate
             }
 
             TagType = tagType;
-            Status = PreservationStatus.NotStarted;
+            Status = StatusEnum = PreservationStatus.NotStarted;
             TagNo = tagNo;
             Description = description;
             StepId = step.Id;
             _requirements.AddRange(reqList);
         }
 
-        public PreservationStatus Status { get; private set; }
+        public PreservationStatus StatusEnum { get; private set; }
+        public PreservationStatus Status { get; private set; } // To be Deleted in future PR
         public string AreaCode { get; private set; }
         public string AreaDescription { get; private set; }
         public string Calloff { get; set; }
@@ -203,7 +204,7 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate
                 requirement.StartPreservation();
             }
 
-            Status = PreservationStatus.Active;
+            Status = StatusEnum = PreservationStatus.Active;
             UpdateNextDueTimeUtc();
         }
 
@@ -218,7 +219,7 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate
                 requirement.CompletePreservation();
             }
 
-            Status = PreservationStatus.Completed;
+            Status = StatusEnum = PreservationStatus.Completed;
             NextDueTimeUtc = null;
         }
 

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/TagConfiguration.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Entityconfigurations/TagConfiguration.cs
@@ -79,6 +79,10 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
                 .WithOne()
                 .IsRequired();
 
+            builder.Property(f => f.StatusEnum)
+                .HasDefaultValue(PreservationStatus.NotStarted)
+                .IsRequired();
+
             builder.Property(f => f.Status)
                 .HasConversion<string>()
                 .HasDefaultValue(PreservationStatus.NotStarted)
@@ -93,6 +97,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
                 .HasConversion(PreservationContext.NullableDateTimeKindConverter);
 
             builder.HasCheckConstraint("constraint_tag_check_valid_status", $"{nameof(Tag.Status)} in ({GetValidStatuses()})");
+            builder.HasCheckConstraint("constraint_tag_check_valid_statusenum", $"{nameof(Tag.StatusEnum)} in ({GetValidStatusEnums()})");
 
             builder.HasCheckConstraint("constraint_tag_check_valid_tag_type", $"{nameof(Tag.TagType)} in ({GetValidTagTypes()})");
 
@@ -229,16 +234,22 @@ namespace Equinor.Procosys.Preservation.Infrastructure.EntityConfigurations
 
         }
 
+        private string GetValidStatusEnums()
+        {
+            var values = Enum.GetValues(typeof(PreservationStatus)).Cast<int>();
+            return string.Join(',', values);
+        }
+
         private string GetValidStatuses()
         {
-            var fieldTypes = Enum.GetNames(typeof(PreservationStatus)).Select(t => $"'{t}'");
-            return string.Join(',', fieldTypes);
+            var names = Enum.GetNames(typeof(PreservationStatus)).Select(t => $"'{t}'");
+            return string.Join(',', names);
         }
 
         private string GetValidTagTypes()
         {
-            var fieldTypes = Enum.GetNames(typeof(TagType)).Select(t => $"'{t}'");
-            return string.Join(',', fieldTypes);
+            var names = Enum.GetNames(typeof(TagType)).Select(t => $"'{t}'");
+            return string.Join(',', names);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200518131838_AddColumnTagStatusEnum.Designer.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200518131838_AddColumnTagStatusEnum.Designer.cs
@@ -4,14 +4,16 @@ using Equinor.Procosys.Preservation.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Equinor.Procosys.Preservation.Infrastructure.Migrations
 {
     [DbContext(typeof(PreservationContext))]
-    partial class PreservationContextModelSnapshot : ModelSnapshot
+    [Migration("20200518131838_AddColumnTagStatusEnum")]
+    partial class AddColumnTagStatusEnum
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200518131838_AddColumnTagStatusEnum.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200518131838_AddColumnTagStatusEnum.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Equinor.Procosys.Preservation.Infrastructure.Migrations
+{
+    public partial class AddColumnTagStatusEnum : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "StatusEnum",
+                table: "Tags",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateCheckConstraint(
+                name: "constraint_tag_check_valid_statusenum",
+                table: "Tags",
+                sql: "StatusEnum in (0,1,2)");
+
+            migrationBuilder.Sql("update Tags set StatusEnum=0 where Status='NotStarted'");
+            migrationBuilder.Sql("update Tags set StatusEnum=1 where Status='Active'");
+            migrationBuilder.Sql("update Tags set StatusEnum=2 where Status='Completed'");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "constraint_tag_check_valid_statusenum",
+                table: "Tags");
+
+            migrationBuilder.DropColumn(
+                name: "StatusEnum",
+                table: "Tags");
+        }
+    }
+}


### PR DESCRIPTION
Tag.Status is an Enum with 3 possible values: NotStarted, Active and Completed.
Today we've chosen to store this as string in DB. We convert to int: 0, 1 or 2

In next PR I'll throw old Status-column rename StatusEnum back to Status.
Then we can use Status for sorting + implement better disaplayvalues (as "Not started")