### PR TITLE
74973 Update validator to prohibit voiding of all requirements

### DIFF
--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateAreaTag/CreateAreaTagCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateAreaTag/CreateAreaTagCommandValidator.cs
@@ -79,7 +79,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.CreateAreaTag
             async Task<bool> RequirementUsageIsNotForSupplierStepOnlyAsync(IEnumerable<RequirementForCommand> requirements, CancellationToken token)
             {
                 var reqIds = requirements.Select(dto => dto.RequirementDefinitionId).ToList();
-                return !await requirementDefinitionValidator.HasForSupplierOnlyUsageAsync(reqIds, token);
+                return !await requirementDefinitionValidator.HasAnyForSupplierOnlyUsageAsync(reqIds, token);
             }                        
 
             async Task<bool> NotBeAnExistingAndClosedProjectAsync(string projectName, CancellationToken token)

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateAreaTag/CreateAreaTagCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateAreaTag/CreateAreaTagCommandValidator.cs
@@ -79,7 +79,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.CreateAreaTag
             async Task<bool> RequirementUsageIsNotForSupplierStepOnlyAsync(IEnumerable<RequirementForCommand> requirements, CancellationToken token)
             {
                 var reqIds = requirements.Select(dto => dto.RequirementDefinitionId).ToList();
-                return !await requirementDefinitionValidator.UsageCoversForSupplierOnlyAsync(reqIds, token);
+                return !await requirementDefinitionValidator.HasForSupplierOnlyUsageAsync(reqIds, token);
             }                        
 
             async Task<bool> NotBeAnExistingAndClosedProjectAsync(string projectName, CancellationToken token)

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateTags/CreateTagsCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateTags/CreateTagsCommandValidator.cs
@@ -91,7 +91,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.CreateTags
             async Task<bool> RequirementUsageIsNotForSupplierStepOnlyAsync(IEnumerable<RequirementForCommand> requirements, CancellationToken token)
             {
                 var reqIds = requirements.Select(dto => dto.RequirementDefinitionId).ToList();
-                return !await requirementDefinitionValidator.UsageCoversForSupplierOnlyAsync(reqIds, token);
+                return !await requirementDefinitionValidator.HasForSupplierOnlyUsageAsync(reqIds, token);
             }                        
 
             async Task<bool> NotBeAnExistingTagWithinProjectAsync(string tagNo, string projectName, CancellationToken token) =>

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateTags/CreateTagsCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateTags/CreateTagsCommandValidator.cs
@@ -91,7 +91,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.CreateTags
             async Task<bool> RequirementUsageIsNotForSupplierStepOnlyAsync(IEnumerable<RequirementForCommand> requirements, CancellationToken token)
             {
                 var reqIds = requirements.Select(dto => dto.RequirementDefinitionId).ToList();
-                return !await requirementDefinitionValidator.HasForSupplierOnlyUsageAsync(reqIds, token);
+                return !await requirementDefinitionValidator.HasAnyForSupplierOnlyUsageAsync(reqIds, token);
             }                        
 
             async Task<bool> NotBeAnExistingTagWithinProjectAsync(string tagNo, string projectName, CancellationToken token) =>

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTagStepAndRequirements/RequirementForCommand.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTagStepAndRequirements/RequirementForCommand.cs
@@ -2,15 +2,15 @@
 {
     public class UpdateRequirementForCommand
     {
-        public UpdateRequirementForCommand(int requirementId, int intervalWeeks, bool isVoided, string rowVersion)
+        public UpdateRequirementForCommand(int tagRequirementId, int intervalWeeks, bool isVoided, string rowVersion)
         {
-            RequirementId = requirementId;
+            TagRequirementId = tagRequirementId;
             IntervalWeeks = intervalWeeks;
             IsVoided = isVoided;
             RowVersion = rowVersion;
         }
 
-        public int RequirementId { get;  }
+        public int TagRequirementId { get;  }
         public int IntervalWeeks { get; }
         public bool IsVoided { get; }
         public string RowVersion { get; set; }

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandHandler.cs
@@ -40,7 +40,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.UpdateTagStepAndRequ
 
             foreach (var update in request.UpdatedRequirements)
             {
-                tag.UpdateRequirement(update.RequirementId, update.IsVoided, update.IntervalWeeks, update.RowVersion);
+                tag.UpdateRequirement(update.TagRequirementId, update.IsVoided, update.IntervalWeeks, update.RowVersion);
             }
 
             foreach (var newRequirement in request.NewRequirements)

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandValidator.cs
@@ -35,8 +35,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.UpdateTagStepAndRequ
                             command.UpdatedRequirements.Where(u => u.IsVoided).Select(u => u.TagRequirementId).ToList(),
                             command.NewRequirements.Select(r => r.RequirementDefinitionId).ToList(),
                             token))
-                    .WithMessage(command =>
-                        "Requirements must include requirements to be used both for supplier and other than suppliers!");
+                    .WithMessage(command => "Requirements must include requirements to be used both for supplier and other than suppliers!");
             }).Otherwise(() =>
             {
                 RuleFor(command => command)
@@ -52,8 +51,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.UpdateTagStepAndRequ
                             command.UpdatedRequirements.Where(u => u.IsVoided).Select(u => u.TagRequirementId).ToList(),
                             command.NewRequirements.Select(r => r.RequirementDefinitionId).ToList(),
                             token))
