### PR TITLE
74436 Sync Projects and Tags with Main

### DIFF
--- a/src/Equinor.Procosys.Preservation.Command/SyncCommands/SyncProjects/SyncProjectsCommand.cs
+++ b/src/Equinor.Procosys.Preservation.Command/SyncCommands/SyncProjects/SyncProjectsCommand.cs
@@ -1,0 +1,12 @@
+﻿using MediatR;
+using ServiceResult;
+
+namespace Equinor.Procosys.Preservation.Command.SyncCommands.SyncProjects
+{
+    public class SyncProjectsCommand : IRequest<Result<Unit>>
+    {
+        public SyncProjectsCommand()
+        {
+        }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Command/SyncCommands/SyncProjects/SyncProjectsCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/SyncCommands/SyncProjects/SyncProjectsCommandHandler.cs
@@ -97,7 +97,7 @@ namespace Equinor.Procosys.Preservation.Command.SyncCommands.SyncProjects
                     {
                         var tag = standardTags.Single(t => t.TagNo == pcsTag.TagNo);
 
-                        tag.SetArea(pcsTag.AreaCode, pcsTag.Description);
+                        tag.SetArea(pcsTag.AreaCode, pcsTag.AreaDescription);
                         tag.SetDiscipline(pcsTag.DisciplineCode, pcsTag.DisciplineDescription);
                         tag.Calloff = pcsTag.CallOffNo;
                         tag.PurchaseOrderNo = pcsTag.PurchaseOrderNo;

--- a/src/Equinor.Procosys.Preservation.Command/SyncCommands/SyncProjects/SyncProjectsCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/SyncCommands/SyncProjects/SyncProjectsCommandHandler.cs
@@ -1,0 +1,88 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Domain;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
+using Equinor.Procosys.Preservation.MainApi.Project;
+using Equinor.Procosys.Preservation.MainApi.Tag;
+using MediatR;
+using ServiceResult;
+
+namespace Equinor.Procosys.Preservation.Command.SyncCommands.SyncProjects
+{
+    public class SyncProjectsCommandHandler : IRequestHandler<SyncProjectsCommand, Result<Unit>>
+    {
+        private readonly IProjectRepository _projectRepository;
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly IPlantProvider _plantProvider;
+        private readonly IProjectApiService _projectApiService;
+        private readonly ITagApiService _tagApiService;
+
+        public SyncProjectsCommandHandler(
+            IProjectRepository projectRepository,
+            IUnitOfWork unitOfWork,
+            IPlantProvider plantProvider, 
+            IProjectApiService projectApiService,
+            ITagApiService tagApiService)
+        {
+            _projectRepository = projectRepository;
+            _unitOfWork = unitOfWork;
+            _plantProvider = plantProvider;
+            _projectApiService = projectApiService;
+            _tagApiService = tagApiService;
+        }
+
+        public async Task<Result<Unit>> Handle(SyncProjectsCommand request, CancellationToken cancellationToken)
+        {
+            var plant = _plantProvider.Plant;
+
+            await SyncProjectData(plant);
+
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+            return new SuccessResult<Unit>(Unit.Value);
+        }
+
+        private async Task SyncProjectData(string plant)
+        {
+            var projects = await _projectRepository.GetAllProjectsWithTagsOnlyAsync();
+
+            foreach (var project in projects)
+            {
+                var pcsProject = await _projectApiService.GetProjectAsync(plant, project.Name);
+                if (pcsProject != null)
+                {
+                    project.IsClosed = pcsProject.IsClosed;
+                    project.Description = pcsProject.Description;
+
+                    await SyncTagData(plant, project.Name, project.Tags);
+                }
+            }
+        }
+
+        private async Task SyncTagData(string plant, string projectName, IReadOnlyCollection<Tag> tags)
+        {
+            var tagNos = tags.Select(t => t.TagNo);
+            var pcsTags = await _tagApiService.GetTagDetailsAsync(plant, projectName, tagNos);
+
+            // todo implement "paging" ... take 1000 and 1000
+            foreach (var tag in tags)
+            {
+                var pcsTag = pcsTags.SingleOrDefault(t => t.TagNo == tag.TagNo);
+
+                if (pcsTag != null)
+                {
+                    tag.SetArea(pcsTag.AreaCode, pcsTag.Description);
+                    tag.SetDiscipline(pcsTag.DisciplineCode, pcsTag.DisciplineDescription);
+                    tag.Calloff = pcsTag.CallOffNo;
+                    tag.PurchaseOrderNo = pcsTag.PurchaseOrderNo;
+                    tag.CommPkgNo = pcsTag.CommPkgNo;
+                    tag.Description = pcsTag.Description;
+                    tag.McPkgNo = pcsTag.McPkgNo;
+                    tag.TagFunctionCode = pcsTag.TagFunctionCode;
+                }
+            }
+        }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Command/SyncCommands/SyncProjects/SyncProjectsCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/SyncCommands/SyncProjects/SyncProjectsCommandHandler.cs
@@ -14,32 +14,32 @@ namespace Equinor.Procosys.Preservation.Command.SyncCommands.SyncProjects
 {
     public class SyncProjectsCommandHandler : IRequestHandler<SyncProjectsCommand, Result<Unit>>
     {
-        private readonly IPlantProvider _plantProvider;
-        private readonly IUnitOfWork _unitOfWork;
-        private readonly IPermissionCache _permissionCache;
-        private readonly ICurrentUserProvider _currentUserProvider;
         private readonly IProjectRepository _projectRepository;
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly IPlantProvider _plantProvider;
         private readonly IProjectApiService _projectApiService;
         private readonly ITagApiService _tagApiService;
+        private readonly IPermissionCache _permissionCache;
+        private readonly ICurrentUserProvider _currentUserProvider;
         private readonly ILogger<SyncProjectsCommandHandler> _logger;
 
         public SyncProjectsCommandHandler(
-            IPlantProvider plantProvider, 
-            IUnitOfWork unitOfWork,
-            IPermissionCache permissionCache,
-            ICurrentUserProvider currentUserProvider,
             IProjectRepository projectRepository,
+            IUnitOfWork unitOfWork,
+            IPlantProvider plantProvider, 
             IProjectApiService projectApiService,
             ITagApiService tagApiService,
+            IPermissionCache permissionCache,
+            ICurrentUserProvider currentUserProvider,
             ILogger<SyncProjectsCommandHandler> logger)
         {
-            _plantProvider = plantProvider;
-            _unitOfWork = unitOfWork;
-            _permissionCache = permissionCache;
-            _currentUserProvider = currentUserProvider;
             _projectRepository = projectRepository;
+            _unitOfWork = unitOfWork;
+            _plantProvider = plantProvider;
             _projectApiService = projectApiService;
             _tagApiService = tagApiService;
+            _permissionCache = permissionCache;
+            _currentUserProvider = currentUserProvider;
             _logger = logger;
         }
 

--- a/src/Equinor.Procosys.Preservation.Command/SyncCommands/SyncProjects/SyncProjectsCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/SyncCommands/SyncProjects/SyncProjectsCommandHandler.cs
@@ -7,6 +7,7 @@ using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Equinor.Procosys.Preservation.MainApi.Project;
 using Equinor.Procosys.Preservation.MainApi.Tag;
 using MediatR;
+using Microsoft.Extensions.Logging;
 using ServiceResult;
 
 namespace Equinor.Procosys.Preservation.Command.SyncCommands.SyncProjects
@@ -20,6 +21,7 @@ namespace Equinor.Procosys.Preservation.Command.SyncCommands.SyncProjects
         private readonly IProjectRepository _projectRepository;
         private readonly IProjectApiService _projectApiService;
         private readonly ITagApiService _tagApiService;
+        private readonly ILogger<SyncProjectsCommandHandler> _logger;
 
         public SyncProjectsCommandHandler(
             IPlantProvider plantProvider, 
@@ -28,7 +30,8 @@ namespace Equinor.Procosys.Preservation.Command.SyncCommands.SyncProjects
             ICurrentUserProvider currentUserProvider,
             IProjectRepository projectRepository,
             IProjectApiService projectApiService,
-            ITagApiService tagApiService)
+            ITagApiService tagApiService,
+            ILogger<SyncProjectsCommandHandler> logger)
         {
             _plantProvider = plantProvider;
             _unitOfWork = unitOfWork;
@@ -37,6 +40,7 @@ namespace Equinor.Procosys.Preservation.Command.SyncCommands.SyncProjects
             _projectRepository = projectRepository;
             _projectApiService = projectApiService;
             _tagApiService = tagApiService;
+            _logger = logger;
         }
 
         public async Task<Result<Unit>> Handle(SyncProjectsCommand request, CancellationToken cancellationToken)
@@ -53,13 +57,15 @@ namespace Equinor.Procosys.Preservation.Command.SyncCommands.SyncProjects
         private async Task SyncProjectData(string plant)
         {
             var projects = await _projectRepository.GetAllProjectsOnlyAsync();
-            var projectsWhichUserCanAccess =
-                await _permissionCache.GetProjectNamesForUserOidAsync(plant, _currentUserProvider.GetCurrentUserOid());
+            var currentUserOid = _currentUserProvider.GetCurrentUserOid();
+            
+            var projectsWhichUserCanAccess = await _permissionCache.GetProjectNamesForUserOidAsync(plant, currentUserOid);
+            
             foreach (var project in projects)
             {
                 if (!projectsWhichUserCanAccess.Contains(project.Name))
                 {
-                    // todo log ?
+                    _logger.LogWarning($"Current user with oid {currentUserOid} don't have access to project {project.Name}. Synchronization skipped ...");
                     continue;
                 }
 
@@ -77,26 +83,29 @@ namespace Equinor.Procosys.Preservation.Command.SyncCommands.SyncProjects
             var allTagNos = standardTags.Select(t => t.TagNo).ToList();
 
             var page = 0;
-            // Use relative small pagesize since TagNos are added to querystring of url and maxlength is 2000
+            // Use relative small page size since TagNos are added to querystring of url and maxlength is 2000
             var pageSize = 50;
             IEnumerable<string> pageWithTagNos;
             do
             {
                 pageWithTagNos = allTagNos.Skip(pageSize * page).Take(pageSize).ToList();
-                
-                var pcsTags = await _tagApiService.GetTagDetailsAsync(plant, projectName, pageWithTagNos);
-                foreach (var pcsTag in pcsTags)
-                {
-                    var tag = standardTags.Single(t => t.TagNo == pcsTag.TagNo);
 
-                    tag.SetArea(pcsTag.AreaCode, pcsTag.Description);
-                    tag.SetDiscipline(pcsTag.DisciplineCode, pcsTag.DisciplineDescription);
-                    tag.Calloff = pcsTag.CallOffNo;
-                    tag.PurchaseOrderNo = pcsTag.PurchaseOrderNo;
-                    tag.CommPkgNo = pcsTag.CommPkgNo;
-                    tag.Description = pcsTag.Description;
-                    tag.McPkgNo = pcsTag.McPkgNo;
-                    tag.TagFunctionCode = pcsTag.TagFunctionCode;
+                if (pageWithTagNos.Any())
+                {
+                    var pcsTags = await _tagApiService.GetTagDetailsAsync(plant, projectName, pageWithTagNos);
+                    foreach (var pcsTag in pcsTags)
+                    {
+                        var tag = standardTags.Single(t => t.TagNo == pcsTag.TagNo);
+
+                        tag.SetArea(pcsTag.AreaCode, pcsTag.Description);
+                        tag.SetDiscipline(pcsTag.DisciplineCode, pcsTag.DisciplineDescription);
+                        tag.Calloff = pcsTag.CallOffNo;
+                        tag.PurchaseOrderNo = pcsTag.PurchaseOrderNo;
+                        tag.CommPkgNo = pcsTag.CommPkgNo;
+                        tag.Description = pcsTag.Description;
+                        tag.McPkgNo = pcsTag.McPkgNo;
+                        tag.TagFunctionCode = pcsTag.TagFunctionCode;
+                    }
                 }
 
                 page++;

--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/IProjectRepository.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/IProjectRepository.cs
@@ -8,6 +8,7 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate
         Task<Project> GetProjectOnlyByNameAsync(string projectName);
         Task<Tag> GetTagByTagIdAsync(int tagId);
         Task<List<Tag>> GetTagsByTagIdsAsync(IEnumerable<int> tagIds);
-        Task<List<Project>> GetAllProjectsWithTagsOnlyAsync();
+        Task<List<Project>> GetAllProjectsOnlyAsync();
+        Task<List<Tag>> GetStandardTagsInProjectOnlyAsync(string projectName);
     }
 }

--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/IProjectRepository.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/IProjectRepository.cs
@@ -6,8 +6,8 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate
     public interface IProjectRepository : IRepository<Project>
     {
         Task<Project> GetProjectOnlyByNameAsync(string projectName);
-        Task<List<Tag>> GetAllTagsInProjectAsync(string projectName);
         Task<Tag> GetTagByTagIdAsync(int tagId);
         Task<List<Tag>> GetTagsByTagIdsAsync(IEnumerable<int> tagIds);
+        Task<List<Project>> GetAllProjectsWithTagsOnlyAsync();
     }
 }

--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/Project.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/Project.cs
@@ -25,8 +25,8 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate
         }
 
         public string Name { get; private set; }
-        public string Description { get; private set; }
-        public bool IsClosed { get; private set; }
+        public string Description { get; set; }
+        public bool IsClosed { get; set; }
         public IReadOnlyCollection<Tag> Tags => _tags.AsReadOnly();
         public DateTime CreatedAtUtc { get; private set; }
         public int CreatedById { get; private set; }

--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/Tag.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/Tag.cs
@@ -89,7 +89,7 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate
         public string DisciplineDescription { get; private set; }
         public TagType TagType { get; private set; }
         public string McPkgNo { get; set; }
-        public string Description { get; private set; }
+        public string Description { get; set; }
         public string PurchaseOrderNo { get; set; }
         public string Remark { get; set; }
         public string StorageArea { get; set; }

--- a/src/Equinor.Procosys.Preservation.Domain/IPermissionCache.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/IPermissionCache.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace Equinor.Procosys.Preservation.WebApi.Caches
+namespace Equinor.Procosys.Preservation.Domain
 {
     public interface IPermissionCache
     {

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200617062759_UpdateEventTypeConstrains.Designer.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200617062759_UpdateEventTypeConstrains.Designer.cs
@@ -4,14 +4,16 @@ using Equinor.Procosys.Preservation.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Equinor.Procosys.Preservation.Infrastructure.Migrations
 {
     [DbContext(typeof(PreservationContext))]
-    partial class PreservationContextModelSnapshot : ModelSnapshot
+    [Migration("20200617062759_UpdateEventTypeConstrains")]
+    partial class UpdateEventTypeConstrains
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200617062759_UpdateEventTypeConstrains.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Migrations/20200617062759_UpdateEventTypeConstrains.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Equinor.Procosys.Preservation.Infrastructure.Migrations
+{
+    public partial class UpdateEventTypeConstrains : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "constraint_history_check_valid_event_type",
+                table: "History");
+
+            migrationBuilder.CreateCheckConstraint(
+                name: "constraint_history_check_valid_event_type",
+                table: "History",
+                sql: "EventType in ('RequirementAdded','RequirementDeleted','RequirementVoided','RequirementUnvoided','RequirementPreserved','TagVoided','TagUnvoided','TagCreated','TagDeleted','PreservationStarted','PreservationCompleted','IntervalChanged','TransferredManually','TransferredAutomatically','ActionAdded','ActionClosed')");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "constraint_history_check_valid_event_type",
+                table: "History");
+
+            migrationBuilder.CreateCheckConstraint(
+                name: "constraint_history_check_valid_event_type",
+                table: "History",
+                sql: "EventType in ('AddRequirement','DeleteRequirement','VoidRequirement','UnvoidRequirement','PreserveRequirement','VoidTag','UnvoidTag','CreateTag','DeleteTag','StartPreservation','CompletePreservation','ChangeInterval','ManualTransfer','AutomaticTransfer','AddAction','CloseAction')");
+        }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Repositories/ProjectRepository.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Repositories/ProjectRepository.cs
@@ -39,7 +39,13 @@ namespace Equinor.Procosys.Preservation.Infrastructure.Repositories
                 .Where(tag => tagIds.Contains(tag.Id))
                 .ToListAsync();
 
-        public Task<List<Project>> GetAllProjectsWithTagsOnlyAsync()
-            => Set.Include(p => p.Tags).ToListAsync();
+        public Task<List<Project>> GetAllProjectsOnlyAsync()
+            => Set.ToListAsync();
+
+        public Task<List<Tag>> GetStandardTagsInProjectOnlyAsync(string projectName)
+            => Set.Where(project => project.Name == projectName)
+                .SelectMany(project => project.Tags)
+                .Where(tag => tag.TagType == TagType.Standard)
+                .ToListAsync();
     }
 }

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Repositories/ProjectRepository.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Repositories/ProjectRepository.cs
@@ -28,12 +28,6 @@ namespace Equinor.Procosys.Preservation.Infrastructure.Repositories
         public Task<Project> GetProjectOnlyByNameAsync(string projectName)
             => Set.SingleOrDefaultAsync(p => p.Name == projectName);
 
-        public Task<List<Tag>> GetAllTagsInProjectAsync(string projectName)
-            => DefaultQuery
-                .Where(p => p.Name == projectName)
-                .SelectMany(p => p.Tags)
-                .ToListAsync();
-
         public Task<Tag> GetTagByTagIdAsync(int tagId)
             => DefaultQuery
                 .SelectMany(project => project.Tags)
@@ -44,5 +38,8 @@ namespace Equinor.Procosys.Preservation.Infrastructure.Repositories
                 .SelectMany(project => project.Tags)
                 .Where(tag => tagIds.Contains(tag.Id))
                 .ToListAsync();
+
+        public Task<List<Project>> GetAllProjectsWithTagsOnlyAsync()
+            => Set.Include(p => p.Tags).ToListAsync();
     }
 }

--- a/src/Equinor.Procosys.Preservation.MainApi/Client/BearerTokenApiClient.cs
+++ b/src/Equinor.Procosys.Preservation.MainApi/Client/BearerTokenApiClient.cs
@@ -26,6 +26,16 @@ namespace Equinor.Procosys.Preservation.MainApi.Client
 
         public async Task<T> QueryAndDeserializeAsync<T>(string url)
         {
+            if (string.IsNullOrEmpty(url))
+            {
+                throw new ArgumentNullException(nameof(url));
+            }
+
+            if (url.Length > 2000)
+            {
+                throw new ArgumentException("url exceed max 2000 characters", nameof(url));
+            }
+
             var httpClient = CreateHttpClient();
 
             var stopWatch = Stopwatch.StartNew();

--- a/src/Equinor.Procosys.Preservation.MainApi/Project/ProcosysProject.cs
+++ b/src/Equinor.Procosys.Preservation.MainApi/Project/ProcosysProject.cs
@@ -5,5 +5,6 @@
         public int Id { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
+        public bool IsClosed { get; set; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.WebApi/Caches/PermissionCache.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Caches/PermissionCache.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Domain;
 using Equinor.Procosys.Preservation.Infrastructure.Caching;
 using Equinor.Procosys.Preservation.MainApi.Permission;
 using Microsoft.Extensions.Options;

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Synchronize/SynchronizeController.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Synchronize/SynchronizeController.cs
@@ -18,7 +18,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Synchronize
 
         public SynchronizeController(IMediator mediator) => _mediator = mediator;
 
-        [Authorize(Roles = Permissions.PRESERVATION_READ)] // todo change to correct 
+        [Authorize(Roles = Permissions.PRESERVATION_PLAN_CREATE)]
         [HttpPut("Projects")]
         public async Task<ActionResult> Projects(
             [FromHeader( Name = PlantProvider.PlantHeader)]

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Synchronize/SynchronizeController.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Synchronize/SynchronizeController.cs
@@ -1,0 +1,33 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.SyncCommands.SyncProjects;
+using Equinor.Procosys.Preservation.Domain;
+using Equinor.Procosys.Preservation.WebApi.Misc;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using ServiceResult.ApiExtensions;
+
+namespace Equinor.Procosys.Preservation.WebApi.Controllers.Synchronize
+{
+    [ApiController]
+    [Route("Synchronize")]
+    public class SynchronizeController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+
+        public SynchronizeController(IMediator mediator) => _mediator = mediator;
+
+        [Authorize(Roles = Permissions.PRESERVATION_READ)] // todo change to correct 
+        [HttpPut("Projects")]
+        public async Task<ActionResult> Projects(
+            [FromHeader( Name = PlantProvider.PlantHeader)]
+            [Required]
+            [StringLength(PlantEntityBase.PlantLengthMax, MinimumLength = PlantEntityBase.PlantLengthMin)]
+            string plant)
+        {
+            var result = await _mediator.Send(new SyncProjectsCommand());
+            return this.FromResult(result);
+        }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionCommands/CloseAction/CloseActionCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionCommands/CloseAction/CloseActionCommandHandlerTests.cs
@@ -17,22 +17,18 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionCommands.CloseAction
         private readonly int _personId = 16;
         private readonly string _rowVersion = "AAAAAAAAABA=";
 
-        private readonly  Guid _currentUserOid = new Guid("12345678-1234-1234-1234-123456789123");
-
         private CloseActionCommand _command;
         private CloseActionCommandHandler _dut;
 
         private Mock<IProjectRepository> _projectRepositoryMock;
         private Action _action;
         private Mock<IPersonRepository> _personRepositoryMock;
-        private Mock<ICurrentUserProvider> _currentUserProviderMock;
         private Mock<Person> _personMock;
 
         [TestInitialize]
         public void Setup()
         {
             _projectRepositoryMock = new Mock<IProjectRepository>();
-            _currentUserProviderMock = new Mock<ICurrentUserProvider>();
             _personRepositoryMock = new Mock<IPersonRepository>();
 
             var tagId = 2;
@@ -51,12 +47,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionCommands.CloseAction
                 .Setup(r => r.GetTagByTagIdAsync(tagId))
                 .Returns(Task.FromResult(tagMock.Object));
 
-            _currentUserProviderMock
-                .Setup(x => x.GetCurrentUserOid())
-                .Returns(_currentUserOid);
-
             _personRepositoryMock
-                .Setup(p => p.GetByOidAsync(It.Is<Guid>(x => x == _currentUserOid)))
+                .Setup(p => p.GetByOidAsync(It.Is<Guid>(x => x == CurrentUserOid)))
                 .Returns(Task.FromResult(_personMock.Object));
 
             _command = new CloseActionCommand(tagId, actionId, _rowVersion);
@@ -65,7 +57,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionCommands.CloseAction
                 _projectRepositoryMock.Object,
                 UnitOfWorkMock.Object,
                 _personRepositoryMock.Object,
-                _currentUserProviderMock.Object
+                CurrentUserProviderMock.Object
             );
         }
 

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/CommandHandlerTestsBase.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/CommandHandlerTestsBase.cs
@@ -9,6 +9,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests
     [TestClass]
     public abstract class CommandHandlerTestsBase
     {
+        protected readonly Guid CurrentUserOid = new Guid("12345678-1234-1234-1234-123456789123"); // todo rename
+        protected Mock<ICurrentUserProvider> CurrentUserProviderMock;
         protected const string TestPlant = "TestPlant";
         protected Mock<IUnitOfWork> UnitOfWorkMock;
         protected Mock<IPlantProvider> PlantProviderMock;
@@ -18,6 +20,10 @@ namespace Equinor.Procosys.Preservation.Command.Tests
         [TestInitialize]
         public void BaseSetup()
         {
+            CurrentUserProviderMock = new Mock<ICurrentUserProvider>();
+            CurrentUserProviderMock
+                .Setup(x => x.GetCurrentUserOid())
+                .Returns(CurrentUserOid);
             UnitOfWorkMock = new Mock<IUnitOfWork>();
             PlantProviderMock = new Mock<IPlantProvider>();
             PlantProviderMock

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementCommands/Preserve/PreserveCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementCommands/Preserve/PreserveCommandHandlerTests.cs
@@ -29,10 +29,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementCommands.Preser
         private const int RequirementForOtherId = 72;
         private const int Interval = 2;
 
-        private readonly Guid _currentUserOid = new Guid("12345678-1234-1234-1234-123456789123");
         private Mock<IProjectRepository> _projectRepoMock;
         private Mock<IPersonRepository> _personRepoMock;
-        private Mock<ICurrentUserProvider> _currentUserProvider;
         private PreserveCommand _commandForSupplierRequirement;
         private PreserveCommand _commandForOtherRequirement;
         private TagRequirement _requirementForSupplier;
@@ -81,17 +79,13 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementCommands.Preser
             });
             _tagInOtherStep.SetProtectedIdForTesting(TagInOtherStepId);
 
-            _currentUserProvider = new Mock<ICurrentUserProvider>();
-            _currentUserProvider
-                .Setup(x => x.GetCurrentUserOid())
-                .Returns(_currentUserOid);
             _projectRepoMock = new Mock<IProjectRepository>();
             _projectRepoMock.Setup(r => r.GetTagByTagIdAsync(TagInSupplierStepId)).Returns(Task.FromResult(_tagInSupplierStep));
             _projectRepoMock.Setup(r => r.GetTagByTagIdAsync(TagInOtherStepId)).Returns(Task.FromResult(_tagInOtherStep));
             _personRepoMock = new Mock<IPersonRepository>();
             _personRepoMock
-                .Setup(p => p.GetByOidAsync(It.Is<Guid>(x => x == _currentUserOid)))
-                .Returns(Task.FromResult(new Person(_currentUserOid, "Test", "User")));
+                .Setup(p => p.GetByOidAsync(It.Is<Guid>(x => x == CurrentUserOid)))
+                .Returns(Task.FromResult(new Person(CurrentUserOid, "Test", "User")));
 
             _commandForSupplierRequirement = new PreserveCommand(TagInSupplierStepId, RequirementForSupplierId);
             _commandForOtherRequirement = new PreserveCommand(TagInOtherStepId, RequirementForOtherId);
@@ -109,7 +103,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementCommands.Preser
                 _projectRepoMock.Object,
                 _personRepoMock.Object,
                 UnitOfWorkMock.Object,
-                _currentUserProvider.Object);
+                CurrentUserProviderMock.Object);
         }
 
         [TestMethod]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/SyncCommands/SyncProjects/SyncProjectsCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/SyncCommands/SyncProjects/SyncProjectsCommandHandlerTests.cs
@@ -1,0 +1,207 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.SyncCommands.SyncProjects;
+using Equinor.Procosys.Preservation.Domain;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
+using Equinor.Procosys.Preservation.MainApi.Project;
+using Equinor.Procosys.Preservation.MainApi.Tag;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Equinor.Procosys.Preservation.Command.Tests.SyncCommands.SyncProjects
+{
+    [TestClass]
+    public class SyncProjectsCommandHandlerTests : CommandHandlerTestsBase
+    {
+        private const string TagNo1 = "TagNo1";
+        private const string TagNo2 = "TagNo2";
+        private const string ProjectName1 = "Project1";
+        private const string OldProjectDescription1 = "OldProject1Description";
+        private const string ProjectName2 = "Project2";
+        private const string ProjectNameNoAccess = "ProjectNoAccess";
+        private const string OldProjectDescription2 = "OldProject2Description";
+        private const string ProjectDescriptionNoAccess = "ProjectDescriptionNoAccess";
+        private const string NewProjectDescription1 = "NewProject1Description";
+        private const string NewProjectDescription2 = "NewProject2Description";
+
+        private Mock<IProjectRepository> _projectRepositoryMock;
+        private Mock<ITagApiService> _tagApiServiceMock;
+        private Mock<IProjectApiService> _projectApiServiceMock;
+        private Mock<IPermissionCache> _permissionCacheMock;
+
+        private ProcosysTagDetails _mainTagDetails1;
+        private ProcosysTagDetails _mainTagDetails2;
+        
+        private SyncProjectsCommand _command;
+        private SyncProjectsCommandHandler _dut;
+        private Project _project1;
+        private Project _project2;
+        private Project _projectNoAccess;
+        private ProcosysProject _mainProject1;
+        private ProcosysProject _mainProject2;
+        private ProcosysProject _mainProjectNoAccess;
+        private Mock<ILogger<SyncProjectsCommandHandler>> _loggerMock;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _project1 = new Project(TestPlant, ProjectName1, OldProjectDescription1);
+            _project2 = new Project(TestPlant, ProjectName2, OldProjectDescription2);
+            _projectNoAccess = new Project(TestPlant, ProjectNameNoAccess, ProjectDescriptionNoAccess);
+            _projectRepositoryMock = new Mock<IProjectRepository>();
+            _projectRepositoryMock
+                .Setup(p => p.GetAllProjectsOnlyAsync())
+                .Returns(Task.FromResult(new List<Project>{ _project1, _project2, _projectNoAccess}));
+
+            _mainProject1 = new ProcosysProject
+            {
+                Name = ProjectName1,
+                Description = NewProjectDescription1,
+                IsClosed = true
+            };
+            _mainProject2 = new ProcosysProject
+            {
+                Name = ProjectName2,
+                Description = NewProjectDescription2,
+                IsClosed = false
+            };
+            _mainProjectNoAccess = new ProcosysProject
+            {
+                Name = ProjectNameNoAccess,
+                Description = ProjectDescriptionNoAccess,
+                IsClosed = true
+            };
+
+            _projectRepositoryMock
+                .Setup(p => p.GetStandardTagsInProjectOnlyAsync(ProjectName1))
+                .Returns(Task.FromResult(new List<Tag>()));
+
+            _projectRepositoryMock
+                .Setup(p => p.GetStandardTagsInProjectOnlyAsync(ProjectName2))
+                .Returns(Task.FromResult(new List<Tag>()));
+
+            _projectApiServiceMock = new Mock<IProjectApiService>();
+            _projectApiServiceMock
+                .Setup(x => x.GetProjectAsync(TestPlant, ProjectName1))
+                .Returns(Task.FromResult(_mainProject1));
+            _projectApiServiceMock
+                .Setup(x => x.GetProjectAsync(TestPlant, ProjectName2))
+                .Returns(Task.FromResult(_mainProject2));
+            _projectApiServiceMock
+                .Setup(x => x.GetProjectAsync(TestPlant, ProjectNameNoAccess))
+                .Returns(Task.FromResult(_mainProjectNoAccess));
+
+            _permissionCacheMock = new Mock<IPermissionCache>();
+            _permissionCacheMock.Setup(p => p.GetProjectNamesForUserOidAsync(TestPlant, CurrentUserOid))
+                .Returns(Task.FromResult<IList<string>>(new List<string> {ProjectName1, ProjectName2}));
+
+            _mainTagDetails1 = new ProcosysTagDetails
+            {
+                AreaCode = "AreaCode1",
+                AreaDescription = "AreaDescription1",
+                CallOffNo = "CalloffNo1",
+                CommPkgNo = "CommPkgNo1",
+                Description = "Description1",
+                DisciplineCode = "DisciplineCode1",
+                DisciplineDescription = "DisciplineDescription1",
+                McPkgNo = "McPkgNo1",
+                PurchaseOrderNo = "PurchaseOrderNo1",
+                TagFunctionCode = "TagFunctionCode1",
+                TagNo = TagNo1,
+                ProjectDescription = OldProjectDescription1
+            };
+            _mainTagDetails2 = new ProcosysTagDetails
+            {
+                AreaCode = "AreaCode2",
+                AreaDescription = "AreaDescription2",
+                CallOffNo = "CalloffNo2",
+                CommPkgNo = "CommPkgNo2",
+                Description = "Description2",
+                DisciplineCode = "DisciplineCode2",
+                DisciplineDescription = "DisciplineDescription1",
+                McPkgNo = "McPkgNo2",
+                PurchaseOrderNo = "PurchaseOrderNo2",
+                TagFunctionCode = "TagFunctionCode2",
+                TagNo = TagNo2,
+                ProjectDescription = OldProjectDescription1
+            };
+
+            IList<ProcosysTagDetails> mainTagDetailList = new List<ProcosysTagDetails> {_mainTagDetails1, _mainTagDetails2};
+            _tagApiServiceMock = new Mock<ITagApiService>();
+            _tagApiServiceMock
+                .Setup(x => x.GetTagDetailsAsync(TestPlant, ProjectName1, new List<string>{TagNo1, TagNo2}))
+                .Returns(Task.FromResult(mainTagDetailList));
+
+            _command = new SyncProjectsCommand();
+
+            _loggerMock = new Mock<ILogger<SyncProjectsCommandHandler>>();
+            _dut = new SyncProjectsCommandHandler(
+                _projectRepositoryMock.Object,
+                UnitOfWorkMock.Object,
+                PlantProviderMock.Object,
+                _projectApiServiceMock.Object,
+                _tagApiServiceMock.Object,
+                _permissionCacheMock.Object,
+                CurrentUserProviderMock.Object,
+                _loggerMock.Object);
+        }
+
+        [TestMethod]
+        public async Task HandlingSyncProjectsCommand_ShouldUpdateProjects()
+        {
+            // Act
+            var result = await _dut.Handle(_command, default);
+
+            // Assert
+            Assert.AreEqual(0, result.Errors.Count);
+            AssertProjectProperties(_mainProject1, _project1);
+            AssertProjectProperties(_mainProject2, _project2);
+        }
+
+        [TestMethod]
+        public async Task HandlingSyncProjectsCommand_ShouldNotUpdateProject_ForProjectWithoutAccess()
+        {
+            // Act
+            await _dut.Handle(_command, default);
+
+            // Assert
+            _projectApiServiceMock.Verify(x => x.GetProjectAsync(TestPlant, ProjectNameNoAccess), Times.Never);
+            Assert.AreEqual(ProjectDescriptionNoAccess, _projectNoAccess.Description);
+            Assert.IsFalse(_projectNoAccess.IsClosed);
+        }
+
+        [TestMethod]
+        public async Task HandlingSyncProjectsCommand_ShouldSave()
+        {
+            // Act
+            await _dut.Handle(_command, default);
+            
+            // Assert
+            UnitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+        }
+
+        private void AssertProjectProperties(ProcosysProject mainProject, Project project)
+        {
+            Assert.AreEqual(mainProject.Description, project.Description);
+            Assert.AreEqual(mainProject.IsClosed, project.IsClosed);
+        }
+
+        private void AssertTagProperties(ProcosysTagDetails mainTag, Tag tag)
+        {
+            Assert.AreEqual(mainTag.AreaCode, tag.AreaCode);
+            Assert.AreEqual(mainTag.AreaDescription, tag.AreaDescription);
+            Assert.AreEqual(mainTag.CallOffNo, tag.Calloff);
+            Assert.AreEqual(mainTag.CommPkgNo, tag.CommPkgNo);
+            Assert.AreEqual(mainTag.DisciplineCode, tag.DisciplineCode);
+            Assert.AreEqual(mainTag.DisciplineDescription, tag.DisciplineDescription);
+            Assert.AreEqual(TagType.Standard, tag.TagType);
+            Assert.AreEqual(mainTag.McPkgNo, tag.McPkgNo);
+            Assert.AreEqual(mainTag.Description, tag.Description);
+            Assert.AreEqual(mainTag.PurchaseOrderNo, tag.PurchaseOrderNo);
+            Assert.AreEqual(TestPlant, tag.Plant);
+            Assert.AreEqual(mainTag.TagFunctionCode, tag.TagFunctionCode);
+            Assert.AreEqual(mainTag.TagNo, tag.TagNo);
+        }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/BulkPreserve/BulkPreserveCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/BulkPreserve/BulkPreserveCommandHandlerTests.cs
@@ -25,10 +25,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.BulkPreserve
         private const int TwoWeeksInterval = 2;
         private const int FourWeeksInterval = 4;
 
-        private readonly Guid _currentUserOid = new Guid("12345678-1234-1234-1234-123456789123");
         private Mock<IProjectRepository> _projectRepoMock;
         private Mock<IPersonRepository> _personRepoMock;
-        private Mock<ICurrentUserProvider> _currentUserProvider;
         private BulkPreserveCommand _command;
         private Tag _tag1;
         private Tag _tag2;
@@ -65,17 +63,13 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.BulkPreserve
             {
                 _tag1, _tag2
             };
-            _currentUserProvider = new Mock<ICurrentUserProvider>();
-            _currentUserProvider
-                .Setup(x => x.GetCurrentUserOid())
-                .Returns(_currentUserOid);
             var tagIds = new List<int> {TagId1, TagId2};
             _projectRepoMock = new Mock<IProjectRepository>();
             _projectRepoMock.Setup(r => r.GetTagsByTagIdsAsync(tagIds)).Returns(Task.FromResult(tags));
             _personRepoMock = new Mock<IPersonRepository>();
             _personRepoMock
-                .Setup(p => p.GetByOidAsync(It.Is<Guid>(x => x == _currentUserOid)))
-                .Returns(Task.FromResult(new Person(_currentUserOid, "Test", "User")));
+                .Setup(p => p.GetByOidAsync(It.Is<Guid>(x => x == CurrentUserOid)))
+                .Returns(Task.FromResult(new Person(CurrentUserOid, "Test", "User")));
             _command = new BulkPreserveCommand(tagIds);
 
             _tag1.StartPreservation();
@@ -85,7 +79,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.BulkPreserve
                 _projectRepoMock.Object,
                 _personRepoMock.Object,
                 UnitOfWorkMock.Object,
-                _currentUserProvider.Object);
+                CurrentUserProviderMock.Object);
         }
 
         [TestMethod]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/Preserve/PreserveCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/Preserve/PreserveCommandHandlerTests.cs
@@ -28,10 +28,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.Preserve
         private const int TwoWeeksInterval = 2;
         private const int FourWeeksInterval = 4;
 
-        private readonly Guid _currentUserOid = new Guid("12345678-1234-1234-1234-123456789123");
         private Mock<IProjectRepository> _projectRepoMock;
         private Mock<IPersonRepository> _personRepoMock;
-        private Mock<ICurrentUserProvider> _currentUserProvider;
         private PreserveCommand _commandForTagWithForAllRequirements;
         private PreserveCommand _commandForTagInSupplierStep;
         private PreserveCommand _commandForTagInOtherStep;
@@ -93,10 +91,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.Preserve
                 _reqForOtherInOtherStep
             });
 
