### PR TITLE
74112 clone endpoint

### DIFF
--- a/src/Equinor.Procosys.Preservation.Command/MiscCommands/Clone/CloneCommand.cs
+++ b/src/Equinor.Procosys.Preservation.Command/MiscCommands/Clone/CloneCommand.cs
@@ -1,0 +1,12 @@
+﻿using MediatR;
+using ServiceResult;
+
+namespace Equinor.Procosys.Preservation.Command.MiscCommands.Clone
+{
+    public class CloneCommand : IRequest<Result<Unit>>
+    {
+        public CloneCommand(string sourcePlant) => SourcePlant = sourcePlant;
+
+        public string SourcePlant { get; }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Command/MiscCommands/Clone/CloneCommand.cs
+++ b/src/Equinor.Procosys.Preservation.Command/MiscCommands/Clone/CloneCommand.cs
@@ -5,8 +5,13 @@ namespace Equinor.Procosys.Preservation.Command.MiscCommands.Clone
 {
     public class CloneCommand : IRequest<Result<Unit>>
     {
-        public CloneCommand(string sourcePlant) => SourcePlant = sourcePlant;
+        public CloneCommand(string sourcePlant, string targetPlant)
+        {
+            SourcePlant = sourcePlant;
+            TargetPlant = targetPlant;
+        }
 
         public string SourcePlant { get; }
+        public string TargetPlant { get; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/MiscCommands/Clone/CloneCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/MiscCommands/Clone/CloneCommandHandler.cs
@@ -193,7 +193,7 @@ namespace Equinor.Procosys.Preservation.Command.MiscCommands.Clone
             {
                 var sourceRD = sourceRDs.Single(s => s.Id == sourceRequirement.RequirementDefinitionId);
                 var targetRD = targetRDs.Single(t => t.Title == sourceRD.Title);
-                if (targetTagFunction.Requirements.SingleOrDefault(t => t.Id == targetRD.Id) == null)
+                if (targetTagFunction.Requirements.SingleOrDefault(r => r.RequirementDefinitionId == targetRD.Id) == null)
                 {
                     var targetRequirement = new TagFunctionRequirement(targetTagFunction.Plant, sourceRequirement.IntervalWeeks, targetRD);
                     targetTagFunction.AddRequirement(targetRequirement);

--- a/src/Equinor.Procosys.Preservation.Command/MiscCommands/Clone/CloneCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/MiscCommands/Clone/CloneCommandHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Domain;
@@ -24,6 +25,11 @@ namespace Equinor.Procosys.Preservation.Command.MiscCommands.Clone
         public async Task<Result<Unit>> Handle(CloneCommand request, CancellationToken cancellationToken)
         {
             var targetPlant = _plantProvider.Plant;
+
+            if (targetPlant != request.TargetPlant)
+            {
+                throw new Exception($"Target plant '{request.TargetPlant}' in request must match target plant '{targetPlant}' in provider");
+            }
 
             await CloneModes(request.SourcePlant, targetPlant);
 

--- a/src/Equinor.Procosys.Preservation.Command/MiscCommands/Clone/CloneCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/MiscCommands/Clone/CloneCommandHandler.cs
@@ -1,0 +1,53 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Domain;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.ModeAggregate;
+using MediatR;
+using ServiceResult;
+
+namespace Equinor.Procosys.Preservation.Command.MiscCommands.Clone
+{
+    public class CloneCommandHandler : IRequestHandler<CloneCommand, Result<Unit>>
+    {
+        private readonly IPlantProvider _plantProvider;
+        private readonly IModeRepository _modeRepository;
+        private readonly IUnitOfWork _unitOfWork;
+
+        public CloneCommandHandler(IPlantProvider plantProvider, IModeRepository modeRepository, IUnitOfWork unitOfWork)
+        {
+            _plantProvider = plantProvider;
+            _modeRepository = modeRepository;
+            _unitOfWork = unitOfWork;
+        }
+
+        public async Task<Result<Unit>> Handle(CloneCommand request, CancellationToken cancellationToken)
+        {
+            var targetPlant = _plantProvider.Plant;
+
+            await CloneModes(request.SourcePlant, targetPlant);
+
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+            return new SuccessResult<Unit>(Unit.Value);
+        }
+
+        private async Task CloneModes(string sourcePlant, string targetPlant)
+        {
+            _plantProvider.SetTemporaryPlant(sourcePlant);
+            var sourceModes = await _modeRepository.GetAllAsync();
+            _plantProvider.ReleaseTemporaryPlant();
+
+            var targetModes = await _modeRepository.GetAllAsync();
+
+            foreach (var sourceMode in sourceModes)
+            {
+                if (targetModes.SingleOrDefault(t => t.Title == sourceMode.Title) == null)
+                {
+                    var targetMode = new Mode(targetPlant, sourceMode.Title);
+                    _modeRepository.Add(targetMode);
+                }
+            }
+        }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Command/MiscCommands/Clone/CloneCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/MiscCommands/Clone/CloneCommandHandler.cs
@@ -49,6 +49,7 @@ namespace Equinor.Procosys.Preservation.Command.MiscCommands.Clone
             await CloneModes(request.SourcePlant, targetPlant);
             await CloneResponsibles(request.SourcePlant, targetPlant);
             await CloneRequirementTypes(request.SourcePlant, targetPlant);
+            await CloneTagFunctions(request.SourcePlant, targetPlant);
 
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 
@@ -137,6 +138,32 @@ namespace Equinor.Procosys.Preservation.Command.MiscCommands.Clone
                     targetRD.AddField(targetField);
                 }
             }
+        }
+
+        private async Task CloneTagFunctions(string sourcePlant, string targetPlant)
+        {
+            _plantProvider.SetTemporaryPlant(sourcePlant);
+            var sourceTagFunctions = await _tagFunctionRepository.GetAllAsync();
+            _plantProvider.ReleaseTemporaryPlant();
+
+            var targetTagFunctions = await _tagFunctionRepository.GetAllAsync();
+
+            foreach (var sourceTagFunction in sourceTagFunctions)
+            {
+                var targetTagFunction = targetTagFunctions.SingleOrDefault(t => t.Code == sourceTagFunction.Code && t.RegisterCode == sourceTagFunction.RegisterCode);
+                if (targetTagFunction == null)
+                {
+                    targetTagFunction = new TagFunction(targetPlant, sourceTagFunction.Code, sourceTagFunction.Description, sourceTagFunction.RegisterCode);
+                    _tagFunctionRepository.Add(targetTagFunction);
+                }
+
+                CloneRequirements(sourceTagFunction, targetTagFunction);
+            }
+        }
+
+        private void CloneRequirements(TagFunction sourceTagFunction, TagFunction targetTagFunction)
+        {
+            
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/MiscCommands/Clone/CloneCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/MiscCommands/Clone/CloneCommandValidator.cs
@@ -1,0 +1,32 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.MainApi.Plant;
+using FluentValidation;
+
+namespace Equinor.Procosys.Preservation.Command.MiscCommands.Clone
+{
+    public class CloneCommandValidator : AbstractValidator<CloneCommand>
+    {
+        private static string[] BasisPlants = {"PCS$STATOIL_BASIS", "PCS$SUN_BASIS", "PCS$WIND_BASIS"};
+
+        public CloneCommandValidator(IPlantCache plantCache)
+        {
+            CascadeMode = CascadeMode.StopOnFirstFailure;
+
+            RuleFor(command => command.SourcePlant)
+                .MustAsync((_, sourcePlant, token) => BeAValidPlantAsync(sourcePlant.ToUpperInvariant()))
+                .WithMessage(command => $"Source plant is not valid! Plant={command.SourcePlant}");
+
+            RuleFor(command => command.TargetPlant)
+                .MustAsync((_, targetPlant, token) => BeAValidPlantAsync(targetPlant.ToUpperInvariant()))
+                .WithMessage(command => $"Source plant is not valid! Plant={command.TargetPlant}")
+                .Must((_, targetPlant, token) => NotBeABasisPlant(targetPlant.ToUpperInvariant()))
+                .WithMessage(command => $"Basis plant can't be a target plant for clone! Plant={command.TargetPlant}");
+
+            async Task<bool> BeAValidPlantAsync(string plantId)
+                => await plantCache.IsValidPlantForCurrentUserAsync(plantId);
+            
+            bool NotBeABasisPlant(string plantId) => !BasisPlants.Contains(plantId);
+        }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Domain/IPlantProvider.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/IPlantProvider.cs
@@ -3,5 +3,7 @@
     public interface IPlantProvider
     {
         string Plant { get; }
+        void SetTemporaryPlant(string plant);
+        void ReleaseTemporaryPlant();
     }
 }

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Misc/CloneController.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Misc/CloneController.cs
@@ -1,0 +1,41 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.MiscCommands.Clone;
+using Equinor.Procosys.Preservation.Domain;
+using Equinor.Procosys.Preservation.WebApi.Misc;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using ServiceResult.ApiExtensions;
+
+namespace Equinor.Procosys.Preservation.WebApi.Controllers.Misc
+{
+    [ApiController]
+    [Route("Clone")]
+    public class CloneController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+
+        public CloneController(IMediator mediator) => _mediator = mediator;
+
+        [Authorize(Roles = Permissions.LIBRARY_PRESERVATION_CREATE)]
+        [HttpPut("Clone")]
+        public async Task<IActionResult> Clone(
+            [FromHeader(Name = PlantProvider.PlantHeader)]
+            [Required]
+            [StringLength(PlantEntityBase.PlantLengthMax, MinimumLength = PlantEntityBase.PlantLengthMin)]
+            string targetPlant,
+            [FromQuery]
+            [Required]
+            [StringLength(PlantEntityBase.PlantLengthMax, MinimumLength = PlantEntityBase.PlantLengthMin)]
+            string sourcePlant
+            )
+        {
+            var command = new CloneCommand(sourcePlant);
+
+            var result = await _mediator.Send(command);
+
+            return this.FromResult(result);
+        }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Misc/CloneController.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Misc/CloneController.cs
@@ -31,7 +31,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Misc
             string sourcePlant
             )
         {
-            var command = new CloneCommand(sourcePlant);
+            var command = new CloneCommand(sourcePlant, targetPlant);
 
             var result = await _mediator.Send(command);
 

--- a/src/Equinor.Procosys.Preservation.WebApi/Misc/PlantProvider.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Misc/PlantProvider.cs
@@ -9,9 +9,25 @@ namespace Equinor.Procosys.Preservation.WebApi.Misc
         public const string PlantHeader = "x-plant";
 
         private readonly IHttpContextAccessor _accessor;
+        private string _temporaryPlant;
 
         public PlantProvider(IHttpContextAccessor accessor) => _accessor = accessor;
 
-        public string Plant => _accessor?.HttpContext?.Request?.Headers[PlantHeader].ToString().ToUpperInvariant() ?? throw new Exception("Could not determine current plant");
+        public string Plant
+        {
+            get
+            {
+                if (_temporaryPlant != null)
+                {
+                    return _temporaryPlant;
+                }
+                return _accessor?.HttpContext?.Request?.Headers[PlantHeader].ToString().ToUpperInvariant() ??
+                       throw new Exception("Could not determine current plant");
+            }
+        }
+
+        public void SetTemporaryPlant(string plant) => _temporaryPlant = plant;
+
+        public void ReleaseTemporaryPlant() => _temporaryPlant = null;
     }
 }

--- a/src/Equinor.Procosys.Preservation.WebApi/Seeding/SeedingPlantProvider.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Seeding/SeedingPlantProvider.cs
@@ -7,5 +7,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Seeding
         public SeedingPlantProvider(string plant) => Plant = plant;
 
         public string Plant { get; }
+        public void SetTemporaryPlant(string plant) => throw new System.NotImplementedException();
+        public void ReleaseTemporaryPlant() => throw new System.NotImplementedException();
     }
 }


### PR DESCRIPTION
Endpoint for cloning Library data from one plant to another.
Not allowed to clone into a BASIS plant.
User must have LIBRARY_PRESERVATION/CREATE permission (privilege) to **target** plant. Read access (LIBRARY_PRESERVATION/READ) to **source** plant not checked, but can be checked in validator. I'm not sure that is important here in this context.

Affected Tables:
- Modes
- Responsibles
- RequirementsTypes, including RequirementsDefinitions and Fields
- TagFunctions, including TagFunctionsRequirements