-                    .WithMessage(command =>
-                        "Requirements must include requirements to be used for other than suppliers!")
+                    .WithMessage(command => "Requirements must include requirements to be used for other than suppliers!")
                     .MustAsync((_, command, token) =>
                         RequirementUsageIsNotForSupplierStepOnlyAsync(
                             command.TagId,

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandValidator.cs
@@ -101,7 +101,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.UpdateTagStepAndRequ
                 List<int> tagRequirementIdsToBeVoided,
                 List<int> requirementDefinitionIdsToBeAdded,
                 CancellationToken token)
-                => !await tagValidator.HasForSupplierOnlyUsageAsync(tagId, tagRequirementIdsToBeVoided, requirementDefinitionIdsToBeAdded, token);
+                => !await tagValidator.HasAnyForSupplierOnlyUsageAsync(tagId, tagRequirementIdsToBeVoided, requirementDefinitionIdsToBeAdded, token);
             async Task<bool> BeASupplierStepAsync(int stepId, CancellationToken token)
                 => await stepValidator.IsForSupplierAsync(stepId, token);
             async Task<bool> NotBeAClosedProjectForTagAsync(int tagId, CancellationToken token)

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandValidator.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.Validators.ProjectValidators;
@@ -20,21 +21,48 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.UpdateTagStepAndRequ
             CascadeMode = CascadeMode.StopOnFirstFailure;
 
             RuleFor(command => command)
-                // todo must not void all requirements
-                .MustAsync((_, command, token) => requirementDefinitionValidator.BeUniqueRequirements(command.UpdatedRequirements.Select(u => u.RequirementId).ToList(), command.NewRequirements.Select(r => r.RequirementDefinitionId).ToList(), token))
-                .WithMessage(command => "Requirement definitions must be unique!");
+                .MustAsync((_, command, token) =>
+                    RequirementsMustBeUniqueAfterUpdateAsync(
+                        command.TagId,
+                        command.NewRequirements.Select(r => r.RequirementDefinitionId).ToList(),
+                        token))
+                .WithMessage(command => "Requirements must be unique!")
+                .MustAsync((_, command, token) =>
+                    NotAllRequirementsCanBeVoidedAfterUpdateAsync(
+                        command.TagId, 
+                        command.UpdatedRequirements.Where(u => u.IsVoided).Select(u => u.TagRequirementId).ToList(),
+                        command.NewRequirements.Any(), 
+                        token))
+                .WithMessage(command => "Not all requirement can be voided!");
 
             WhenAsync((command, token) => BeASupplierStepAsync(command.StepId, token), () =>
             {
                 RuleFor(command => command)
-                    .MustAsync((_, command, token) => requirementDefinitionValidator.RequirementUsageIsForAllJourneysAsync(command.UpdatedRequirements.Select(u => u.RequirementId), command.NewRequirements.Select(r => r.RequirementDefinitionId), token))
-                    .WithMessage(command => "Requirements must include requirements to be used both for supplier and other than suppliers!");
+                    .MustAsync((_, command, token) =>
+                        RequirementUsageIsForAllJourneysAsync(
+                            command.TagId, 
+                            command.UpdatedRequirements.Where(u => u.IsVoided).Select(u => u.TagRequirementId).ToList(),
+                            command.NewRequirements.Select(r => r.RequirementDefinitionId).ToList(), 
+                            token))
+                    .WithMessage(command =>
+                        "Requirements must include requirements to be used both for supplier and other than suppliers!");
             }).Otherwise(() =>
             {
                 RuleFor(command => command)
-                    .MustAsync((_, command, token) => requirementDefinitionValidator.RequirementUsageIsForJourneysWithoutSupplierAsync(command.UpdatedRequirements.Select(u => u.RequirementId), command.NewRequirements.Select(r => r.RequirementDefinitionId), token))
-                    .WithMessage(command => "Requirements must include requirements to be used for other than suppliers!")
-                    .MustAsync((_, command, token) => requirementDefinitionValidator.RequirementUsageIsNotForSupplierStepOnlyAsync(command.UpdatedRequirements.Select(u => u.RequirementId), command.NewRequirements.Select(r => r.RequirementDefinitionId), token))
+                    .MustAsync((_, command, token) =>
+                        RequirementUsageIsForJourneysWithoutSupplierAsync(
+                            command.TagId, 
+                            command.UpdatedRequirements.Where(u => u.IsVoided).Select(u => u.TagRequirementId).ToList(),
+                            command.NewRequirements.Select(r => r.RequirementDefinitionId).ToList(), 
+                            token))
+                    .WithMessage(command =>
+                        "Requirements must include requirements to be used for other than suppliers!")
+                    .MustAsync((_, command, token) =>
+                        RequirementUsageIsNotForSupplierStepOnlyAsync(
+                            command.TagId, 
+                            command.UpdatedRequirements.Where(u => u.IsVoided).Select(u => u.TagRequirementId).ToList(),
+                            command.NewRequirements.Select(r => r.RequirementDefinitionId).ToList(), 
+                            token))
                     .WithMessage(command => "Requirements can't include requirements just for suppliers!");
             });
 
@@ -45,7 +73,43 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.UpdateTagStepAndRequ
                 .WithMessage(command => $"Tag doesn't exist! Tag={command.TagId}")
                 .MustAsync((command, token) => NotBeAVoidedTagAsync(command.TagId, token))
                 .WithMessage(command => $"Tag is voided! Tag={command.TagId}");
+            
+            RuleForEach(command => command.UpdatedRequirements)
+                .MustAsync((command, req, __, token) => BeAnExistingTagRequirementAsync(command.TagId, req.TagRequirementId, token))
+                .WithMessage((_, req) => $"Requirement doesn't exists! Requirement={req.TagRequirementId}");
+            
+            RuleForEach(command => command.NewRequirements)
+                .MustAsync((_, req, __, token) => BeAnExistingRequirementDefinitionAsync(req.RequirementDefinitionId, token))
+                .WithMessage((_, req) =>
+                    $"Requirement definition doesn't exists! Requirement={req.RequirementDefinitionId}")
+                .MustAsync((_, req, __, token) => NotBeAVoidedRequirementDefinitionAsync(req.RequirementDefinitionId, token))
+                .WithMessage((_, req) =>
+                    $"Requirement definition is voided! Requirement={req.RequirementDefinitionId}");
 
+            async Task<bool> RequirementsMustBeUniqueAfterUpdateAsync(int tagId, List<int> requirementDefinitionIdsToBeAdded, CancellationToken token)
+                => requirementDefinitionIdsToBeAdded.Count == 0 || 
+                   await tagValidator.AllRequirementsWillBeUniqueAsync(tagId, requirementDefinitionIdsToBeAdded, token);
+            async Task<bool> NotAllRequirementsCanBeVoidedAfterUpdateAsync(int tagId, List<int> tagRequirementIdsToBeVoided, bool newRequirementAdded, CancellationToken token)
+                => newRequirementAdded || 
+                   !await tagValidator.AllRequirementsWillBeVoidedAsync(tagId, tagRequirementIdsToBeVoided, token);
+            async Task<bool> RequirementUsageIsForAllJourneysAsync(
+                int tagId, 
+                List<int> tagRequirementIdsToBeVoided,
+                List<int> requirementDefinitionIdsToBeAdded,
+                CancellationToken token)
+                => await tagValidator.UsageCoversBothForSupplierAndOtherAsync(tagId, tagRequirementIdsToBeVoided, requirementDefinitionIdsToBeAdded, token);
+            async Task<bool> RequirementUsageIsForJourneysWithoutSupplierAsync(
+                int tagId, 
+                List<int> tagRequirementIdsToBeVoided,
+                List<int> requirementDefinitionIdsToBeAdded,
+                CancellationToken token)
+                => await tagValidator.UsageCoversForOtherThanSuppliersAsync(tagId, tagRequirementIdsToBeVoided, requirementDefinitionIdsToBeAdded, token);
+            async Task<bool> RequirementUsageIsNotForSupplierStepOnlyAsync(
+                int tagId, 
+                List<int> tagRequirementIdsToBeVoided,
+                List<int> requirementDefinitionIdsToBeAdded,
+                CancellationToken token)
+                => !await tagValidator.UsageCoversForSupplierOnlyAsync(tagId, tagRequirementIdsToBeVoided, requirementDefinitionIdsToBeAdded, token);
             async Task<bool> BeASupplierStepAsync(int stepId, CancellationToken token)
                 => await stepValidator.IsForSupplierAsync(stepId, token);
             async Task<bool> NotBeAClosedProjectForTagAsync(int tagId, CancellationToken token)
@@ -54,6 +118,12 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.UpdateTagStepAndRequ
                 => await tagValidator.ExistsAsync(tagId, token);
             async Task<bool> NotBeAVoidedTagAsync(int tagId, CancellationToken token)
                 => !await tagValidator.IsVoidedAsync(tagId, token);
+            async Task<bool> BeAnExistingRequirementDefinitionAsync(int requirementDefinitionId, CancellationToken token)
+                => await requirementDefinitionValidator.ExistsAsync(requirementDefinitionId, token);
+            async Task<bool> NotBeAVoidedRequirementDefinitionAsync(int requirementDefinitionId, CancellationToken token)
+                => !await requirementDefinitionValidator.IsVoidedAsync(requirementDefinitionId, token);
+            async Task<bool> BeAnExistingTagRequirementAsync(int tagId, int tagRequirementId, CancellationToken token)
+                => await tagValidator.HasRequirementAsync(tagId, tagRequirementId, token);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/IRequirementDefinitionValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/IRequirementDefinitionValidator.cs
@@ -10,6 +10,6 @@ namespace Equinor.Procosys.Preservation.Command.Validators.RequirementDefinition
         Task<bool> IsVoidedAsync(int requirementDefinitionId, CancellationToken token);
         Task<bool> UsageCoversBothForSupplierAndOtherAsync(List<int> requirementDefinitionIds, CancellationToken token);
         Task<bool> UsageCoversForOtherThanSuppliersAsync(List<int> requirementDefinitionIds, CancellationToken token);
-        Task<bool> UsageCoversForSupplierOnlyAsync(List<int> requirementDefinitionIds, CancellationToken token);
+        Task<bool> HasForSupplierOnlyUsageAsync(List<int> requirementDefinitionIds, CancellationToken token);
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/IRequirementDefinitionValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/IRequirementDefinitionValidator.cs
@@ -10,6 +10,6 @@ namespace Equinor.Procosys.Preservation.Command.Validators.RequirementDefinition
         Task<bool> IsVoidedAsync(int requirementDefinitionId, CancellationToken token);
         Task<bool> UsageCoversBothForSupplierAndOtherAsync(List<int> requirementDefinitionIds, CancellationToken token);
         Task<bool> UsageCoversForOtherThanSuppliersAsync(List<int> requirementDefinitionIds, CancellationToken token);
-        Task<bool> HasForSupplierOnlyUsageAsync(List<int> requirementDefinitionIds, CancellationToken token);
+        Task<bool> HasAnyForSupplierOnlyUsageAsync(List<int> requirementDefinitionIds, CancellationToken token);
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/IRequirementDefinitionValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/IRequirementDefinitionValidator.cs
@@ -11,9 +11,5 @@ namespace Equinor.Procosys.Preservation.Command.Validators.RequirementDefinition
         Task<bool> UsageCoversBothForSupplierAndOtherAsync(List<int> requirementDefinitionIds, CancellationToken token);
         Task<bool> UsageCoversForOtherThanSuppliersAsync(List<int> requirementDefinitionIds, CancellationToken token);
         Task<bool> UsageCoversForSupplierOnlyAsync(List<int> requirementDefinitionIds, CancellationToken token);
-        Task<bool> BeUniqueRequirements(IEnumerable<int> updatedTagReqIds, IEnumerable<int> newReqDefIds, CancellationToken token);
-        Task<bool> RequirementUsageIsForAllJourneysAsync(IEnumerable<int> updatedTagReqIds, IEnumerable<int> newReqDefIds, CancellationToken token);
-        Task<bool> RequirementUsageIsForJourneysWithoutSupplierAsync(IEnumerable<int> updatedTagReqIds, IEnumerable<int> newReqDefIds, CancellationToken token);
-        Task<bool> RequirementUsageIsNotForSupplierStepOnlyAsync(IEnumerable<int> updatedTagReqIds, IEnumerable<int> newReqDefIds, CancellationToken token);
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/RequirementDefinitionValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/RequirementDefinitionValidator.cs
@@ -42,7 +42,7 @@ namespace Equinor.Procosys.Preservation.Command.Validators.RequirementDefinition
                    reqDefs.Any(rd => rd.Usage == RequirementUsage.ForOtherThanSuppliers);
         }
 