-            _currentUserProvider = new Mock<ICurrentUserProvider>();
-            _currentUserProvider
-                .Setup(x => x.GetCurrentUserOid())
-                .Returns(_currentUserOid);
             _projectRepoMock = new Mock<IProjectRepository>();
             _projectRepoMock.Setup(r => r.GetTagByTagIdAsync(TagWithForAllRequirementsId)).Returns(Task.FromResult(_tagWithForAllRequirements));
             _projectRepoMock.Setup(r => r.GetTagByTagIdAsync(TagInOtherStepId)).Returns(Task.FromResult(_tagWithSupplierAndOtherRequirementsInOtherStep));
@@ -104,8 +98,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.Preserve
             
             _personRepoMock = new Mock<IPersonRepository>();
             _personRepoMock
-                .Setup(p => p.GetByOidAsync(It.Is<Guid>(x => x == _currentUserOid)))
-                .Returns(Task.FromResult(new Person(_currentUserOid, "Test", "User")));
+                .Setup(p => p.GetByOidAsync(It.Is<Guid>(x => x == CurrentUserOid)))
+                .Returns(Task.FromResult(new Person(CurrentUserOid, "Test", "User")));
             _commandForTagWithForAllRequirements = new PreserveCommand(TagWithForAllRequirementsId);
             _commandForTagInOtherStep = new PreserveCommand(TagInOtherStepId);
             _commandForTagInSupplierStep = new PreserveCommand(TagInSupplierStepId);
