### PR TITLE
74884-Uniform Json after validation errors (errorcode 400)

### DIFF
--- a/src/Equinor.Procosys.Preservation.WebApi/Middleware/GlobalExceptionHandler.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Middleware/GlobalExceptionHandler.cs
@@ -48,7 +48,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Middleware
                 var problems = new ValidationProblemDetails(errors)
                 {
                     Status = context.Response.StatusCode,
-                    Title = $"Business validation errors: {errors.Count}"
+                    Title = $"One or more business validation errors occurred. ({errors.Count})"
                 };
                 var json = JsonSerializer.Serialize(problems);
                 _logger.LogInformation(json);


### PR DESCRIPTION
This PR also covers review of commit https://github.com/equinor/procosys-preservation-api/commit/5e307665185f99603fd26880136d6ded7efb415f which was committed to Master without purpose.

Commit message other commit:
"Rewrite GlobalExceptionHandler in catch of ValidationException to return a json of type ValidationProblemDetails. This is what ASP.NET Core do when validating Controller inputs.

We want to return same json structure after business validation errors so client have one structure to handle after all type of 400-errors"