-        public async Task<bool> UsageCoversForSupplierOnlyAsync(List<int> requirementDefinitionIds, CancellationToken token)
+        public async Task<bool> HasForSupplierOnlyUsageAsync(List<int> requirementDefinitionIds, CancellationToken token)
         {
             var reqDefs = await GetRequirementDefinitions(requirementDefinitionIds, token);
             return reqDefs.Any(rd => rd.Usage == RequirementUsage.ForSuppliersOnly);

--- a/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/RequirementDefinitionValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/RequirementDefinitionValidator.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Domain;
-using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
 using Microsoft.EntityFrameworkCore;
 
@@ -47,55 +46,6 @@ namespace Equinor.Procosys.Preservation.Command.Validators.RequirementDefinition
         {
             var reqDefs = await GetRequirementDefinitions(requirementDefinitionIds, token);
             return reqDefs.Any(rd => rd.Usage == RequirementUsage.ForSuppliersOnly);
-        }
-
-        public async Task<bool> BeUniqueRequirements(IEnumerable<int> updatedTagReqIds, IEnumerable<int> newReqDefIds, CancellationToken token)
-        {
-            var updatedReqDefIds = await GetAllUpdatedReqDefIds(updatedTagReqIds, token);
-            var newReqDefIdsList = newReqDefIds.ToList();
-            
-            if (newReqDefIdsList.Distinct().Count() != newReqDefIdsList.Count())
-            {
-                return false;
-            }
-
-            return updatedReqDefIds.Intersect(newReqDefIdsList).Any() == false;
-        }
-
-        public async Task<bool> RequirementUsageIsForAllJourneysAsync(IEnumerable<int> updatedTagReqIds, IEnumerable<int> newReqDefIds, CancellationToken token)
-        {
-            var updatedReqDefIds = await GetAllUpdatedReqDefIds(updatedTagReqIds, token);
-
-            var allReqDefIds = updatedReqDefIds.Union(newReqDefIds).ToList();
-
-            return (allReqDefIds.Count == 0) || (await UsageCoversBothForSupplierAndOtherAsync(allReqDefIds, token));
-        }
-
-        public async Task<bool> RequirementUsageIsForJourneysWithoutSupplierAsync(IEnumerable<int> updatedTagReqIds, IEnumerable<int> newReqDefIds, CancellationToken token)
-        {
-            var updatedReqDefIds = await GetAllUpdatedReqDefIds(updatedTagReqIds, token);
-
-            var allReqDefIds = updatedReqDefIds.Union(newReqDefIds).ToList();
-
-            return (allReqDefIds.Count == 0) || await UsageCoversForOtherThanSuppliersAsync(allReqDefIds, token);
-        }
-
-        public async Task<bool> RequirementUsageIsNotForSupplierStepOnlyAsync(IEnumerable<int> updatedTagReqIds, IEnumerable<int> newReqDefIds, CancellationToken token)
-        {
-            var updatedReqDefIds = await GetAllUpdatedReqDefIds(updatedTagReqIds, token);
-
-            var allReqDefIds = updatedReqDefIds.Union(newReqDefIds).ToList();
-
-            return (allReqDefIds.Count == 0) || !await UsageCoversForSupplierOnlyAsync(allReqDefIds, token);
-        }
-
-        private async Task<List<int>> GetAllUpdatedReqDefIds(IEnumerable<int> updatedTagReqIds, CancellationToken token)
-        {
-            var updatedReqDefIds = await (from req in _context.QuerySet<TagRequirement>()
-                                          where updatedTagReqIds.Contains(req.Id)
-                                          select req.RequirementDefinitionId).ToListAsync(token);
-
-            return updatedReqDefIds;
         }
 
         private async Task<List<RequirementDefinition>> GetRequirementDefinitions(

--- a/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/RequirementDefinitionValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/RequirementDefinitionValidator.cs
@@ -42,7 +42,7 @@ namespace Equinor.Procosys.Preservation.Command.Validators.RequirementDefinition
                    reqDefs.Any(rd => rd.Usage == RequirementUsage.ForOtherThanSuppliers);
         }
 
-        public async Task<bool> HasForSupplierOnlyUsageAsync(List<int> requirementDefinitionIds, CancellationToken token)
+        public async Task<bool> HasAnyForSupplierOnlyUsageAsync(List<int> requirementDefinitionIds, CancellationToken token)
         {
             var reqDefs = await GetRequirementDefinitions(requirementDefinitionIds, token);
             return reqDefs.Any(rd => rd.Usage == RequirementUsage.ForSuppliersOnly);

--- a/src/Equinor.Procosys.Preservation.Command/Validators/TagValidators/ITagValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/TagValidators/ITagValidator.cs
@@ -39,6 +39,6 @@ namespace Equinor.Procosys.Preservation.Command.Validators.TagValidators
         
         Task<bool> UsageCoversForOtherThanSuppliersAsync(int tagId, List<int> tagRequirementIdsToBeVoided, List<int> requirementDefinitionIdsToBeAdded, CancellationToken token);
         
-        Task<bool> HasForSupplierOnlyUsageAsync(int tagId, List<int> tagRequirementIdsToBeVoided, List<int> requirementDefinitionIdsToBeAdded, CancellationToken token);
+        Task<bool> HasAnyForSupplierOnlyUsageAsync(int tagId, List<int> tagRequirementIdsToBeVoided, List<int> requirementDefinitionIdsToBeAdded, CancellationToken token);
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/Validators/TagValidators/ITagValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/TagValidators/ITagValidator.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
 
@@ -29,5 +30,17 @@ namespace Equinor.Procosys.Preservation.Command.Validators.TagValidators
         Task<bool> IsReadyToBeCompletedAsync(int tagId, CancellationToken token);
             
         Task<bool> IsReadyToBeTransferredAsync(int tagId, CancellationToken token);
+        
+        Task<bool> AllRequirementsWillBeVoidedAsync(int tagId, List<int> tagRequirementIdsToBeVoided, CancellationToken token);
+        
+        Task<bool> HasRequirementAsync(int tagId, int tagRequirementId, CancellationToken token);
+        
+        Task<bool> AllRequirementsWillBeUniqueAsync(int tagId, List<int> requirementDefinitionIdsToBeAdded, CancellationToken token);
+        
+        Task<bool> UsageCoversBothForSupplierAndOtherAsync(int tagId, List<int> tagRequirementIdsToBeVoided, List<int> requirementDefinitionIdsToBeAdded, CancellationToken token);
+        
+        Task<bool> UsageCoversForOtherThanSuppliersAsync(int tagId, List<int> tagRequirementIdsToBeVoided, List<int> requirementDefinitionIdsToBeAdded, CancellationToken token);
+        
+        Task<bool> UsageCoversForSupplierOnlyAsync(int tagId, List<int> tagRequirementIdsToBeVoided, List<int> requirementDefinitionIdsToBeAdded, CancellationToken token);
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/Validators/TagValidators/ITagValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/TagValidators/ITagValidator.cs
@@ -31,8 +31,6 @@ namespace Equinor.Procosys.Preservation.Command.Validators.TagValidators
             
         Task<bool> IsReadyToBeTransferredAsync(int tagId, CancellationToken token);
         
-        Task<bool> AllRequirementsWillBeVoidedAsync(int tagId, List<int> tagRequirementIdsToBeVoided, CancellationToken token);
-        
         Task<bool> HasRequirementAsync(int tagId, int tagRequirementId, CancellationToken token);
         
         Task<bool> AllRequirementsWillBeUniqueAsync(int tagId, List<int> requirementDefinitionIdsToBeAdded, CancellationToken token);
@@ -41,6 +39,6 @@ namespace Equinor.Procosys.Preservation.Command.Validators.TagValidators
         
         Task<bool> UsageCoversForOtherThanSuppliersAsync(int tagId, List<int> tagRequirementIdsToBeVoided, List<int> requirementDefinitionIdsToBeAdded, CancellationToken token);
         
-        Task<bool> UsageCoversForSupplierOnlyAsync(int tagId, List<int> tagRequirementIdsToBeVoided, List<int> requirementDefinitionIdsToBeAdded, CancellationToken token);
+        Task<bool> HasForSupplierOnlyUsageAsync(int tagId, List<int> tagRequirementIdsToBeVoided, List<int> requirementDefinitionIdsToBeAdded, CancellationToken token);
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/Validators/TagValidators/TagValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/TagValidators/TagValidator.cs
@@ -210,7 +210,7 @@ namespace Equinor.Procosys.Preservation.Command.Validators.TagValidators
             return await _requirementDefinitionValidator.UsageCoversForOtherThanSuppliersAsync(requirementDefinitionIds, token);
         }
 
-        public async Task<bool> HasForSupplierOnlyUsageAsync(
+        public async Task<bool> HasAnyForSupplierOnlyUsageAsync(
             int tagId,
             List<int> tagRequirementIdsToBeVoided,
             List<int> requirementDefinitionIdsToBeAdded,
@@ -229,7 +229,7 @@ namespace Equinor.Procosys.Preservation.Command.Validators.TagValidators
                 return false;
             }
 
-            return await _requirementDefinitionValidator.HasForSupplierOnlyUsageAsync(requirementDefinitionIds, token);
+            return await _requirementDefinitionValidator.HasAnyForSupplierOnlyUsageAsync(requirementDefinitionIds, token);
         }
 
         private async Task<Tag> GetTagWithoutIncludes(int tagId, CancellationToken token)

--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/Tag.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/Tag.cs
@@ -389,8 +389,7 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate
 
         public void UpdateRequirement(int requirementId, bool isVoided, int intervalWeeks, string requirementRowVersion)
         {
-            var tagRequirement =
-                Requirements.Single(r => r.Id == requirementId);
+            var tagRequirement = Requirements.Single(r => r.Id == requirementId);
 
             if (tagRequirement.IsVoided != isVoided)
             {

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateAreaTag/CreateAreaTagCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateAreaTag/CreateAreaTagCommandValidatorTests.cs
@@ -188,7 +188,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateAreaTag
         {
             _stepValidatorMock.Setup(r => r.IsForSupplierAsync(_stepId, default)).Returns(Task.FromResult(false));
             _rdValidatorMock.Setup(r => r.UsageCoversForOtherThanSuppliersAsync(new List<int>{_rd1Id, _rd2Id}, default)).Returns(Task.FromResult(true));
-            _rdValidatorMock.Setup(r => r.HasForSupplierOnlyUsageAsync(new List<int>{_rd1Id, _rd2Id}, default)).Returns(Task.FromResult(true));
+            _rdValidatorMock.Setup(r => r.HasAnyForSupplierOnlyUsageAsync(new List<int>{_rd1Id, _rd2Id}, default)).Returns(Task.FromResult(true));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateAreaTag/CreateAreaTagCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateAreaTag/CreateAreaTagCommandValidatorTests.cs
@@ -188,7 +188,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateAreaTag
         {
             _stepValidatorMock.Setup(r => r.IsForSupplierAsync(_stepId, default)).Returns(Task.FromResult(false));
             _rdValidatorMock.Setup(r => r.UsageCoversForOtherThanSuppliersAsync(new List<int>{_rd1Id, _rd2Id}, default)).Returns(Task.FromResult(true));
-            _rdValidatorMock.Setup(r => r.UsageCoversForSupplierOnlyAsync(new List<int>{_rd1Id, _rd2Id}, default)).Returns(Task.FromResult(true));
+            _rdValidatorMock.Setup(r => r.HasForSupplierOnlyUsageAsync(new List<int>{_rd1Id, _rd2Id}, default)).Returns(Task.FromResult(true));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateTags/CreateTagsCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateTags/CreateTagsCommandValidatorTests.cs
@@ -217,7 +217,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateTags
         {
             _stepValidatorMock.Setup(r => r.IsForSupplierAsync(_stepId, default)).Returns(Task.FromResult(false));
             _rdValidatorMock.Setup(r => r.UsageCoversForOtherThanSuppliersAsync(new List<int>{_rd1Id, _rd2Id}, default)).Returns(Task.FromResult(true));
-            _rdValidatorMock.Setup(r => r.UsageCoversForSupplierOnlyAsync(new List<int>{_rd1Id, _rd2Id}, default)).Returns(Task.FromResult(true));
+            _rdValidatorMock.Setup(r => r.HasForSupplierOnlyUsageAsync(new List<int>{_rd1Id, _rd2Id}, default)).Returns(Task.FromResult(true));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateTags/CreateTagsCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateTags/CreateTagsCommandValidatorTests.cs
@@ -217,7 +217,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateTags
         {
             _stepValidatorMock.Setup(r => r.IsForSupplierAsync(_stepId, default)).Returns(Task.FromResult(false));
             _rdValidatorMock.Setup(r => r.UsageCoversForOtherThanSuppliersAsync(new List<int>{_rd1Id, _rd2Id}, default)).Returns(Task.FromResult(true));
-            _rdValidatorMock.Setup(r => r.HasForSupplierOnlyUsageAsync(new List<int>{_rd1Id, _rd2Id}, default)).Returns(Task.FromResult(true));
+            _rdValidatorMock.Setup(r => r.HasAnyForSupplierOnlyUsageAsync(new List<int>{_rd1Id, _rd2Id}, default)).Returns(Task.FromResult(true));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandHandlerTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.TagCommands.UpdateTagStepAndRequirements;

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandHandlerTests.cs
@@ -207,27 +207,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
         }
 
         [TestMethod]
-        public async Task HandlingUpdateTagStepAndRequirementsCommand_ShouldFail_WhenVoidingOnlyRequirement()
-        {
-            // Arrange
-            var tagRequirement = _tagWithOneRequirement.Requirements.First();
-            Assert.IsFalse(tagRequirement.IsVoided);
-            var updatedRequirements = new List<UpdateRequirementForCommand>
-            {
-                new UpdateRequirementForCommand(tagRequirement.Id, ThreeWeekInterval, true, RowVersion)
-            };
-            var command = new UpdateTagStepAndRequirementsCommand(
-                TagId1,
-                StepId2,
-                updatedRequirements,
-                new List<RequirementForCommand>(),
-                RowVersion);
-
-            // Act
-            await Assert.ThrowsExceptionAsync<Exception>(() => _dut.Handle(command, default));
-        }
-
-        [TestMethod]
         public async Task HandlingUpdateTagStepAndRequirementsCommand_ShouldBeAbleToVoidRequirement_WhenNonVoidingRequirementExistsAfter()
         {
             // Arrange

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandValidatorTests.cs
@@ -18,17 +18,16 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
         private Mock<IStepValidator> _stepValidatorMock;
         private Mock<IProjectValidator> _projectValidatorMock;
         private Mock<IRequirementDefinitionValidator> _rdValidatorMock;
-        private UpdateTagStepAndRequirementsCommand _command;
+        private UpdateTagStepAndRequirementsCommand _addTwoReqsCommand;
 
         private int _supplierStep = 1;
 
-        private int _tr1Id = 2;
-        private int _tr2Id = 3;
-        private int _rd3NotSupplierId = 4;
+        private int _tagReq1Id = 12;
+        private int _tagReq2Id = 13;
+        private int _reqDef1Id = 2;
+        private int _reqDef2Id = 3;
+        private int _reqDef3Id = 4;
         private int _tagId = 123;
-        private int _voidedTagId = 456;
-        private int _notFoundTagId = 789;
-        private int _tagIdOnClosedProject = 321;
         private const string RowVersion = "AAAAAAAAD6U=";
 
         [TestInitialize]
@@ -36,79 +35,55 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
         {
             _tagValidatorMock = new Mock<ITagValidator>();
             _tagValidatorMock.Setup(t => t.ExistsAsync(_tagId, default)).Returns(Task.FromResult(true));
-            _tagValidatorMock.Setup(t => t.ExistsAsync(_voidedTagId, default)).Returns(Task.FromResult(true));
-            _tagValidatorMock.Setup(t => t.ExistsAsync(_tagIdOnClosedProject, default)).Returns(Task.FromResult(true));
-            _tagValidatorMock.Setup(t => t.ExistsAsync(_notFoundTagId, default)).Returns(Task.FromResult(false));
-            _tagValidatorMock.Setup(t => t.IsVoidedAsync(_voidedTagId, default)).Returns(Task.FromResult(true));
+            _tagValidatorMock.Setup(t => t.HasRequirementAsync(_tagId, _tagReq1Id, default)).Returns(Task.FromResult(true));
+            _tagValidatorMock.Setup(t => t.HasRequirementAsync(_tagId, _tagReq2Id, default)).Returns(Task.FromResult(true));
+            _tagValidatorMock.Setup(t => t.AllRequirementsWillBeUniqueAsync(_tagId, new List<int>{_reqDef1Id, _reqDef2Id}, default)).Returns(Task.FromResult(true));
+            _tagValidatorMock.Setup(t => t.UsageCoversBothForSupplierAndOtherAsync(_tagId, new List<int>(), new List<int>{_reqDef1Id, _reqDef2Id}, default)).Returns(Task.FromResult(true));
 
             _stepValidatorMock = new Mock<IStepValidator>();
             _stepValidatorMock.Setup(r => r.ExistsAsync(_supplierStep, default)).Returns(Task.FromResult(true));
             _stepValidatorMock.Setup(r => r.IsForSupplierAsync(_supplierStep, default)).Returns(Task.FromResult(true));
 
             _projectValidatorMock = new Mock<IProjectValidator>();
-            _projectValidatorMock.Setup(p => p.IsClosedForTagAsync(_tagId, default)).Returns(Task.FromResult(false));
-            _projectValidatorMock.Setup(p => p.IsClosedForTagAsync(_voidedTagId, default))
-                .Returns(Task.FromResult(false));
-            _projectValidatorMock.Setup(p => p.IsClosedForTagAsync(_tagIdOnClosedProject, default))
-                .Returns(Task.FromResult(true));
 
             _rdValidatorMock = new Mock<IRequirementDefinitionValidator>();
-            _rdValidatorMock.Setup(r => r.ExistsAsync(_tr1Id, default))
-                .Returns(Task.FromResult(true));
-            _rdValidatorMock.Setup(r => r.ExistsAsync(_tr2Id, default))
-                .Returns(Task.FromResult(true));
-            _rdValidatorMock.Setup(r => r.ExistsAsync(_rd3NotSupplierId, default)).Returns(Task.FromResult(true));
-            _rdValidatorMock.Setup(r => r.BeUniqueRequirements(new List<int>{_tr1Id, _tr2Id}, new List<int>(), default))
-                .Returns(Task.FromResult(true));
-            _rdValidatorMock.Setup(r => r.BeUniqueRequirements(new List<int>(), new List<int>(), default))
-                .Returns(Task.FromResult(true));
-            _rdValidatorMock
-                .Setup(r => r.UsageCoversBothForSupplierAndOtherAsync(
-                    new List<int> {_tr1Id, _tr2Id, _rd3NotSupplierId}, default))
-                .Returns(Task.FromResult(true));
-            _rdValidatorMock.Setup(r => r.RequirementUsageIsForAllJourneysAsync(new List<int> { _tr1Id, _tr2Id }, new List<int>(), default))
-                .Returns(Task.FromResult(true));
-            _rdValidatorMock.Setup(r => r.RequirementUsageIsForAllJourneysAsync(new List<int> (), new List<int>(), default))
-                .Returns(Task.FromResult(true));
-            _rdValidatorMock
-                .Setup(
-                    r => r.UsageCoversForOtherThanSuppliersAsync(new List<int> {_tr1Id}, default))
-                .Returns(Task.FromResult(true));
+            _rdValidatorMock.Setup(r => r.ExistsAsync(_reqDef1Id, default)).Returns(Task.FromResult(true));
+            _rdValidatorMock.Setup(r => r.ExistsAsync(_reqDef2Id, default)).Returns(Task.FromResult(true));
+
+            _dut = new UpdateTagStepAndRequirementsCommandValidator(
+                _projectValidatorMock.Object,
+                _tagValidatorMock.Object,
+                _stepValidatorMock.Object,
+                _rdValidatorMock.Object);
+
+            _addTwoReqsCommand = new UpdateTagStepAndRequirementsCommand(
+                _tagId,
+                _supplierStep,
+                new List<UpdateRequirementForCommand>(), 
+                new List<RequirementForCommand>
+                {
+                    new RequirementForCommand(_reqDef1Id, 1), 
+                    new RequirementForCommand(_reqDef2Id, 1)
+                },
+                null);
         }
 
         [TestMethod]
-        public void Validate_ShouldBeValid_WhenOkState()
+        public void Validate_ShouldBeValid_WhenAddingNewUniqueRequirements()
         {
-            // Arrange
-            _dut = new UpdateTagStepAndRequirementsCommandValidator(_projectValidatorMock.Object,
-                _tagValidatorMock.Object, _stepValidatorMock.Object, _rdValidatorMock.Object);
-
-            _command = new UpdateTagStepAndRequirementsCommand(
-                _tagId,
-                _supplierStep,
-                new List<UpdateRequirementForCommand>
-                {
-                    new UpdateRequirementForCommand(_tr1Id, 1, true, RowVersion),
-                    new UpdateRequirementForCommand(_tr2Id, 1, false, RowVersion)
-                },
-                new List<RequirementForCommand>(),
-                null);
-
             // Act
-            var result = _dut.Validate(_command);
+            var result = _dut.Validate(_addTwoReqsCommand);
 
             // Assert
             Assert.IsTrue(result.IsValid);
         }
 
         [TestMethod]
-        public void Validate_ShouldBeValid_WhenEmptyLists()
+        public void Validate_ShouldBeValid_WhenNeitherUpdateOrAdd()
         {
             // Arrange
-            _dut = new UpdateTagStepAndRequirementsCommandValidator(_projectValidatorMock.Object,
-                _tagValidatorMock.Object, _stepValidatorMock.Object, _rdValidatorMock.Object);
-
-            _command = new UpdateTagStepAndRequirementsCommand(
+            _tagValidatorMock.Setup(t => t.UsageCoversBothForSupplierAndOtherAsync(_tagId, new List<int>(), new List<int>(), default)).Returns(Task.FromResult(true));
+            var command = new UpdateTagStepAndRequirementsCommand(
                 _tagId,
                 _supplierStep,
                 new List<UpdateRequirementForCommand>(),
@@ -116,66 +91,86 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
                 null);
 
             // Act
-            var result = _dut.Validate(_command);
+            var result = _dut.Validate(command);
 
             // Assert
             Assert.IsTrue(result.IsValid);
+        }
+        
+        [TestMethod]
+        public void Validate_ShouldBeValid_WhenVoidingAllRequirementsButAddingNew()
+        {
+            // Arrange
+            _rdValidatorMock.Setup(r => r.ExistsAsync(_reqDef3Id, default)).Returns(Task.FromResult(true));
+            _tagValidatorMock.Setup(t => t.AllRequirementsWillBeVoidedAsync(_tagId, new List<int>{_tagReq1Id, _tagReq2Id}, default)).Returns(Task.FromResult(true));
+            _tagValidatorMock.Setup(t => t.AllRequirementsWillBeUniqueAsync(_tagId, new List<int>{_reqDef3Id}, default)).Returns(Task.FromResult(true));
+            _tagValidatorMock.Setup(t => t.UsageCoversBothForSupplierAndOtherAsync(_tagId, new List<int>{_tagReq1Id, _tagReq2Id}, new List<int>{_reqDef3Id}, default)).Returns(Task.FromResult(true));
+            var command = new UpdateTagStepAndRequirementsCommand(
+                _tagId,
+                _supplierStep,
+                new List<UpdateRequirementForCommand>
+                {
+                    new UpdateRequirementForCommand(_tagReq1Id, 1, true, RowVersion),
+                    new UpdateRequirementForCommand(_tagReq2Id, 1, true, RowVersion)
+                },
+                new List<RequirementForCommand> {new RequirementForCommand(_reqDef3Id, 1)},
+                null);
+
+            // Act
+            var result = _dut.Validate(command);
+
+            // Assert
+            Assert.IsTrue(result.IsValid);
+        }
+        
+        [TestMethod]
+        public void Validate_ShouldFail_WhenVoidingAllRequirementsAndNotAddingNew()
+        {
+            // Arrange
+            _tagValidatorMock.Setup(t => t.UsageCoversBothForSupplierAndOtherAsync(_tagId, new List<int>{_tagReq1Id, _tagReq2Id}, new List<int>(), default)).Returns(Task.FromResult(true));
+            _tagValidatorMock.Setup(t => t.AllRequirementsWillBeVoidedAsync(_tagId, new List<int>{_tagReq1Id, _tagReq2Id}, default)).Returns(Task.FromResult(true));
+            var command = new UpdateTagStepAndRequirementsCommand(
+                _tagId,
+                _supplierStep,
+                new List<UpdateRequirementForCommand>
+                {
+                    new UpdateRequirementForCommand(_tagReq1Id, 1, true, RowVersion),
+                    new UpdateRequirementForCommand(_tagReq2Id, 1, true, RowVersion)
+                },
+                new List<RequirementForCommand>(),
+                null);
+
+            // Act
+            var result = _dut.Validate(command);
+
+            // Assert
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not all requirement can be voided!"));
         }
 
         [TestMethod]
         public void Validate_ShouldFail_WhenAnyRequirementAlreadyExists()
         {
             // Arrange
-            _dut = new UpdateTagStepAndRequirementsCommandValidator(_projectValidatorMock.Object,
-                _tagValidatorMock.Object, _stepValidatorMock.Object, _rdValidatorMock.Object);
-
-            _command = new UpdateTagStepAndRequirementsCommand(
-                _tagId,
-                _supplierStep,
-                new List<UpdateRequirementForCommand>
-                {
-                    new UpdateRequirementForCommand(_tr1Id, 1, true, RowVersion),
-                    new UpdateRequirementForCommand(_tr2Id, 1, false, RowVersion)
-                },
-                new List<RequirementForCommand>
-                {
-                    new RequirementForCommand(_tr1Id, 1), new RequirementForCommand(_tr2Id, 1)
-                },
-                null);
+            _tagValidatorMock.Setup(t => t.AllRequirementsWillBeUniqueAsync(_tagId, new List<int>{_reqDef1Id, _reqDef2Id}, default)).Returns(Task.FromResult(false));
 
             // Act
-            var result = _dut.Validate(_command);
+            var result = _dut.Validate(_addTwoReqsCommand);
 
             // Assert
             Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirements must be unique!"));
         }
 
         [TestMethod]
-        public void Validate_ShouldFail_WhenSupplierStepAndHasNoRequirmentsForSupplier()
+        public void Validate_ShouldFail_WhenSupplierStepAndHasNoRequirementsForSupplier()
         {
             // Arrange
-            _dut = new UpdateTagStepAndRequirementsCommandValidator(_projectValidatorMock.Object,
-                _tagValidatorMock.Object, _stepValidatorMock.Object, _rdValidatorMock.Object);
-
-            _rdValidatorMock
-                .Setup(r => r.UsageCoversBothForSupplierAndOtherAsync(
-                    new List<int> {_tr1Id, _tr2Id, _rd3NotSupplierId},
-                    default))
-                .Returns(Task.FromResult(false));
-
-            _command = new UpdateTagStepAndRequirementsCommand(
-                _tagId,
-                _supplierStep,
-                new List<UpdateRequirementForCommand>
-                {
-                    new UpdateRequirementForCommand(_tr1Id, 1, true, RowVersion),
-                    new UpdateRequirementForCommand(_tr2Id, 1, false, RowVersion)
-                },
-                new List<RequirementForCommand> {new RequirementForCommand(_rd3NotSupplierId, 1)},
-                null);
 
             // Act
-            var result = _dut.Validate(_command);
+            var result = _dut.Validate(_addTwoReqsCommand);
 
             // Assert
             Assert.IsFalse(result.IsValid);
@@ -185,75 +180,45 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
         public void Validate_ShouldFail_WhenTagIsVoided()
         {
             // Arrange
-            _dut = new UpdateTagStepAndRequirementsCommandValidator(_projectValidatorMock.Object,
-                _tagValidatorMock.Object, _stepValidatorMock.Object, _rdValidatorMock.Object);
-
-            _command = new UpdateTagStepAndRequirementsCommand(
-                _voidedTagId,
-                _supplierStep,
-                new List<UpdateRequirementForCommand>
-                {
-                    new UpdateRequirementForCommand(_tr1Id, 1, true, RowVersion),
-                    new UpdateRequirementForCommand(_tr2Id, 1, false, RowVersion)
-                },
-                new List<RequirementForCommand> {new RequirementForCommand(_rd3NotSupplierId, 1)},
-                null);
+            _tagValidatorMock.Setup(t => t.IsVoidedAsync(_tagId, default)).Returns(Task.FromResult(true));
 
             // Act
-            var result = _dut.Validate(_command);
+            var result = _dut.Validate(_addTwoReqsCommand);
 
             // Assert
             Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Tag is voided!"));
         }
 
         [TestMethod]
         public void Validate_ShouldFail_WhenProjectIsClosed()
         {
             // Arrange
-            _dut = new UpdateTagStepAndRequirementsCommandValidator(_projectValidatorMock.Object,
-                _tagValidatorMock.Object, _stepValidatorMock.Object, _rdValidatorMock.Object);
-
-            _command = new UpdateTagStepAndRequirementsCommand(
-                _tagIdOnClosedProject,
-                _supplierStep,
-                new List<UpdateRequirementForCommand>
-                {
-                    new UpdateRequirementForCommand(_tr1Id, 1, true, RowVersion),
-                    new UpdateRequirementForCommand(_tr2Id, 1, false, RowVersion)
-                },
-                new List<RequirementForCommand> {new RequirementForCommand(_rd3NotSupplierId, 1)},
-                null);
+            _projectValidatorMock.Setup(p => p.IsClosedForTagAsync(_tagId, default)).Returns(Task.FromResult(true));
 
             // Act
-            var result = _dut.Validate(_command);
+            var result = _dut.Validate(_addTwoReqsCommand);
 
             // Assert
             Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Project for tag is closed!"));
         }
 
         [TestMethod]
         public void Validate_ShouldFail_WhenTagNotExists()
         {
             // Arrange
-            _dut = new UpdateTagStepAndRequirementsCommandValidator(_projectValidatorMock.Object,
-                _tagValidatorMock.Object, _stepValidatorMock.Object, _rdValidatorMock.Object);
-
-            _command = new UpdateTagStepAndRequirementsCommand(
-                _notFoundTagId,
-                _supplierStep,
-                new List<UpdateRequirementForCommand>
-                {
-                    new UpdateRequirementForCommand(_tr1Id, 1, true, RowVersion),
-                    new UpdateRequirementForCommand(_tr2Id, 1, false, RowVersion)
-                },
-                new List<RequirementForCommand> {new RequirementForCommand(_rd3NotSupplierId, 1),},
-                null);
+            _tagValidatorMock.Setup(t => t.ExistsAsync(_tagId, default)).Returns(Task.FromResult(false));
 
             // Act
-            var result = _dut.Validate(_command);
+            var result = _dut.Validate(_addTwoReqsCommand);
 
             // Assert
             Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Tag doesn't exist!"));
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandValidatorTests.cs
@@ -102,7 +102,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
         {
             // Arrange
             _rdValidatorMock.Setup(r => r.ExistsAsync(_reqDef3Id, default)).Returns(Task.FromResult(true));
-            _tagValidatorMock.Setup(t => t.AllRequirementsWillBeVoidedAsync(_tagId, new List<int>{_tagReq1Id, _tagReq2Id}, default)).Returns(Task.FromResult(true));
             _tagValidatorMock.Setup(t => t.AllRequirementsWillBeUniqueAsync(_tagId, new List<int>{_reqDef3Id}, default)).Returns(Task.FromResult(true));
             _tagValidatorMock.Setup(t => t.UsageCoversBothForSupplierAndOtherAsync(_tagId, new List<int>{_tagReq1Id, _tagReq2Id}, new List<int>{_reqDef3Id}, default)).Returns(Task.FromResult(true));
             var command = new UpdateTagStepAndRequirementsCommand(
@@ -128,7 +127,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
         {
             // Arrange
             _tagValidatorMock.Setup(t => t.UsageCoversBothForSupplierAndOtherAsync(_tagId, new List<int>{_tagReq1Id, _tagReq2Id}, new List<int>(), default)).Returns(Task.FromResult(true));
-            _tagValidatorMock.Setup(t => t.AllRequirementsWillBeVoidedAsync(_tagId, new List<int>{_tagReq1Id, _tagReq2Id}, default)).Returns(Task.FromResult(true));
             var command = new UpdateTagStepAndRequirementsCommand(
                 _tagId,
                 _supplierStep,

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandValidatorTests.cs
@@ -195,7 +195,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
             _rdValidatorMock.Setup(r => r.ExistsAsync(_reqDef3Id, default)).Returns(Task.FromResult(true));
             _tagValidatorMock.Setup(t => t.AllRequirementsWillBeUniqueAsync(_tagId, new List<int>{_reqDef3Id}, default)).Returns(Task.FromResult(true));
             _tagValidatorMock.Setup(t => t.UsageCoversForOtherThanSuppliersAsync(_tagId, new List<int>(), new List<int>{_reqDef3Id}, default)).Returns(Task.FromResult(true));
-            _tagValidatorMock.Setup(t => t.HasForSupplierOnlyUsageAsync(_tagId, new List<int>(), new List<int>{_reqDef3Id}, default)).Returns(Task.FromResult(true));
+            _tagValidatorMock.Setup(t => t.HasAnyForSupplierOnlyUsageAsync(_tagId, new List<int>(), new List<int>{_reqDef3Id}, default)).Returns(Task.FromResult(true));
             var command = new UpdateTagStepAndRequirementsCommand(
                 _tagId,
                 _stepId,

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RequirementDefinitionValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RequirementDefinitionValidatorTests.cs
@@ -16,7 +16,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         private int _reqDefForAllId;
         private RequirementType _requirementType;
         private int _reqDefForSupplierId;
-        private int _reqDefForOther;
+        private int _reqDefForOtherId;
 
         protected override void SetupNewDatabase(DbContextOptions<PreservationContext> dbContextOptions)
         {
@@ -31,7 +31,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
                 context.SaveChangesAsync().Wait();
 
                 _reqDefForSupplierId = reqDefForSupplier.Id;
-                _reqDefForOther = reqDefForOther.Id;
+                _reqDefForOtherId = reqDefForOther.Id;
             }
         }
 
@@ -97,73 +97,73 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task UsageCoversForSupplierOnlyAsync_UsageForAllRequirement_ReturnsFalse()
+        public async Task HasForSupplierOnlyUsageAsync_UsageForAllRequirement_ReturnsFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var reqIds = new List<int> {_reqDefForAllId};
                 var dut = new RequirementDefinitionValidator(context);
-                var result = await dut.UsageCoversForSupplierOnlyAsync(reqIds, default);
+                var result = await dut.HasForSupplierOnlyUsageAsync(reqIds, default);
                 Assert.IsFalse(result);
             }
         }
 
         [TestMethod]
-        public async Task UsageCoversForSupplierOnlyAsync_UsageForOtherRequirement_ReturnsFalse()
+        public async Task HasForSupplierOnlyUsageAsync_UsageForOtherRequirement_ReturnsFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var reqIds = new List<int> {_reqDefForOther};
+                var reqIds = new List<int> {_reqDefForOtherId};
                 var dut = new RequirementDefinitionValidator(context);
-                var result = await dut.UsageCoversForSupplierOnlyAsync(reqIds, default);
+                var result = await dut.HasForSupplierOnlyUsageAsync(reqIds, default);
                 Assert.IsFalse(result);
             }
         }
 
         [TestMethod]
-        public async Task UsageCoversForSupplierOnlyAsync_UsageForSupplierRequirement_ReturnsTrue()
+        public async Task HasForSupplierOnlyUsageAsync_UsageForSupplierRequirement_ReturnsTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var reqIds = new List<int> {_reqDefForSupplierId};
                 var dut = new RequirementDefinitionValidator(context);
-                var result = await dut.UsageCoversForSupplierOnlyAsync(reqIds, default);
+                var result = await dut.HasForSupplierOnlyUsageAsync(reqIds, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task UsageCoversForSupplierOnlyAsync_UsageForSupplierAndOtherAndForAllRequirement_ReturnsTrue()
+        public async Task HasForSupplierOnlyUsageAsync_UsageForSupplierAndOtherAndForAllRequirement_ReturnsTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var reqIds = new List<int> {_reqDefForSupplierId, _reqDefForOther, _reqDefForAllId};
+                var reqIds = new List<int> {_reqDefForSupplierId, _reqDefForOtherId, _reqDefForAllId};
                 var dut = new RequirementDefinitionValidator(context);
-                var result = await dut.UsageCoversForSupplierOnlyAsync(reqIds, default);
+                var result = await dut.HasForSupplierOnlyUsageAsync(reqIds, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task UsageCoversForSupplierOnlyAsync_UnknownRequirement_ReturnsFalse()
+        public async Task HasForSupplierOnlyUsageAsync_UnknownRequirement_ReturnsFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var reqIds = new List<int> {0};
                 var dut = new RequirementDefinitionValidator(context);
-                var result = await dut.UsageCoversForSupplierOnlyAsync(reqIds, default);
+                var result = await dut.HasForSupplierOnlyUsageAsync(reqIds, default);
                 Assert.IsFalse(result);
             }
         }
 
         [TestMethod]
-        public async Task UsageCoversForSupplierOnlyAsync_NoRequirements_ReturnsFalse()
+        public async Task HasForSupplierOnlyUsageAsync_NoRequirements_ReturnsFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var reqIds = new List<int>();
                 var dut = new RequirementDefinitionValidator(context);
-                var result = await dut.UsageCoversForSupplierOnlyAsync(reqIds, default);
+                var result = await dut.HasForSupplierOnlyUsageAsync(reqIds, default);
                 Assert.IsFalse(result);
             }
         }
@@ -185,7 +185,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var reqIds = new List<int> {_reqDefForOther};
+                var reqIds = new List<int> {_reqDefForOtherId};
                 var dut = new RequirementDefinitionValidator(context);
                 var result = await dut.UsageCoversForOtherThanSuppliersAsync(reqIds, default);
                 Assert.IsTrue(result);
@@ -209,7 +209,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var reqIds = new List<int> {_reqDefForSupplierId, _reqDefForOther, _reqDefForAllId};
+                var reqIds = new List<int> {_reqDefForSupplierId, _reqDefForOtherId, _reqDefForAllId};
                 var dut = new RequirementDefinitionValidator(context);
                 var result = await dut.UsageCoversForOtherThanSuppliersAsync(reqIds, default);
                 Assert.IsTrue(result);
@@ -257,7 +257,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var reqIds = new List<int> {_reqDefForOther};
+                var reqIds = new List<int> {_reqDefForOtherId};
                 var dut = new RequirementDefinitionValidator(context);
                 var result = await dut.UsageCoversBothForSupplierAndOtherAsync(reqIds, default);
                 Assert.IsFalse(result);
@@ -281,7 +281,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var reqIds = new List<int> {_reqDefForSupplierId, _reqDefForOther, _reqDefForAllId};
+                var reqIds = new List<int> {_reqDefForSupplierId, _reqDefForOtherId, _reqDefForAllId};
                 var dut = new RequirementDefinitionValidator(context);
                 var result = await dut.UsageCoversBothForSupplierAndOtherAsync(reqIds, default);
                 Assert.IsTrue(result);
@@ -293,7 +293,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var reqIds = new List<int> {_reqDefForSupplierId, _reqDefForOther};
+                var reqIds = new List<int> {_reqDefForSupplierId, _reqDefForOtherId};
                 var dut = new RequirementDefinitionValidator(context);
                 var result = await dut.UsageCoversBothForSupplierAndOtherAsync(reqIds, default);
                 Assert.IsTrue(result);

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RequirementDefinitionValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RequirementDefinitionValidatorTests.cs
@@ -97,73 +97,73 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task HasForSupplierOnlyUsageAsync_UsageForAllRequirement_ReturnsFalse()
+        public async Task HasAnyForSupplierOnlyUsageAsync_UsageForAllRequirement_ReturnsFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var reqIds = new List<int> {_reqDefForAllId};
                 var dut = new RequirementDefinitionValidator(context);
-                var result = await dut.HasForSupplierOnlyUsageAsync(reqIds, default);
+                var result = await dut.HasAnyForSupplierOnlyUsageAsync(reqIds, default);
                 Assert.IsFalse(result);
             }
         }
 
         [TestMethod]
-        public async Task HasForSupplierOnlyUsageAsync_UsageForOtherRequirement_ReturnsFalse()
+        public async Task HasAnyForSupplierOnlyUsageAsync_UsageForOtherRequirement_ReturnsFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var reqIds = new List<int> {_reqDefForOtherId};
                 var dut = new RequirementDefinitionValidator(context);
-                var result = await dut.HasForSupplierOnlyUsageAsync(reqIds, default);
+                var result = await dut.HasAnyForSupplierOnlyUsageAsync(reqIds, default);
                 Assert.IsFalse(result);
             }
         }
 
         [TestMethod]
-        public async Task HasForSupplierOnlyUsageAsync_UsageForSupplierRequirement_ReturnsTrue()
+        public async Task HasAnyForSupplierOnlyUsageAsync_UsageForSupplierRequirement_ReturnsTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var reqIds = new List<int> {_reqDefForSupplierId};
                 var dut = new RequirementDefinitionValidator(context);
-                var result = await dut.HasForSupplierOnlyUsageAsync(reqIds, default);
+                var result = await dut.HasAnyForSupplierOnlyUsageAsync(reqIds, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task HasForSupplierOnlyUsageAsync_UsageForSupplierAndOtherAndForAllRequirement_ReturnsTrue()
+        public async Task HasAnyForSupplierOnlyUsageAsync_UsageForSupplierAndOtherAndForAllRequirement_ReturnsTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var reqIds = new List<int> {_reqDefForSupplierId, _reqDefForOtherId, _reqDefForAllId};
                 var dut = new RequirementDefinitionValidator(context);
-                var result = await dut.HasForSupplierOnlyUsageAsync(reqIds, default);
+                var result = await dut.HasAnyForSupplierOnlyUsageAsync(reqIds, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task HasForSupplierOnlyUsageAsync_UnknownRequirement_ReturnsFalse()
+        public async Task HasAnyForSupplierOnlyUsageAsync_UnknownRequirement_ReturnsFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var reqIds = new List<int> {0};
                 var dut = new RequirementDefinitionValidator(context);
-                var result = await dut.HasForSupplierOnlyUsageAsync(reqIds, default);
+                var result = await dut.HasAnyForSupplierOnlyUsageAsync(reqIds, default);
                 Assert.IsFalse(result);
             }
         }
 
         [TestMethod]
-        public async Task HasForSupplierOnlyUsageAsync_NoRequirements_ReturnsFalse()
+        public async Task HasAnyForSupplierOnlyUsageAsync_NoRequirements_ReturnsFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var reqIds = new List<int>();
                 var dut = new RequirementDefinitionValidator(context);
-                var result = await dut.HasForSupplierOnlyUsageAsync(reqIds, default);
+                var result = await dut.HasAnyForSupplierOnlyUsageAsync(reqIds, default);
                 Assert.IsFalse(result);
             }
         }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/TagValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/TagValidatorTests.cs
@@ -2,10 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.Validators.RequirementDefinitionValidators;
 using Equinor.Procosys.Preservation.Command.Validators.TagValidators;
 using Equinor.Procosys.Preservation.Domain;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
 using Equinor.Procosys.Preservation.Infrastructure;
 using Equinor.Procosys.Preservation.Test.Common;
 using Microsoft.EntityFrameworkCore;
@@ -19,8 +21,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         private const string ProjectName = "P";
         private const string TagNo1 = "PA-13";
         private const string TagNo2 = "PA-14";
-        private int _tagWithTwoReqsId;
         private int _tagWithOneReqsId;
+        private int _tagWithAllReqsId;
         private int _standardTagNotStartedInFirstStepId;
         private int _standardTagStartedAndInLastStepId;
         private int _preAreaTagNotStartedInFirstStepId;
@@ -29,7 +31,10 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         private int _poAreaTagNotStartedId;
         private int _siteAreaTagStartedId;
         private int _poAreaTagStartedId;
-        private int _reqDef2Id;
+        private int _reqDefForAll2Id;
+        private int _tagReqForAll1Id;
+        private int _tagReqForSupplierId;
+        private int _tagReqForOtherId;
         private const int IntervalWeeks = 4;
 
         protected override void SetupNewDatabase(DbContextOptions<PreservationContext> dbContextOptions)
@@ -40,37 +45,50 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
                 var journey = AddJourneyWithStep(context, "J", "S1", AddMode(context, "M1",false), AddResponsible(context, "R1"));
                 journey.AddStep(new Step(TestPlant, "S2", AddMode(context, "M2", false), AddResponsible(context, "R2")));
 
-                var rd1 = AddRequirementTypeWith1DefWithoutField(context, "R1", "D1").RequirementDefinitions.First();
-                var rd2 = AddRequirementTypeWith1DefWithoutField(context, "R2", "D2").RequirementDefinitions.First();
-                _reqDef2Id = rd2.Id;
+                var requirementType = AddRequirementTypeWith1DefWithoutField(context, "R1", "D1");
+                var reqDefForAll1 = requirementType.RequirementDefinitions.First();
+                var reqDefForAll2 = AddRequirementTypeWith1DefWithoutField(context, "R2", "D2").RequirementDefinitions.First();
+                var reqDefForSupplier = new RequirementDefinition(TestPlant, "D2", 2, RequirementUsage.ForSuppliersOnly, 1);
+                requirementType.AddRequirementDefinition(reqDefForSupplier);
+                var reqDefForOther = new RequirementDefinition(TestPlant, "D3", 2, RequirementUsage.ForOtherThanSuppliers, 1);
+                requirementType.AddRequirementDefinition(reqDefForOther);
+                context.SaveChangesAsync().Wait();
+
                 var standardTagNotStartedInFirstStep = AddTag(context, project, TagType.Standard, TagNo1,
                     "Tag description", journey.Steps.First(), new List<TagRequirement>
                     {
-                        new TagRequirement(TestPlant, IntervalWeeks, rd1), 
-                        new TagRequirement(TestPlant, IntervalWeeks, rd2)
+                        new TagRequirement(TestPlant, IntervalWeeks, reqDefForAll1), 
+                        new TagRequirement(TestPlant, IntervalWeeks, reqDefForSupplier), 
+                        new TagRequirement(TestPlant, IntervalWeeks, reqDefForOther)
                     });
 
                 var standardTagStartedInLastStep = AddTag(context, project, TagType.Standard, TagNo2, "",
-                    journey.Steps.Last(), new List<TagRequirement> {new TagRequirement(TestPlant, IntervalWeeks, rd1)});
+                    journey.Steps.Last(), new List<TagRequirement> {new TagRequirement(TestPlant, IntervalWeeks, reqDefForAll1)});
                 standardTagStartedInLastStep.StartPreservation();
 
                 var preAreaTagNotStartedInFirstStep = AddTag(context, project, TagType.PreArea, "#PRE-E-A1", "Tag description",
-                    journey.Steps.First(), new List<TagRequirement> {new TagRequirement(TestPlant, IntervalWeeks, rd1)});
+                    journey.Steps.First(), new List<TagRequirement> {new TagRequirement(TestPlant, IntervalWeeks, reqDefForAll1)});
                 var preAreaTagStartedInFirstStep = AddTag(context, project, TagType.PreArea, "#PRE-E-A2", "Tag description",
-                    journey.Steps.First(), new List<TagRequirement> {new TagRequirement(TestPlant, IntervalWeeks, rd1)});
+                    journey.Steps.First(), new List<TagRequirement> {new TagRequirement(TestPlant, IntervalWeeks, reqDefForAll1)});
                 preAreaTagStartedInFirstStep.StartPreservation();
                 var siteAreaTagNotStarted = AddTag(context, project, TagType.SiteArea, "#SITE-E-A1", "Tag description", 
-                    journey.Steps.First(), new List<TagRequirement> {new TagRequirement(TestPlant, IntervalWeeks, rd1)});
+                    journey.Steps.First(), new List<TagRequirement> {new TagRequirement(TestPlant, IntervalWeeks, reqDefForAll1)});
                 var siteAreaTagStarted = AddTag(context, project, TagType.SiteArea, "#SITE-E-A2", "Tag description", 
-                    journey.Steps.First(), new List<TagRequirement> {new TagRequirement(TestPlant, IntervalWeeks, rd1)});
+                    journey.Steps.First(), new List<TagRequirement> {new TagRequirement(TestPlant, IntervalWeeks, reqDefForAll1)});
                 siteAreaTagStarted.StartPreservation();
                 var poAreaTagNotStarted = AddTag(context, project, TagType.PoArea, "#PO-E-A1", "Tag description",
-                    journey.Steps.First(), new List<TagRequirement> {new TagRequirement(TestPlant, IntervalWeeks, rd1)});
+                    journey.Steps.First(), new List<TagRequirement> {new TagRequirement(TestPlant, IntervalWeeks, reqDefForAll1)});
                 var poAreaTagStarted = AddTag(context, project, TagType.PoArea, "#PO-E-A2", "Tag description",
-                    journey.Steps.First(), new List<TagRequirement> {new TagRequirement(TestPlant, IntervalWeeks, rd1)});
+                    journey.Steps.First(), new List<TagRequirement> {new TagRequirement(TestPlant, IntervalWeeks, reqDefForAll1)});
                 poAreaTagStarted.StartPreservation();