@@ -118,7 +112,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.Preserve
                 _projectRepoMock.Object,
                 _personRepoMock.Object,
                 UnitOfWorkMock.Object,
-                _currentUserProvider.Object);
+                CurrentUserProviderMock.Object);
         }
 
         [TestMethod]

--- a/src/tests/Equinor.Procosys.Preservation.Infrastructure.Tests/Repositories/ProjectRepositoryTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Infrastructure.Tests/Repositories/ProjectRepositoryTests.cs
@@ -68,22 +68,6 @@ namespace Equinor.Procosys.Preservation.Infrastructure.Tests.Repositories
         }
 
         [TestMethod]
-        public async Task GetAllTagsInProject_Returns3Tags_WhenProjectHas3Tags()
-        {
-            var result = await _dut.GetAllTagsInProjectAsync(ProjectNameWithTags);
-
-            Assert.AreEqual(3, result.Count);
-        }
-
-        [TestMethod]
-        public async Task GetAllTagsInProject_ReturnsZeroTags_WhenProjectHasNoTags()
-        {
-            var result = await _dut.GetAllTagsInProjectAsync(ProjectNameWithoutTags);
-
-            Assert.AreEqual(0, result.Count);
-        }
-
-        [TestMethod]
         public async Task GetTagByTagId_ReturnsTag()
         {
             var result = await _dut.GetTagByTagIdAsync(TestTagId);

--- a/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Client/BearerTokenApiClientTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Client/BearerTokenApiClientTests.cs
@@ -28,7 +28,7 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Client
             var httpClientFactory = HttpHelper.GetHttpClientFactory(HttpStatusCode.OK, "{\"Id\": 123}");
             var dut = new BearerTokenApiClient(httpClientFactory, _bearerTokenProvider.Object, _logger.Object);
 
-            var response = await dut.QueryAndDeserializeAsync<DummyClass>("");
+            var response = await dut.QueryAndDeserializeAsync<DummyClass>("url");
 
             Assert.IsNotNull(response);
             Assert.AreEqual(123, response.Id);
@@ -40,7 +40,7 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Client
             var httpClientFactory = HttpHelper.GetHttpClientFactory(HttpStatusCode.BadGateway, "");
             var dut = new BearerTokenApiClient(httpClientFactory, _bearerTokenProvider.Object, _logger.Object);
 
-            await Assert.ThrowsExceptionAsync<Exception>(async () => await dut.QueryAndDeserializeAsync<DummyClass>(""));
+            await Assert.ThrowsExceptionAsync<Exception>(async () => await dut.QueryAndDeserializeAsync<DummyClass>("url"));
         }
 
         [TestMethod]
