### PR TITLE
75278: Delete requirement definition

### DIFF
--- a/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/DeleteRequirementDefinition/DeleteRequirementDefinitionCommand.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/DeleteRequirementDefinition/DeleteRequirementDefinitionCommand.cs
@@ -1,0 +1,19 @@
+﻿using MediatR;
+using ServiceResult;
+
+namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.DeleteRequirementDefinition
+{
+    public class DeleteRequirementDefinitionCommand : IRequest<Result<Unit>>
+    {
+        public DeleteRequirementDefinitionCommand(int requirementTypeId, int requirementDefinitionId, string rowVersion)
+        {
+            RequirementTypeId = requirementTypeId;
+            RequirementDefinitionId = requirementDefinitionId;
+            RowVersion = rowVersion;
+        }
+
+        public int RequirementTypeId { get; }
+        public int RequirementDefinitionId { get; }
+        public string RowVersion { get; }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/DeleteRequirementDefinition/DeleteRequirementDefinitionCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/DeleteRequirementDefinition/DeleteRequirementDefinitionCommandHandler.cs
@@ -1,0 +1,36 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Domain;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
+using MediatR;
+using ServiceResult;
+
+namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.DeleteRequirementDefinition
+{
+    public class DeleteRequirementDefinitionCommandHandler : IRequestHandler<DeleteRequirementDefinitionCommand, Result<Unit>>
+    {
+        private readonly IRequirementTypeRepository _requirementTypeRepository;
+        private readonly IUnitOfWork _unitOfWork;
+
+        public DeleteRequirementDefinitionCommandHandler(IRequirementTypeRepository requirementTypeRepository, IUnitOfWork unitOfWork)
+        {
+            _requirementTypeRepository = requirementTypeRepository;
+            _unitOfWork = unitOfWork;
+        }
+
+        public async Task<Result<Unit>> Handle(DeleteRequirementDefinitionCommand request, CancellationToken cancellationToken)
+        {
+            var requirementType = await _requirementTypeRepository.GetByIdAsync(request.RequirementTypeId);
+
+            var requirementDefinition =
+                requirementType.RequirementDefinitions.Single(rd => rd.Id == request.RequirementDefinitionId);
+            requirementDefinition.SetRowVersion(request.RowVersion);
+
+            requirementType.RemoveRequirementDefinition(requirementDefinition);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+            return new SuccessResult<Unit>(Unit.Value);
+        }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/DeleteRequirementDefinition/DeleteRequirementDefinitionCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/DeleteRequirementDefinition/DeleteRequirementDefinitionCommandHandler.cs
@@ -25,7 +25,7 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.DeleteRe
             var requirementDefinition = requirementType.RequirementDefinitions.Single(rd => rd.Id == request.RequirementDefinitionId);
             
             requirementDefinition.SetRowVersion(request.RowVersion);
-            requirementType.RemoveRequirementDefinition(requirementDefinition);
+            _requirementTypeRepository.RemoveRequirementDefinition(requirementDefinition);
 
             await _unitOfWork.SaveChangesAsync(cancellationToken);
             return new SuccessResult<Unit>(Unit.Value);

--- a/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/DeleteRequirementDefinition/DeleteRequirementDefinitionCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/DeleteRequirementDefinition/DeleteRequirementDefinitionCommandHandler.cs
@@ -22,14 +22,12 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.DeleteRe
         public async Task<Result<Unit>> Handle(DeleteRequirementDefinitionCommand request, CancellationToken cancellationToken)
         {
             var requirementType = await _requirementTypeRepository.GetByIdAsync(request.RequirementTypeId);
-
-            var requirementDefinition =
-                requirementType.RequirementDefinitions.Single(rd => rd.Id == request.RequirementDefinitionId);
+            var requirementDefinition = requirementType.RequirementDefinitions.Single(rd => rd.Id == request.RequirementDefinitionId);
+            
             requirementDefinition.SetRowVersion(request.RowVersion);
-
             requirementType.RemoveRequirementDefinition(requirementDefinition);
-            await _unitOfWork.SaveChangesAsync(cancellationToken);
 
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
             return new SuccessResult<Unit>(Unit.Value);
         }
     }

--- a/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/DeleteRequirementDefinition/DeleteRequirementDefinitionCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/DeleteRequirementDefinition/DeleteRequirementDefinitionCommandValidator.cs
@@ -1,0 +1,51 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.Validators.RequirementDefinitionValidators;
+using Equinor.Procosys.Preservation.Command.Validators.RequirementTypeValidators;
+using FluentValidation;
+
+namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.DeleteRequirementDefinition
+{
+    public class DeleteRequirementDefinitionCommandValidator : AbstractValidator<DeleteRequirementDefinitionCommand>
+    {
+        public DeleteRequirementDefinitionCommandValidator(IRequirementTypeValidator requirementTypeValidator,
+            IRequirementDefinitionValidator requirementDefinitionValidator)
+        {
+            CascadeMode = CascadeMode.StopOnFirstFailure;
+
+            RuleFor(command => command)
+                .MustAsync((command, token) => BeAnExistingRequirementTypeAsync(command.RequirementTypeId, token))
+                .WithMessage(command => $"Requirement type doesn't exist! RequirementType={command.RequirementTypeId}")
+                .MustAsync((command, token) =>
+                    BeAnExistingRequirementDefinitionAsync(command.RequirementDefinitionId, token))
+                .WithMessage(command =>
+                    $"Requirement definition doesn't exist! RequirementDefinition={command.RequirementDefinitionId}")
+                .MustAsync((command, token) =>
+                    BeAVoidedRequirementDefinitionAsync(command.RequirementDefinitionId, token))
+                .WithMessage(command =>
+                    $"Requirement definition is not voided! RequirementDefinition={command.RequirementDefinitionId}")
+                .MustAsync((command, token) => NotHaveAnyFieldsAsync(command.RequirementDefinitionId, token))
+                .WithMessage(command =>
+                    $"Requirement definition has fields! RequirementDefinition={command.RequirementDefinitionId}")
+                .MustAsync((command, token) => NotHaveAnyTagRequirementsAsync(command.RequirementDefinitionId, token))
+                .WithMessage(command =>
+                    $"Tag requirement with this requirement definition exists! RequirementDefinition={command.RequirementDefinitionId}")
+                .MustAsync((command, token) => NotHaveAnyTagFunctionRequirementsAsync(command.RequirementDefinitionId, token))
+                .WithMessage(command =>
+                    $"Tag function requirement with this requirement definition exists! RequirementDefinition={command.RequirementDefinitionId}");
+
+            async Task<bool> BeAnExistingRequirementTypeAsync(int requirementTypeId, CancellationToken token)
+                => await requirementTypeValidator.ExistsAsync(requirementTypeId, token);
+            async Task<bool> BeAnExistingRequirementDefinitionAsync(int requirementDefinitionId, CancellationToken token)
+                => await requirementDefinitionValidator.ExistsAsync(requirementDefinitionId, token);
+            async Task<bool> BeAVoidedRequirementDefinitionAsync(int requirementDefinitionId, CancellationToken token)
+                => await requirementDefinitionValidator.IsVoidedAsync(requirementDefinitionId, token);
+            async Task<bool> NotHaveAnyFieldsAsync(int requirementDefinitionId, CancellationToken token)
+                => !await requirementDefinitionValidator.FieldsExistAsync(requirementDefinitionId, token);
+            async Task<bool> NotHaveAnyTagRequirementsAsync(int requirementDefinitionId, CancellationToken token)
+                => !await requirementDefinitionValidator.TagRequirementsExistAsync(requirementDefinitionId, token);
+            async Task<bool> NotHaveAnyTagFunctionRequirementsAsync(int requirementDefinitionId, CancellationToken token)
+                => !await requirementDefinitionValidator.TagFunctionRequirementsExistAsync(requirementDefinitionId, token);
+        }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/IRequirementDefinitionValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/IRequirementDefinitionValidator.cs
@@ -11,5 +11,8 @@ namespace Equinor.Procosys.Preservation.Command.Validators.RequirementDefinition
         Task<bool> UsageCoversBothForSupplierAndOtherAsync(List<int> requirementDefinitionIds, CancellationToken token);
         Task<bool> UsageCoversForOtherThanSuppliersAsync(List<int> requirementDefinitionIds, CancellationToken token);
         Task<bool> HasAnyForSupplierOnlyUsageAsync(List<int> requirementDefinitionIds, CancellationToken token);
+        Task<bool> FieldsExistAsync(int requirementDefinitionId, CancellationToken token);
+        Task<bool> TagRequirementsExistAsync(int requirementDefinitionId, CancellationToken token);
+        Task<bool> TagFunctionRequirementsExistAsync(int requirementDefinitionId, CancellationToken token);
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/RequirementDefinitionValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/RequirementDefinitionValidator.cs
@@ -3,7 +3,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Domain;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.TagFunctionAggregate;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equinor.Procosys.Preservation.Command.Validators.RequirementDefinitionValidators
@@ -54,5 +56,23 @@ namespace Equinor.Procosys.Preservation.Command.Validators.RequirementDefinition
             => await (from rd in _context.QuerySet<RequirementDefinition>()
                 where requirementDefinitionIds.Contains(rd.Id)
                 select rd).ToListAsync(token);
+
+        public async Task<bool> FieldsExistAsync(int requirementDefinitionId, CancellationToken token)
+        {
+            var reqDef = await (from rd in _context.QuerySet<RequirementDefinition>()
+                where rd.Id == requirementDefinitionId
+                select rd).SingleOrDefaultAsync(token);
+            return reqDef != null && reqDef.Fields.Count > 0;
+        }
+
+        public async Task<bool> TagRequirementsExistAsync(int requirementDefinitionId, CancellationToken token)
+             => await (from tr in _context.QuerySet<TagRequirement>()
+                    where tr.RequirementDefinitionId == requirementDefinitionId
+                    select tr).AnyAsync(token);
+
+        public async Task<bool> TagFunctionRequirementsExistAsync(int requirementDefinitionId, CancellationToken token)
+            => await (from tfr in _context.QuerySet<TagFunctionRequirement>()
+                where tfr.RequirementDefinitionId == requirementDefinitionId
+                select tfr).AnyAsync(token);
     }
 }

--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/RequirementTypeAggregate/IRequirementTypeRepository.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/RequirementTypeAggregate/IRequirementTypeRepository.cs
@@ -8,5 +8,7 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.RequirementTypeAg
         Task<RequirementDefinition> GetRequirementDefinitionByIdAsync (int requirementDefinitionId);
         
         Task<List<RequirementDefinition>> GetRequirementDefinitionsByIdsAsync(IList<int> requirementDefinitionIds);
+
+        void RemoveRequirementDefinition(RequirementDefinition requirementDefinition);
     }
 }

--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/RequirementTypeAggregate/RequirementType.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/RequirementTypeAggregate/RequirementType.cs
@@ -54,6 +54,21 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.RequirementTypeAg
             _requirementDefinitions.Add(requirementDefinition);
         }
 