+                
+                context.SaveChangesAsync().Wait();
 
-                _standardTagNotStartedInFirstStepId = _tagWithTwoReqsId = standardTagNotStartedInFirstStep.Id;
+                _reqDefForAll2Id = reqDefForAll2.Id;
+                _tagReqForAll1Id = standardTagNotStartedInFirstStep.Requirements.Single(r => r.RequirementDefinitionId == reqDefForAll1.Id).Id;
+                _tagReqForSupplierId = standardTagNotStartedInFirstStep.Requirements.Single(r => r.RequirementDefinitionId == reqDefForSupplier.Id).Id;
+                _tagReqForOtherId = standardTagNotStartedInFirstStep.Requirements.Single(r => r.RequirementDefinitionId == reqDefForOther.Id).Id;
+                _standardTagNotStartedInFirstStepId = _tagWithAllReqsId = standardTagNotStartedInFirstStep.Id;
                 _standardTagStartedAndInLastStepId = _tagWithOneReqsId = standardTagStartedInLastStep.Id;
                 _preAreaTagNotStartedInFirstStepId = preAreaTagNotStartedInFirstStep.Id;
                 _preAreaTagStartedInFirstStepId = preAreaTagStartedInFirstStep.Id;
@@ -78,8 +96,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
                 _poAreaTagNotStartedId = poAreaTagNotStarted.Id;
                 _siteAreaTagStartedId = siteAreaTagStarted.Id;
                 _poAreaTagStartedId = poAreaTagStarted.Id;
