### PR TITLE
Rename from PurchaseOrderNumber to PurchaseOrderTitle in dto

### DIFF
--- a/src/Equinor.Procosys.Preservation.Query/TagApiQueries/SearchTags/ProcosysTagDto.cs
+++ b/src/Equinor.Procosys.Preservation.Query/TagApiQueries/SearchTags/ProcosysTagDto.cs
@@ -15,7 +15,7 @@
         {
             TagNo = tagNo;
             Description = description;
-            PurchaseOrderNumber = purchaseOrderTitle;
+            PurchaseOrderTitle = purchaseOrderTitle;
             CommPkgNo = commPkgNo;
             McPkgNo = mcPkgNo;
             RegisterCode = registerCode;
@@ -26,7 +26,7 @@
 
         public string TagNo { get; }
         public string Description { get; }
-        public string PurchaseOrderNumber { get; } // todo rename to PurchaseOrderTitle. Coordinate with UI-developers
+        public string PurchaseOrderTitle { get; }
         public string CommPkgNo { get; }
         public string McPkgNo { get; }
         public string RegisterCode { get; }

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/TagApiQueries/SearchTags/ProCoSysTagDtoTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/TagApiQueries/SearchTags/ProCoSysTagDtoTests.cs
@@ -13,7 +13,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.TagApiQueries.SearchTags
 
             Assert.AreEqual("TagNo", dut.TagNo);
             Assert.AreEqual("Desc", dut.Description);
-            Assert.AreEqual("PoNo", dut.PurchaseOrderNumber);
+            Assert.AreEqual("PoNo", dut.PurchaseOrderTitle);
             Assert.AreEqual("CommPkgNo", dut.CommPkgNo);
             Assert.AreEqual("McPkgNo", dut.McPkgNo);
             Assert.AreEqual("McPkgNo", dut.McPkgNo);

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/TagApiQueries/SearchTags/SearchTagsByTagFunctionQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/TagApiQueries/SearchTags/SearchTagsByTagFunctionQueryHandlerTests.cs
@@ -209,7 +209,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.TagApiQueries.SearchTags
             Assert.AreEqual(tagOverview.CommPkgNo, tagDto.CommPkgNo);
             Assert.AreEqual(tagOverview.Description, tagDto.Description);
             Assert.AreEqual(tagOverview.McPkgNo, tagDto.McPkgNo);
-            Assert.AreEqual(tagOverview.PurchaseOrderTitle, tagDto.PurchaseOrderNumber);
+            Assert.AreEqual(tagOverview.PurchaseOrderTitle, tagDto.PurchaseOrderTitle);
             Assert.AreEqual(tagOverview.MccrResponsibleCodes, tagDto.MccrResponsibleCodes);
         }
     }

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/TagApiQueries/SearchTags/SearchTagsByTagNoQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/TagApiQueries/SearchTags/SearchTagsByTagNoQueryHandlerTests.cs
@@ -161,7 +161,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.TagApiQueries.SearchTags
             Assert.AreEqual(tagOverview.CommPkgNo, tagDto.CommPkgNo);
             Assert.AreEqual(tagOverview.Description, tagDto.Description);
             Assert.AreEqual(tagOverview.McPkgNo, tagDto.McPkgNo);
-            Assert.AreEqual(tagOverview.PurchaseOrderTitle, tagDto.PurchaseOrderNumber);
+            Assert.AreEqual(tagOverview.PurchaseOrderTitle, tagDto.PurchaseOrderTitle);
             Assert.AreEqual(tagOverview.MccrResponsibleCodes, tagDto.MccrResponsibleCodes);
         }
     }


### PR DESCRIPTION
Breaking change for client, but coordinated with UI dev