### PR TITLE
Automatic update of Swashbuckle.AspNetCore to 5.5.1

### DIFF
--- a/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
+++ b/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />
     <PackageReference Include="ServiceResult.ApiExtensions" Version="1.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a patch update of `Swashbuckle.AspNetCore` to `5.5.1` from `5.5.0`
`Swashbuckle.AspNetCore 5.5.1` was published at `2020-06-25T21:16:00Z`, 7 days ago

1 project update:
Updated `src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj` to `Swashbuckle.AspNetCore` `5.5.1` from `5.5.0`

[Swashbuckle.AspNetCore 5.5.1 on NuGet.org](https://www.nuget.org/packages/Swashbuckle.AspNetCore/5.5.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