-
-                context.SaveChangesAsync().Wait();
             }
         }
 
@@ -88,7 +104,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.ExistsAsync(TagNo1, ProjectName, default);
                 Assert.IsTrue(result);
             }
@@ -99,7 +115,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.ExistsAsync("X", ProjectName, default);
                 Assert.IsFalse(result);
             }
@@ -110,7 +126,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsVoidedAsync(_standardTagNotStartedInFirstStepId, default);
                 Assert.IsFalse(result);
             }
@@ -127,7 +143,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
             }
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsVoidedAsync(_standardTagNotStartedInFirstStepId, default);
                 Assert.IsTrue(result);
             }
@@ -138,7 +154,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsVoidedAsync(0, default);
                 Assert.IsFalse(result);
             }
@@ -149,7 +165,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.HasANonVoidedRequirementAsync(_standardTagNotStartedInFirstStepId, default);
                 Assert.IsTrue(result);
             }
@@ -167,7 +183,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
             }
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.HasANonVoidedRequirementAsync(_standardTagNotStartedInFirstStepId, default);
                 Assert.IsTrue(result);
             }
@@ -178,7 +194,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.VerifyPreservationStatusAsync(_standardTagNotStartedInFirstStepId, PreservationStatus.Completed, default);
                 Assert.IsFalse(result);
             }