+        public void RemoveRequirementDefinition(RequirementDefinition requirementDefinition)
+        {
+            if (requirementDefinition == null)
+            {
+                throw new ArgumentNullException(nameof(requirementDefinition));
+            }
+
+            if (requirementDefinition.Plant != Plant)
+            {
+                throw new ArgumentException($"Can't remove item in {requirementDefinition.Plant} from item in {Plant}");
+            }
+
+            _requirementDefinitions.Remove(requirementDefinition);
+        }
+
         public void Void() => IsVoided = true;
         public void UnVoid() => IsVoided = false;
         

--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/RequirementTypeAggregate/RequirementType.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/RequirementTypeAggregate/RequirementType.cs
@@ -54,21 +54,6 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.RequirementTypeAg
             _requirementDefinitions.Add(requirementDefinition);
         }
 
-        public void RemoveRequirementDefinition(RequirementDefinition requirementDefinition)
-        {
-            if (requirementDefinition == null)
-            {
-                throw new ArgumentNullException(nameof(requirementDefinition));
-            }
-
-            if (requirementDefinition.Plant != Plant)
-            {
-                throw new ArgumentException($"Can't remove item in {requirementDefinition.Plant} from item in {Plant}");
-            }
-
-            _requirementDefinitions.Remove(requirementDefinition);
-        }
-
         public void Void() => IsVoided = true;
         public void UnVoid() => IsVoided = false;
         

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Repositories/RequirementTypeRepository.cs
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Repositories/RequirementTypeRepository.cs
@@ -8,9 +8,11 @@ namespace Equinor.Procosys.Preservation.Infrastructure.Repositories
 {
     public class RequirementTypeRepository : RepositoryBase<RequirementType>, IRequirementTypeRepository
     {
+        readonly PreservationContext _context;
         public RequirementTypeRepository(PreservationContext context)
             : base(context.RequirementTypes, context.RequirementTypes.Include(x => x.RequirementDefinitions).ThenInclude(x => x.Fields))
         {
+            _context = context;
         }
 
         public Task<RequirementDefinition> GetRequirementDefinitionByIdAsync(int requirementDefinitionId)
@@ -23,5 +25,8 @@ namespace Equinor.Procosys.Preservation.Infrastructure.Repositories
                 .SelectMany(rt => rt.RequirementDefinitions)
                 .Where(rd => requirementDefinitionIds.Contains(rd.Id))
                 .ToListAsync();
+
+        public void RemoveRequirementDefinition(RequirementDefinition requirementDefinition) 
+            => _context.RequirementDefinitions.Remove(requirementDefinition);
     }
 }