@@ -49,7 +49,25 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Client
             var httpClientFactory = HttpHelper.GetHttpClientFactory(HttpStatusCode.OK, "");
             var dut = new BearerTokenApiClient(httpClientFactory, _bearerTokenProvider.Object, _logger.Object);
 
-            await Assert.ThrowsExceptionAsync<JsonException>(async () => await dut.QueryAndDeserializeAsync<DummyClass>(""));
+            await Assert.ThrowsExceptionAsync<JsonException>(async () => await dut.QueryAndDeserializeAsync<DummyClass>("url"));
+        }
+
+        [TestMethod]
+        public async Task QueryAndDeserialize_ThrowsException_WhenNoUrl()
+        {
+            var httpClientFactory = HttpHelper.GetHttpClientFactory(HttpStatusCode.OK, "");
+            var dut = new BearerTokenApiClient(httpClientFactory, _bearerTokenProvider.Object, _logger.Object);
+
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () => await dut.QueryAndDeserializeAsync<DummyClass>(null));
+        }
+
+        [TestMethod]
+        public async Task QueryAndDeserialize_ThrowsException_WhenUrlTooLong()
+        {
+            var httpClientFactory = HttpHelper.GetHttpClientFactory(HttpStatusCode.OK, "");
+            var dut = new BearerTokenApiClient(httpClientFactory, _bearerTokenProvider.Object, _logger.Object);
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(async () => await dut.QueryAndDeserializeAsync<DummyClass>(new string('u', 2001)));
         }
 
         private class DummyClass

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Authorizations/ClaimsTransformationTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Authorizations/ClaimsTransformationTests.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Domain;
 using Equinor.Procosys.Preservation.MainApi.Plant;
 using Equinor.Procosys.Preservation.WebApi.Authorizations;
-using Equinor.Procosys.Preservation.WebApi.Caches;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 


### PR DESCRIPTION
Command supposed to be called from background job. In this PR its also possible to trigger the command from a normal endpoint in SynchronizeController. Logic in Handler:
* For all projects in preservation where user has access to project (checked via IPermissionCache)
* Get updated project details from Main and update properties we've duplicated into preservation
* For project, get all standard preservation tags in it (we can skip Area tags since the've been created in preservation and never exists in Main)
* Page 50 and 50 for standard tags and get updated tag details from Main and update properties we've duplicated into preservation

We don't check if property has been chaanged since EF Core keep track of changes and don't save if no changes

Removed IProjectRepository.GetAllTagsInProjectAsync(string projectName) and tests. Not in use.

Changes and new tests in BearerTokenApiClient to verify that url not too long

Some refactor in some tests to reuse mock of ICurrentUserProvider and CurrentUserOid