@@ -189,7 +205,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.VerifyPreservationStatusAsync(_standardTagNotStartedInFirstStepId, PreservationStatus.NotStarted, default);
                 Assert.IsTrue(result);
             }
@@ -200,7 +216,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 _timeProvider.ElapseWeeks(IntervalWeeks);
                 var result = await dut.ReadyToBePreservedAsync(_standardTagNotStartedInFirstStepId, default);
                 Assert.IsFalse(result);
@@ -212,7 +228,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 _timeProvider.ElapseWeeks(IntervalWeeks);
                 var result = await dut.ReadyToBePreservedAsync(_standardTagStartedAndInLastStepId, default);
                 Assert.IsTrue(result);
@@ -226,7 +242,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
             {
                 var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _standardTagNotStartedInFirstStepId);
                 var req = tag.Requirements.First();
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.RequirementIsReadyToBePreservedAsync(_standardTagNotStartedInFirstStepId, req.Id, default);
                 Assert.IsFalse(result);
             }
@@ -239,7 +255,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
             {
                 var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _standardTagStartedAndInLastStepId);
                 var req = tag.Requirements.Single();
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.RequirementIsReadyToBePreservedAsync(_standardTagStartedAndInLastStepId, req.Id, default);
                 Assert.IsTrue(result);
             }