--- a/src/Equinor.Procosys.Preservation.Query/RequirementTypeAggregate/GetAllRequirementTypesQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/RequirementTypeAggregate/GetAllRequirementTypesQueryHandler.cs
@@ -38,6 +38,7 @@ namespace Equinor.Procosys.Preservation.Query.RequirementTypeAggregate
                                 rd.Usage,
                                 rd.SortKey,
                                 rd.NeedsUserInput,
+                                rd.RowVersion.ConvertToString(),
                                 rd.OrderedFields(request.IncludeVoided).Select(f
                                     => new FieldDto(
                                         f.Id,

--- a/src/Equinor.Procosys.Preservation.Query/RequirementTypeAggregate/GetAllRequirementTypesQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/RequirementTypeAggregate/GetAllRequirementTypesQueryHandler.cs
@@ -38,7 +38,6 @@ namespace Equinor.Procosys.Preservation.Query.RequirementTypeAggregate
                                 rd.Usage,
                                 rd.SortKey,
                                 rd.NeedsUserInput,
-                                rd.RowVersion.ConvertToString(),
                                 rd.OrderedFields(request.IncludeVoided).Select(f
                                     => new FieldDto(
                                         f.Id,
@@ -47,7 +46,8 @@ namespace Equinor.Procosys.Preservation.Query.RequirementTypeAggregate
                                         f.FieldType,
                                         f.SortKey,
                                         f.Unit,
-                                        f.ShowPrevious)))),
+                                        f.ShowPrevious)),
+                                rd.RowVersion.ConvertToString())),
                         rt.RowVersion.ConvertToString()))
                     .OrderBy(rt => rt.SortKey);
 

--- a/src/Equinor.Procosys.Preservation.Query/RequirementTypeAggregate/GetRequirementTypeByIdQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/RequirementTypeAggregate/GetRequirementTypeByIdQueryHandler.cs
@@ -43,6 +43,7 @@ namespace Equinor.Procosys.Preservation.Query.RequirementTypeAggregate
                             rd.Usage,
                             rd.SortKey,
                             rd.NeedsUserInput,
+                            rd.RowVersion.ConvertToString(),
                             rd.OrderedFields(true)
                                 .Select(f => new FieldDto(
                                     f.Id,

--- a/src/Equinor.Procosys.Preservation.Query/RequirementTypeAggregate/GetRequirementTypeByIdQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/RequirementTypeAggregate/GetRequirementTypeByIdQueryHandler.cs
@@ -43,7 +43,6 @@ namespace Equinor.Procosys.Preservation.Query.RequirementTypeAggregate
                             rd.Usage,
                             rd.SortKey,
                             rd.NeedsUserInput,
-                            rd.RowVersion.ConvertToString(),
                             rd.OrderedFields(true)
                                 .Select(f => new FieldDto(
                                     f.Id,
@@ -52,7 +51,8 @@ namespace Equinor.Procosys.Preservation.Query.RequirementTypeAggregate
                                     f.FieldType,
                                     f.SortKey,
                                     f.Unit,
-                                    f.ShowPrevious)))),
+                                    f.ShowPrevious)),
+                            rd.RowVersion.ConvertToString())),
                 reqType.RowVersion.ConvertToString());
 
             return new SuccessResult<RequirementTypeDto>(dto);

--- a/src/Equinor.Procosys.Preservation.Query/RequirementTypeAggregate/RequirementDefinitionDto.cs
+++ b/src/Equinor.Procosys.Preservation.Query/RequirementTypeAggregate/RequirementDefinitionDto.cs
@@ -15,6 +15,7 @@ namespace Equinor.Procosys.Preservation.Query.RequirementTypeAggregate
             RequirementUsage usage,
             int sortKey,
             bool needsUserInput,