@@ -258,7 +274,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
             }
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.RequirementIsReadyToBePreservedAsync(_standardTagNotStartedInFirstStepId, reqId, default);
                 Assert.IsTrue(result);
             }
@@ -271,7 +287,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
             {
                 var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _standardTagStartedAndInLastStepId);
                 var req = tag.Requirements.Single();
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.HasRequirementWithActivePeriodAsync(_standardTagStartedAndInLastStepId, req.Id, default);
                 Assert.IsTrue(result);
             }
@@ -284,7 +300,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
             {
                 var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _standardTagStartedAndInLastStepId);
                 var req = tag.Requirements.Single();
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.HasRequirementAsync(_standardTagStartedAndInLastStepId, req.Id, default);
                 Assert.IsTrue(result);
             }
@@ -297,7 +313,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
             {
                 var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _standardTagStartedAndInLastStepId);
                 var req = tag.Requirements.Single();
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.HasRequirementAsync(8181, req.Id, default);
                 Assert.IsFalse(result);
             }
@@ -308,7 +324,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.HasRequirementAsync(_standardTagStartedAndInLastStepId, 8181, default);
                 Assert.IsFalse(result);
             }
@@ -319,7 +335,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeTransferredAsync(_standardTagNotStartedInFirstStepId, default);
                 Assert.IsFalse(result);
             }
@@ -330,7 +346,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeTransferredAsync(_standardTagStartedAndInLastStepId, default);
                 Assert.IsFalse(result);
             }
@@ -341,7 +357,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeTransferredAsync(_preAreaTagNotStartedInFirstStepId, default);
                 Assert.IsFalse(result);
             }
@@ -352,7 +368,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeTransferredAsync(_preAreaTagStartedInFirstStepId, default);
                 Assert.IsTrue(result);
             }
@@ -363,7 +379,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeTransferredAsync(_siteAreaTagStartedId, default);
                 Assert.IsFalse(result);
             }
@@ -374,7 +390,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeTransferredAsync(_poAreaTagStartedId, default);
                 Assert.IsFalse(result);
             }
@@ -385,7 +401,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeTransferredAsync(0, default);
                 Assert.IsFalse(result);
             }