+            string rowVersion,
             IEnumerable<FieldDto> fields)
         {
             if (fields == null)
@@ -28,6 +29,7 @@ namespace Equinor.Procosys.Preservation.Query.RequirementTypeAggregate
             Usage = usage;
             SortKey = sortKey;
             Fields = fields.OrderBy(f => f.SortKey);
+            RowVersion = rowVersion;
             NeedsUserInput = needsUserInput;
         }
 
@@ -37,6 +39,7 @@ namespace Equinor.Procosys.Preservation.Query.RequirementTypeAggregate
         public int DefaultIntervalWeeks { get; }
         public RequirementUsage Usage { get; }
         public int SortKey { get; }
+        public string RowVersion { get; }
         public IEnumerable<FieldDto> Fields { get; }
         public bool NeedsUserInput { get; }
     }

--- a/src/Equinor.Procosys.Preservation.Query/RequirementTypeAggregate/RequirementDefinitionDto.cs
+++ b/src/Equinor.Procosys.Preservation.Query/RequirementTypeAggregate/RequirementDefinitionDto.cs
@@ -15,8 +15,8 @@ namespace Equinor.Procosys.Preservation.Query.RequirementTypeAggregate
             RequirementUsage usage,
             int sortKey,
             bool needsUserInput,
-            string rowVersion,
-            IEnumerable<FieldDto> fields)
+            IEnumerable<FieldDto> fields,
+            string rowVersion)
         {
             if (fields == null)
             {
@@ -28,9 +28,9 @@ namespace Equinor.Procosys.Preservation.Query.RequirementTypeAggregate
             DefaultIntervalWeeks = defaultIntervalWeeks;
             Usage = usage;
             SortKey = sortKey;
+            NeedsUserInput = needsUserInput;
             Fields = fields.OrderBy(f => f.SortKey);
             RowVersion = rowVersion;
-            NeedsUserInput = needsUserInput;
         }
 
         public int Id { get; }
@@ -39,8 +39,8 @@ namespace Equinor.Procosys.Preservation.Query.RequirementTypeAggregate
         public int DefaultIntervalWeeks { get; }
         public RequirementUsage Usage { get; }
         public int SortKey { get; }
-        public string RowVersion { get; }
-        public IEnumerable<FieldDto> Fields { get; }
         public bool NeedsUserInput { get; }
+        public IEnumerable<FieldDto> Fields { get; }
+        public string RowVersion { get; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/RequirementTypes/DeleteRequirementDefinitionDto.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/RequirementTypes/DeleteRequirementDefinitionDto.cs
@@ -1,0 +1,7 @@
+﻿namespace Equinor.Procosys.Preservation.WebApi.Controllers.RequirementTypes
+{
+    public class DeleteRequirementDefinitionDto
+    {
+        public string RowVersion { get; set; }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/RequirementTypes/RequirementTypesController.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/RequirementTypes/RequirementTypesController.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.RequirementTypeCommands.CreateRequirementType;
+using Equinor.Procosys.Preservation.Command.RequirementTypeCommands.DeleteRequirementDefinition;
 using Equinor.Procosys.Preservation.Command.RequirementTypeCommands.DeleteRequirementType;
 using Equinor.Procosys.Preservation.Command.RequirementTypeCommands.UnvoidRequirementDefinition;
 using Equinor.Procosys.Preservation.Command.RequirementTypeCommands.UnvoidRequirementType;
@@ -155,6 +156,21 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.RequirementTypes
                 dto.RowVersion);
             var result = await _mediator.Send(command);
             return Ok(result);
+        }
+
+        [Authorize(Roles = Permissions.LIBRARY_PRESERVATION_DELETE)]
+        [HttpDelete("{id}/RequirementDefinitions/{requirementDefinitionId}/Delete")]
+        public async Task<ActionResult> DeleteRequirementDefinition(
+            [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
+            [Required]
+            [StringLength(PlantEntityBase.PlantLengthMax, MinimumLength = PlantEntityBase.PlantLengthMin)]
+            string plant,
+            [FromRoute] int id,
+            [FromRoute] int requirementDefinitionId,
+            [FromBody] DeleteRequirementDefinitionDto dto)
+        {
+            var result = await _mediator.Send(new DeleteRequirementDefinitionCommand(id, requirementDefinitionId, dto.RowVersion));
+            return this.FromResult(result);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/RequirementTypes/RequirementTypesController.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/RequirementTypes/RequirementTypesController.cs
@@ -159,7 +159,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.RequirementTypes
         }
 
         [Authorize(Roles = Permissions.LIBRARY_PRESERVATION_DELETE)]
-        [HttpDelete("{id}/RequirementDefinitions/{requirementDefinitionId}/Delete")]
+        [HttpDelete("{id}/RequirementDefinitions/{requirementDefinitionId}")]
         public async Task<ActionResult> DeleteRequirementDefinition(
             [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
             [Required]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/MiscCommands/Clone/RequirementTypeRepository.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/MiscCommands/Clone/RequirementTypeRepository.cs
@@ -28,5 +28,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.MiscCommands.Clone
 
         public Task<RequirementDefinition> GetRequirementDefinitionByIdAsync(int requirementDefinitionId) => throw new NotImplementedException();
         public Task<List<RequirementDefinition>> GetRequirementDefinitionsByIdsAsync(IList<int> requirementDefinitionIds) => throw new NotImplementedException();
+        public void RemoveRequirementDefinition(RequirementDefinition requirementDefinition) => throw new NotImplementedException();
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/DeleteRequirementDefinition/DeleteRequirementDefinitionCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/DeleteRequirementDefinition/DeleteRequirementDefinitionCommandHandlerTests.cs
@@ -1,0 +1,63 @@
+﻿using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.RequirementTypeCommands.DeleteRequirementDefinition;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.DeleteRequirementDefinition
+{
+    [TestClass]
+    public class DeleteRequirementDefinitionCommandHandlerTests : CommandHandlerTestsBase
+    {
+        private int _requirementTypeId = 1;
+        private int _requirementDefinitionId = 2;
+        private const string _rowVersion = "AAAAAAAAABA=";
+        private Mock<IRequirementTypeRepository> _requirementTypeRepositoryMock;
+        private DeleteRequirementDefinitionCommand _command;
+        private DeleteRequirementDefinitionCommandHandler _dut;
+        private Mock<RequirementDefinition> _requirementDefinitionMock;
+        private RequirementType _requirementType;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            // Arrange
+            _requirementTypeRepositoryMock = new Mock<IRequirementTypeRepository>();
+            _requirementType = new RequirementType(TestPlant, "Code", "Title", RequirementTypeIcon.Other, 10);
+            _requirementDefinitionMock = new Mock<RequirementDefinition>();
+            _requirementDefinitionMock.SetupGet(s => s.Plant).Returns(TestPlant);
+            _requirementDefinitionMock.SetupGet(s => s.Id).Returns(_requirementDefinitionId);
+            _requirementType.AddRequirementDefinition(_requirementDefinitionMock.Object);
+
+            _requirementTypeRepositoryMock
+                .Setup(x => x.GetByIdAsync(_requirementTypeId))
+                    .Returns(Task.FromResult(_requirementType));
+            _command = new DeleteRequirementDefinitionCommand(_requirementTypeId, _requirementDefinitionId, _rowVersion);
+
+            _dut = new DeleteRequirementDefinitionCommandHandler(_requirementTypeRepositoryMock.Object, UnitOfWorkMock.Object);
+        }
+
+        [TestMethod]
+        public async Task HandlingDeleteRequirementDefinitionCommand_ShouldDeleteRequirementDefinitionFromRequirementType()
+        {
+            // Arrange
+            Assert.AreEqual(1, _requirementType.RequirementDefinitions.Count);
+
+            // Act
+            await _dut.Handle(_command, default);
+
+            // Assert
+            _requirementTypeRepositoryMock.Verify(r => r.RemoveRequirementDefinition(_requirementDefinitionMock.Object), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task HandlingDeleteRequirementDefinitionCommand_ShouldSave()
+        {
+            // Act
+            await _dut.Handle(_command, default);
+            
+            // Assert
+            UnitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+        }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/DeleteRequirementDefinition/DeleteRequirementDefinitionCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/DeleteRequirementDefinition/DeleteRequirementDefinitionCommandValidatorTests.cs
@@ -1,0 +1,90 @@
+﻿using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.RequirementTypeCommands.DeleteRequirementDefinition;
+using Equinor.Procosys.Preservation.Command.Validators.RequirementDefinitionValidators;
+using Equinor.Procosys.Preservation.Command.Validators.RequirementTypeValidators;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.DeleteRequirementDefinition
+{
+    [TestClass]
+    public class DeleteRequirementDefinitionCommandValidatorTests
+    {
+        private DeleteRequirementDefinitionCommandValidator _dut;
+        private Mock<IRequirementTypeValidator> _requirementTypeValidatorMock;
+        private DeleteRequirementDefinitionCommand _command;
+
+        private int _requirementTypeId = 1;
+        private int _requirementDefinitionId = 2;
+        private Mock<IRequirementDefinitionValidator> _requirementDefinitionValidatorMock;
+
+        [TestInitialize]
+        public void Setup_OkState()
+        {
+            _requirementTypeValidatorMock = new Mock<IRequirementTypeValidator>();
+            _requirementTypeValidatorMock.Setup(r => r.ExistsAsync(_requirementTypeId, default)).Returns(Task.FromResult(true));
+            _requirementDefinitionValidatorMock = new Mock<IRequirementDefinitionValidator>();
+            _requirementDefinitionValidatorMock.Setup(r => r.ExistsAsync(_requirementDefinitionId, default)).Returns(Task.FromResult(true));
+            _requirementDefinitionValidatorMock.Setup(r => r.IsVoidedAsync(_requirementDefinitionId, default)).Returns(Task.FromResult(true));
+            _command = new DeleteRequirementDefinitionCommand(_requirementTypeId, _requirementDefinitionId, null);
+
+            _dut = new DeleteRequirementDefinitionCommandValidator(_requirementTypeValidatorMock.Object, _requirementDefinitionValidatorMock.Object);
+        }
+
+        [TestMethod]
+        public void Validate_ShouldBeValid_WhenOkState()
+        {
+            var result = _dut.Validate(_command);
+
+            Assert.IsTrue(result.IsValid);
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenRequirementTypeNotExists()
+        {
+            _requirementTypeValidatorMock.Setup(r => r.ExistsAsync(_requirementTypeId, default)).Returns(Task.FromResult(false));
+            
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirement type doesn't exist!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenRequirementDefinitionNotVoided()
+        {
+            _requirementDefinitionValidatorMock.Setup(r => r.IsVoidedAsync(_requirementDefinitionId, default)).Returns(Task.FromResult(false));
+            
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirement definition is not voided!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenRequirementDefinitionExistsOnTagRequirement()
+        {
+            _requirementDefinitionValidatorMock.Setup(r => r.TagRequirementsExistAsync(_requirementDefinitionId, default)).Returns(Task.FromResult(true));
+            
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Tag requirement with this requirement definition exists!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenRequirementDefinitionExistsOnTagFunctionRequirement()
+        {
+            _requirementDefinitionValidatorMock.Setup(r => r.TagFunctionRequirementsExistAsync(_requirementDefinitionId, default)).Returns(Task.FromResult(true));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Tag function requirement with this requirement definition exists!"));
+        }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/DeleteRequirementDefinition/DeleteRequirementDefinitionCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/DeleteRequirementDefinition/DeleteRequirementDefinitionCommandValidatorTests.cs
@@ -86,5 +86,17 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.De
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Tag function requirement with this requirement definition exists!"));
         }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenRequirementDefinitionHasFields()
+        {
+            _requirementDefinitionValidatorMock.Setup(r => r.FieldsExistAsync(_requirementDefinitionId, default)).Returns(Task.FromResult(true));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirement definition has fields!"));
+        }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/RequirementTypeAggregate/RequirementDefDtoTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/RequirementTypeAggregate/RequirementDefDtoTests.cs
@@ -15,7 +15,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.RequirementTypeAggregate
         [TestMethod]
         public void Constructor_ShouldSetProperties()
         {
-            var dut = new RequirementDefinitionDto(1, "TitleA", true, 4, RequirementUsage.ForAll, 10, false, _rowVersion, new List<FieldDto>());
+            var dut = new RequirementDefinitionDto(1, "TitleA", true, 4, RequirementUsage.ForAll, 10, false, new List<FieldDto>(), _rowVersion);
 
             Assert.AreEqual(1, dut.Id);
             Assert.AreEqual("TitleA", dut.Title);
@@ -30,19 +30,19 @@ namespace Equinor.Procosys.Preservation.Query.Tests.RequirementTypeAggregate
         [TestMethod]
         public void Constructor_ShouldThrowException_WhenModeNotGiven()
             => Assert.ThrowsException<ArgumentNullException>(() =>
-                new RequirementDefinitionDto(1, "TitleA", true, 4, RequirementUsage.ForAll, 10, true, _rowVersion, null)
+                new RequirementDefinitionDto(1, "TitleA", true, 4, RequirementUsage.ForAll, 10, true, null, _rowVersion)
             );
 
         [TestMethod]
         public void ConstructorWithFields_ShouldCreateDtoWithFieldsSortedBySortKey()
         {
-            var dut = new RequirementDefinitionDto(1, "TitleA", true, 4, RequirementUsage.ForAll, 10, true, _rowVersion, new List<FieldDto>
+            var dut = new RequirementDefinitionDto(1, "TitleA", true, 4, RequirementUsage.ForAll, 10, true, new List<FieldDto>
             {
                 new FieldDto(1, "", true, FieldType.Info, 1, null, null),
                 new FieldDto(2, "", true, FieldType.Info, 90, null, null),
                 new FieldDto(3, "", true, FieldType.Info, 5, null, null),
                 new FieldDto(4, "", true, FieldType.Info, 10, null, null),
-            });
+            }, _rowVersion);
 
             var dtos = dut.Fields.ToList();
             Assert.AreEqual(4, dtos.Count);

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/RequirementTypeAggregate/RequirementDefDtoTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/RequirementTypeAggregate/RequirementDefDtoTests.cs
@@ -10,10 +10,12 @@ namespace Equinor.Procosys.Preservation.Query.Tests.RequirementTypeAggregate
     [TestClass]
     public class RequirementDefDtoTests
     {
+        private const string _rowVersion = "AAAAAAAAABA=";
+
         [TestMethod]
         public void Constructor_ShouldSetProperties()
         {
-            var dut = new RequirementDefinitionDto(1, "TitleA", true, 4, RequirementUsage.ForAll, 10, false, new List<FieldDto>());
+            var dut = new RequirementDefinitionDto(1, "TitleA", true, 4, RequirementUsage.ForAll, 10, false, _rowVersion, new List<FieldDto>());
 
             Assert.AreEqual(1, dut.Id);
             Assert.AreEqual("TitleA", dut.Title);
@@ -28,13 +30,13 @@ namespace Equinor.Procosys.Preservation.Query.Tests.RequirementTypeAggregate
         [TestMethod]
         public void Constructor_ShouldThrowException_WhenModeNotGiven()
             => Assert.ThrowsException<ArgumentNullException>(() =>
-                new RequirementDefinitionDto(1, "TitleA", true, 4, RequirementUsage.ForAll, 10, true, null)
+                new RequirementDefinitionDto(1, "TitleA", true, 4, RequirementUsage.ForAll, 10, true, _rowVersion, null)
             );
 
         [TestMethod]
         public void ConstructorWithFields_ShouldCreateDtoWithFieldsSortedBySortKey()
         {
-            var dut = new RequirementDefinitionDto(1, "TitleA", true, 4, RequirementUsage.ForAll, 10, true, new List<FieldDto>
+            var dut = new RequirementDefinitionDto(1, "TitleA", true, 4, RequirementUsage.ForAll, 10, true, _rowVersion, new List<FieldDto>
             {
                 new FieldDto(1, "", true, FieldType.Info, 1, null, null),
                 new FieldDto(2, "", true, FieldType.Info, 90, null, null),

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/RequirementTypeAggregate/RequirementTypeDtoTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/RequirementTypeAggregate/RequirementTypeDtoTests.cs
@@ -40,12 +40,11 @@ namespace Equinor.Procosys.Preservation.Query.Tests.RequirementTypeAggregate
         {
             var dut = new RequirementTypeDto(1, "", "", _reqIconOther, true, 10, new List<RequirementDefinitionDto>
             {
-                new RequirementDefinitionDto(1, "",  false, 4, RequirementUsage.ForAll, 999, false, _rowVersion, _fieldsDtos),
-                new RequirementDefinitionDto(2, "", false, 4, RequirementUsage.ForAll, 5, false, _rowVersion, _fieldsDtos),
-                new RequirementDefinitionDto(3, "", false, 4, RequirementUsage.ForAll, 500, false, _rowVersion, _fieldsDtos),
-                new RequirementDefinitionDto(4, "", false, 4, RequirementUsage.ForAll, 10, false, _rowVersion, _fieldsDtos),
-            },
-                _rowVersion);
+                new RequirementDefinitionDto(1, "",  false, 4, RequirementUsage.ForAll, 999, false, _fieldsDtos, _rowVersion),
+                new RequirementDefinitionDto(2, "", false, 4, RequirementUsage.ForAll, 5, false, _fieldsDtos, _rowVersion),
+                new RequirementDefinitionDto(3, "", false, 4, RequirementUsage.ForAll, 500, false, _fieldsDtos, _rowVersion),
+                new RequirementDefinitionDto(4, "", false, 4, RequirementUsage.ForAll, 10, false, _fieldsDtos, _rowVersion),
+            }, _rowVersion);
 
             var requirementDefinitions = dut.RequirementDefinitions.ToList();
             Assert.AreEqual(4, requirementDefinitions.Count);
@@ -60,12 +59,11 @@ namespace Equinor.Procosys.Preservation.Query.Tests.RequirementTypeAggregate
         {
             var dut = new RequirementTypeDto(1, "", "", _reqIconOther, true, 10, new List<RequirementDefinitionDto>
             {
-                new RequirementDefinitionDto(1, "", false, 4, RequirementUsage.ForAll, 999, true, _rowVersion, _fieldsDtos),
-                new RequirementDefinitionDto(2, "", false, 4, RequirementUsage.ForAll, 5, true, _rowVersion, _fieldsDtos),
-                new RequirementDefinitionDto(3, "", false, 4, RequirementUsage.ForAll, 500, true, _rowVersion,_fieldsDtos),
-                new RequirementDefinitionDto(4, "", false, 4, RequirementUsage.ForAll, 10, true, _rowVersion, _fieldsDtos),
-            },
-                _rowVersion);
+                new RequirementDefinitionDto(1, "", false, 4, RequirementUsage.ForAll, 999, true, _fieldsDtos, _rowVersion),
+                new RequirementDefinitionDto(2, "", false, 4, RequirementUsage.ForAll, 5, true, _fieldsDtos, _rowVersion),
+                new RequirementDefinitionDto(3, "", false, 4, RequirementUsage.ForAll, 500, true, _fieldsDtos, _rowVersion),
+                new RequirementDefinitionDto(4, "", false, 4, RequirementUsage.ForAll, 10, true, _fieldsDtos, _rowVersion),
+            }, _rowVersion);
 
             var requirementDefinitions = dut.RequirementDefinitions.ToList();
             Assert.AreEqual(4, requirementDefinitions.Count);
@@ -80,16 +78,15 @@ namespace Equinor.Procosys.Preservation.Query.Tests.RequirementTypeAggregate
         {
             var dut = new RequirementTypeDto(1, "", "", _reqIconOther, true, 10, new List<RequirementDefinitionDto>
             {
-                new RequirementDefinitionDto(1, "", false, 4, RequirementUsage.ForAll, 999, true, _rowVersion, _fieldsDtos),
-                new RequirementDefinitionDto(2, "", false, 4, RequirementUsage.ForAll, 5, true, _rowVersion, _fieldsDtos),
-                new RequirementDefinitionDto(3, "", false, 4, RequirementUsage.ForAll, 500, true, _rowVersion, _fieldsDtos),
-                new RequirementDefinitionDto(4, "", false, 4, RequirementUsage.ForAll, 10, true, _rowVersion, _fieldsDtos),
-                new RequirementDefinitionDto(5, "", false, 4, RequirementUsage.ForAll, 999, false, _rowVersion, _fieldsDtos),
-                new RequirementDefinitionDto(6, "", false, 4, RequirementUsage.ForAll, 5, false, _rowVersion, _fieldsDtos),
-                new RequirementDefinitionDto(7, "", false, 4, RequirementUsage.ForAll, 500, false, _rowVersion, _fieldsDtos),
-                new RequirementDefinitionDto(8, "", false, 4, RequirementUsage.ForAll, 10, false, _rowVersion, _fieldsDtos),
-            },
-                _rowVersion);
+                new RequirementDefinitionDto(1, "", false, 4, RequirementUsage.ForAll, 999, true, _fieldsDtos, _rowVersion),
+                new RequirementDefinitionDto(2, "", false, 4, RequirementUsage.ForAll, 5, true, _fieldsDtos, _rowVersion),
+                new RequirementDefinitionDto(3, "", false, 4, RequirementUsage.ForAll, 500, true, _fieldsDtos, _rowVersion),
+                new RequirementDefinitionDto(4, "", false, 4, RequirementUsage.ForAll, 10, true, _fieldsDtos, _rowVersion),
+                new RequirementDefinitionDto(5, "", false, 4, RequirementUsage.ForAll, 999, false, _fieldsDtos, _rowVersion),
+                new RequirementDefinitionDto(6, "", false, 4, RequirementUsage.ForAll, 5, false, _fieldsDtos, _rowVersion),
+                new RequirementDefinitionDto(7, "", false, 4, RequirementUsage.ForAll, 500, false, _fieldsDtos, _rowVersion),
+                new RequirementDefinitionDto(8, "", false, 4, RequirementUsage.ForAll, 10, false, _fieldsDtos, _rowVersion),
+            }, _rowVersion);
 
             var requirementDefinitions = dut.RequirementDefinitions.ToList();
             Assert.AreEqual(8, requirementDefinitions.Count);

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/RequirementTypeAggregate/RequirementTypeDtoTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/RequirementTypeAggregate/RequirementTypeDtoTests.cs
@@ -40,10 +40,10 @@ namespace Equinor.Procosys.Preservation.Query.Tests.RequirementTypeAggregate
         {
             var dut = new RequirementTypeDto(1, "", "", _reqIconOther, true, 10, new List<RequirementDefinitionDto>
             {
-                new RequirementDefinitionDto(1, "",  false, 4, RequirementUsage.ForAll, 999, false, _fieldsDtos),
-                new RequirementDefinitionDto(2, "", false, 4, RequirementUsage.ForAll, 5, false, _fieldsDtos),
-                new RequirementDefinitionDto(3, "", false, 4, RequirementUsage.ForAll, 500, false, _fieldsDtos),
-                new RequirementDefinitionDto(4, "", false, 4, RequirementUsage.ForAll, 10, false, _fieldsDtos),
+                new RequirementDefinitionDto(1, "",  false, 4, RequirementUsage.ForAll, 999, false, _rowVersion, _fieldsDtos),
+                new RequirementDefinitionDto(2, "", false, 4, RequirementUsage.ForAll, 5, false, _rowVersion, _fieldsDtos),
+                new RequirementDefinitionDto(3, "", false, 4, RequirementUsage.ForAll, 500, false, _rowVersion, _fieldsDtos),
+                new RequirementDefinitionDto(4, "", false, 4, RequirementUsage.ForAll, 10, false, _rowVersion, _fieldsDtos),
             },
                 _rowVersion);
 
@@ -60,10 +60,10 @@ namespace Equinor.Procosys.Preservation.Query.Tests.RequirementTypeAggregate
         {
             var dut = new RequirementTypeDto(1, "", "", _reqIconOther, true, 10, new List<RequirementDefinitionDto>
             {
-                new RequirementDefinitionDto(1, "", false, 4, RequirementUsage.ForAll, 999, true, _fieldsDtos),
-                new RequirementDefinitionDto(2, "", false, 4, RequirementUsage.ForAll, 5, true, _fieldsDtos),
-                new RequirementDefinitionDto(3, "", false, 4, RequirementUsage.ForAll, 500, true, _fieldsDtos),
-                new RequirementDefinitionDto(4, "", false, 4, RequirementUsage.ForAll, 10, true, _fieldsDtos),
+                new RequirementDefinitionDto(1, "", false, 4, RequirementUsage.ForAll, 999, true, _rowVersion, _fieldsDtos),
+                new RequirementDefinitionDto(2, "", false, 4, RequirementUsage.ForAll, 5, true, _rowVersion, _fieldsDtos),
+                new RequirementDefinitionDto(3, "", false, 4, RequirementUsage.ForAll, 500, true, _rowVersion,_fieldsDtos),
+                new RequirementDefinitionDto(4, "", false, 4, RequirementUsage.ForAll, 10, true, _rowVersion, _fieldsDtos),
             },
                 _rowVersion);
 
@@ -80,14 +80,14 @@ namespace Equinor.Procosys.Preservation.Query.Tests.RequirementTypeAggregate
         {
             var dut = new RequirementTypeDto(1, "", "", _reqIconOther, true, 10, new List<RequirementDefinitionDto>
             {
-                new RequirementDefinitionDto(1, "", false, 4, RequirementUsage.ForAll, 999, true, _fieldsDtos),
-                new RequirementDefinitionDto(2, "", false, 4, RequirementUsage.ForAll, 5, true, _fieldsDtos),
-                new RequirementDefinitionDto(3, "", false, 4, RequirementUsage.ForAll, 500, true, _fieldsDtos),
-                new RequirementDefinitionDto(4, "", false, 4, RequirementUsage.ForAll, 10, true, _fieldsDtos),
-                new RequirementDefinitionDto(5, "", false, 4, RequirementUsage.ForAll, 999, false, _fieldsDtos),
-                new RequirementDefinitionDto(6, "", false, 4, RequirementUsage.ForAll, 5, false, _fieldsDtos),
-                new RequirementDefinitionDto(7, "", false, 4, RequirementUsage.ForAll, 500, false, _fieldsDtos),
-                new RequirementDefinitionDto(8, "", false, 4, RequirementUsage.ForAll, 10, false, _fieldsDtos),
+                new RequirementDefinitionDto(1, "", false, 4, RequirementUsage.ForAll, 999, true, _rowVersion, _fieldsDtos),
+                new RequirementDefinitionDto(2, "", false, 4, RequirementUsage.ForAll, 5, true, _rowVersion, _fieldsDtos),
+                new RequirementDefinitionDto(3, "", false, 4, RequirementUsage.ForAll, 500, true, _rowVersion, _fieldsDtos),
+                new RequirementDefinitionDto(4, "", false, 4, RequirementUsage.ForAll, 10, true, _rowVersion, _fieldsDtos),
+                new RequirementDefinitionDto(5, "", false, 4, RequirementUsage.ForAll, 999, false, _rowVersion, _fieldsDtos),
+                new RequirementDefinitionDto(6, "", false, 4, RequirementUsage.ForAll, 5, false, _rowVersion, _fieldsDtos),
+                new RequirementDefinitionDto(7, "", false, 4, RequirementUsage.ForAll, 500, false, _rowVersion, _fieldsDtos),
+                new RequirementDefinitionDto(8, "", false, 4, RequirementUsage.ForAll, 10, false, _rowVersion, _fieldsDtos),
             },
                 _rowVersion);
 


### PR DESCRIPTION
Delete requirement definition.

Have deleteRequirementDefinition in RequirementTypeRepository because using remove as on DeleteStep does not delete object from database (just removes parentId). (ParentId on requirementDefinition is not nullable in database, so would have to change this if we wanted to remove requirement definition in the same way as we are "removing" step for example). 

Need to create composite key to achieve a complete delete, and can then remove this remove method from 

RequirementTypeRepository. The composite key for Requirement Definition would be Id and RequirementTypeId.