@@ -396,7 +412,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeCompletedAsync(_standardTagNotStartedInFirstStepId, default);
                 Assert.IsFalse(result);
             }
@@ -407,7 +423,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeCompletedAsync(_standardTagStartedAndInLastStepId, default);
                 Assert.IsTrue(result);
             }
@@ -418,7 +434,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeCompletedAsync(_preAreaTagNotStartedInFirstStepId, default);
                 Assert.IsFalse(result);
             }
@@ -429,7 +445,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeCompletedAsync(_preAreaTagStartedInFirstStepId, default);
                 Assert.IsFalse(result);
             }
@@ -440,7 +456,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeCompletedAsync(_siteAreaTagStartedId, default);
                 Assert.IsTrue(result);
             }
@@ -451,7 +467,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeCompletedAsync(_poAreaTagStartedId, default);
                 Assert.IsTrue(result);
             }
@@ -462,7 +478,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeCompletedAsync(0, default);
                 Assert.IsFalse(result);
             }
@@ -473,7 +489,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeStartedAsync(_standardTagNotStartedInFirstStepId, default);
                 Assert.IsTrue(result);
             }
@@ -484,7 +500,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeStartedAsync(_standardTagStartedAndInLastStepId, default);
                 Assert.IsFalse(result);
             }
@@ -495,7 +511,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeStartedAsync(_preAreaTagNotStartedInFirstStepId, default);
                 Assert.IsTrue(result);
             }
@@ -506,7 +522,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeStartedAsync(_preAreaTagStartedInFirstStepId, default);
                 Assert.IsFalse(result);
             }
@@ -517,7 +533,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeStartedAsync(_siteAreaTagNotStartedId, default);
                 Assert.IsTrue(result);
             }
@@ -528,7 +544,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeStartedAsync(_siteAreaTagStartedId, default);
                 Assert.IsFalse(result);
             }
@@ -539,7 +555,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeStartedAsync(_poAreaTagNotStartedId, default);
                 Assert.IsTrue(result);
             }
@@ -550,7 +566,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeStartedAsync(_poAreaTagStartedId, default);
                 Assert.IsFalse(result);
             }
@@ -561,7 +577,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.IsReadyToBeStartedAsync(0, default);
                 Assert.IsFalse(result);
             }
@@ -572,7 +588,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.AttachmentWithFilenameExistsAsync(0, "A", default);
                 Assert.IsFalse(result);
             }
@@ -583,7 +599,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.AttachmentWithFilenameExistsAsync(_preAreaTagNotStartedInFirstStepId, "A", default);
                 Assert.IsFalse(result);
             }
@@ -602,36 +618,9 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
 
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.AttachmentWithFilenameExistsAsync(_standardTagNotStartedInFirstStepId, fileName, default);
                 Assert.IsTrue(result);
-            }
-        }
-
-        [TestMethod]
-        public async Task AllRequirementsWillBeVoidedAsync_ShouldReturnsTrue_WhenVoidingBothRequirements()
-        {
-            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
-            {
-                var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithTwoReqsId);
-                var tagReqId1 = tag.Requirements.ElementAt(0).Id;
-                var tagReqId2 = tag.Requirements.ElementAt(1).Id;
-                var dut = new TagValidator(context);
-                var result = await dut.AllRequirementsWillBeVoidedAsync(tag.Id, new List<int>{tagReqId1, tagReqId2}, default);
-                Assert.IsTrue(result);
-            }
-        }
-
-        [TestMethod]
-        public async Task AllRequirementsWillBeVoidedAsync_ShouldReturnsFalse_WhenVoidingOneOfTwoRequirements()
-        {
-            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
-            {
-                var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithTwoReqsId);
-                var tagReqId1 = tag.Requirements.ElementAt(0).Id;
-                var dut = new TagValidator(context);
-                var result = await dut.AllRequirementsWillBeVoidedAsync(tag.Id, new List<int>{tagReqId1}, default);
-                Assert.IsFalse(result);
             }
         }
 
@@ -640,9 +629,9 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
-                var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithTwoReqsId);
+                var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithAllReqsId);
                 var reqDefId = tag.Requirements.ElementAt(0).RequirementDefinitionId;
-                var dut = new TagValidator(context);
+                var dut = new TagValidator(context, null);
                 var result = await dut.AllRequirementsWillBeUniqueAsync(tag.Id, new List<int>{reqDefId}, default);
                 Assert.IsFalse(result);
             }
@@ -654,9 +643,117 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithOneReqsId);
-                var dut = new TagValidator(context);
-                var result = await dut.AllRequirementsWillBeUniqueAsync(tag.Id, new List<int>{_reqDef2Id}, default);
+                var dut = new TagValidator(context, null);
+                var result = await dut.AllRequirementsWillBeUniqueAsync(tag.Id, new List<int>{_reqDefForAll2Id}, default);
                 Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task UsageCoversBothForSupplierAndOtherAsync_ShouldReturnsTrue_WhenRequirementsCoversAll()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithAllReqsId);
+                var dut = new TagValidator(context, new RequirementDefinitionValidator(context));
+                var result = await dut.UsageCoversBothForSupplierAndOtherAsync(tag.Id, new List<int>(), new List<int>(), default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task UsageCoversBothForSupplierAndOtherAsync_ShouldReturnsFalse_WhenVoidingRequirementsForAllAndForSupplier()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithAllReqsId);
+                var dut = new TagValidator(context, new RequirementDefinitionValidator(context));
+                var result = await dut.UsageCoversBothForSupplierAndOtherAsync(tag.Id, new List<int>{_tagReqForAll1Id, _tagReqForSupplierId}, new List<int>(), default);
+                Assert.IsFalse(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task UsageCoversBothForSupplierAndOtherAsync_ShouldReturnsFalse_WhenVoidingRequirementsForAllAndForOther()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithAllReqsId);
+                var dut = new TagValidator(context, new RequirementDefinitionValidator(context));
+                var result = await dut.UsageCoversBothForSupplierAndOtherAsync(tag.Id, new List<int>{_tagReqForAll1Id, _tagReqForOtherId}, new List<int>(), default);
+                Assert.IsFalse(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task UsageCoversBothForSupplierAndOtherAsync_ShouldReturnsTrue_WhenVoidingAllRequirementsAndAddingNew()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithAllReqsId);
+                var dut = new TagValidator(context, new RequirementDefinitionValidator(context));
+                var result = await dut.UsageCoversBothForSupplierAndOtherAsync(tag.Id, new List<int>{_tagReqForAll1Id, _tagReqForSupplierId}, new List<int>{_reqDefForAll2Id}, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task UsageCoversForOtherThanSuppliersAsync_ShouldReturnsTrue_WhenRequirementsCoversAll()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithAllReqsId);
+                var dut = new TagValidator(context, new RequirementDefinitionValidator(context));
+                var result = await dut.UsageCoversForOtherThanSuppliersAsync(tag.Id, new List<int>(), new List<int>(), default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task UsageCoversForOtherThanSuppliersAsync_ShouldReturnsFalse_WhenVoidingRequirementsForAllAndForOther()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithAllReqsId);
+                var dut = new TagValidator(context, new RequirementDefinitionValidator(context));
+                var result = await dut.UsageCoversForOtherThanSuppliersAsync(tag.Id, new List<int>{_tagReqForAll1Id, _tagReqForOtherId}, new List<int>(), default);
+                Assert.IsFalse(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task UsageCoversForOtherThanSuppliersAsync_ShouldReturnsTrue_WhenVoidingAllRequirementsAndAddingNew()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithAllReqsId);
+                var dut = new TagValidator(context, new RequirementDefinitionValidator(context));
+                var result = await dut.UsageCoversForOtherThanSuppliersAsync(tag.Id, new List<int>{_tagReqForAll1Id, _tagReqForOtherId}, new List<int>{_reqDefForAll2Id}, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task HasForSupplierOnlyUsageAsync_ShouldReturnsTrue_WhenRequirementsCoversAll()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithAllReqsId);
+                var dut = new TagValidator(context, new RequirementDefinitionValidator(context));
+                var result = await dut.HasForSupplierOnlyUsageAsync(tag.Id, new List<int>(), new List<int>(), default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task HasForSupplierOnlyUsageAsync_ShouldReturnsFalse_WhenVoidingRequirementsForSupplierOnly()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithAllReqsId);
+                var dut = new TagValidator(context, new RequirementDefinitionValidator(context));
+                var result = await dut.HasForSupplierOnlyUsageAsync(tag.Id, new List<int>{_tagReqForSupplierId}, new List<int>(), default);
+                Assert.IsFalse(result);
             }
         }
     }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/TagValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/TagValidatorTests.cs
@@ -734,25 +734,25 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task HasForSupplierOnlyUsageAsync_ShouldReturnsTrue_WhenRequirementsCoversAll()
+        public async Task HasAnyForSupplierOnlyUsageAsync_ShouldReturnsTrue_WhenRequirementsCoversAll()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithAllReqsId);
                 var dut = new TagValidator(context, new RequirementDefinitionValidator(context));
-                var result = await dut.HasForSupplierOnlyUsageAsync(tag.Id, new List<int>(), new List<int>(), default);
+                var result = await dut.HasAnyForSupplierOnlyUsageAsync(tag.Id, new List<int>(), new List<int>(), default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task HasForSupplierOnlyUsageAsync_ShouldReturnsFalse_WhenVoidingRequirementsForSupplierOnly()
+        public async Task HasAnyForSupplierOnlyUsageAsync_ShouldReturnsFalse_WhenVoidingRequirementsForSupplierOnly()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithAllReqsId);
                 var dut = new TagValidator(context, new RequirementDefinitionValidator(context));
-                var result = await dut.HasForSupplierOnlyUsageAsync(tag.Id, new List<int>{_tagReqForSupplierId}, new List<int>(), default);
+                var result = await dut.HasAnyForSupplierOnlyUsageAsync(tag.Id, new List<int>{_tagReqForSupplierId}, new List<int>(), default);
                 Assert.IsFalse(result);
             }
         }


### PR DESCRIPTION
When starting to fix error and write more unit tests, I noticed that the `UpdateTagStepAndRequirementsCommandValidator` didn't handle all scenarios to ensure that a Tag will always have a requirement in any Step after voiding of requirements. 
The `UpdateTagStepAndRequirementsCommandValidator` was also written in a manner that it didn't check already persisted Requirements on the tag, and align those together with list of requirements to be voided/added in the `UpdateTagStepAndRequirementsCommand`. Therefor the validation methods are moved from `IRequirementDefinitionValidator` to `ITagValidator`

A lot of new unit tests written to check all these odd cornercases