### PR TITLE
74970 extend dto validators row version

### DIFF
--- a/src/Equinor.Procosys.Preservation.Command/ActionCommands/CloseAction/CloseActionCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/ActionCommands/CloseAction/CloseActionCommandValidator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.ActionValidators;
 using Equinor.Procosys.Preservation.Command.Validators.ProjectValidators;
 using Equinor.Procosys.Preservation.Command.Validators.TagValidators;
@@ -12,7 +13,8 @@ namespace Equinor.Procosys.Preservation.Command.ActionCommands.CloseAction
         public CloseActionCommandValidator(
             IProjectValidator projectValidator,
             ITagValidator tagValidator,
-            IActionValidator actionValidator)
+            IActionValidator actionValidator,
+            IRowVersionValidator rowVersionValidator)
         {
             CascadeMode = CascadeMode.StopOnFirstFailure;
 
@@ -26,7 +28,9 @@ namespace Equinor.Procosys.Preservation.Command.ActionCommands.CloseAction
                 .MustAsync((command, token) => BeAnExistingActionAsync(command.ActionId, token))
                 .WithMessage(command => $"Action doesn't exist! Action={command.ActionId}")
                 .MustAsync((command, token) => NotBeAClosedActionAsync(command.ActionId, token))
-                .WithMessage(command => $"Action is already closed! Action={command.ActionId}");
+                .WithMessage(command => $"Action is already closed! Action={command.ActionId}")
+                .MustAsync((command, token) => HaveAValidRowVersion(command.RowVersion, token))
+                .WithMessage(command => $"Not a valid RowVersion! RowVersion={command.RowVersion}");
 
             async Task<bool> NotBeAClosedProjectForTagAsync(int tagId, CancellationToken token)
                 => !await projectValidator.IsClosedForTagAsync(tagId, token);
@@ -38,6 +42,8 @@ namespace Equinor.Procosys.Preservation.Command.ActionCommands.CloseAction
                 => await actionValidator.ExistsAsync(actionId, token);
             async Task<bool> NotBeAClosedActionAsync(int actionId, CancellationToken token)
                 => !await actionValidator.IsClosedAsync(actionId, token);
+            async Task<bool> HaveAValidRowVersion(string rowVersion, CancellationToken token)
+                => await rowVersionValidator.IsValid(rowVersion, token);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/DeleteStep/DeleteStepCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/DeleteStep/DeleteStepCommandValidator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.JourneyValidators;
 using Equinor.Procosys.Preservation.Command.Validators.StepValidators;
 using FluentValidation;
@@ -8,7 +9,10 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.DeleteStep
 {
     public class DeleteStepCommandValidator : AbstractValidator<DeleteStepCommand>
     {
-        public DeleteStepCommandValidator(IJourneyValidator journeyValidator, IStepValidator stepValidator)
+        public DeleteStepCommandValidator(
+            IJourneyValidator journeyValidator,
+            IStepValidator stepValidator,
+            IRowVersionValidator rowVersionValidator)
         {
             CascadeMode = CascadeMode.StopOnFirstFailure;
             
@@ -20,8 +24,10 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.DeleteStep
                 .MustAsync((command, token) => BeAVoidedStepAsync(command.StepId, token))
                 .WithMessage(command => $"Step is not voided! Step={command.StepId}")
                 .MustAsync((command, token) => JourneyForStepNotBeUsedAsync(command.JourneyId, token))
-                .WithMessage(command => $"Journey owning step is used and no steps can be deleted! Journey={command.JourneyId}");
-            
+                .WithMessage(command => $"Journey owning step is used and no steps can be deleted! Journey={command.JourneyId}")
+                .MustAsync((command, token) => HaveAValidRowVersion(command.RowVersion, token))
+                .WithMessage(command => $"Not a valid RowVersion! RowVersion={command.RowVersion}");
+
             async Task<bool> BeAnExistingJourneyAsync(int journeyId, CancellationToken token)
                 => await journeyValidator.ExistsAsync(journeyId, token);
             
@@ -33,6 +39,9 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.DeleteStep
             
             async Task<bool> JourneyForStepNotBeUsedAsync(int journeyId, CancellationToken token)
                 => !await journeyValidator.IsInUseAsync(journeyId, token);
+
+            async Task<bool> HaveAValidRowVersion(string rowVersion, CancellationToken token)
+                => await rowVersionValidator.IsValid(rowVersion, token);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UnvoidJourney/UnvoidJourneyCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UnvoidJourney/UnvoidJourneyCommandValidator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.JourneyValidators;
 using FluentValidation;
 
@@ -7,7 +8,9 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.UnvoidJourney
 {
     public class UnvoidJourneyCommandValidator : AbstractValidator<UnvoidJourneyCommand>
     {
-        public UnvoidJourneyCommandValidator(IJourneyValidator journeyValidator)
+        public UnvoidJourneyCommandValidator(
+            IJourneyValidator journeyValidator,
+            IRowVersionValidator rowVersionValidator)
         {
             CascadeMode = CascadeMode.StopOnFirstFailure;
 
@@ -15,12 +18,16 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.UnvoidJourney
                 .MustAsync((command, token) => BeAnExistingJourneyAsync(command.JourneyId, token))
                 .WithMessage(command => $"Journey doesn't exist! Journey={command.JourneyId}")
                 .MustAsync((command, token) => BeAVoidedJourneyAsync(command.JourneyId, token))
-                .WithMessage(command => $"Journey is not voided! Journey={command.JourneyId}");
+                .WithMessage(command => $"Journey is not voided! Journey={command.JourneyId}")
+                .MustAsync((command, token) => HaveAValidRowVersion(command.RowVersion, token))
+                .WithMessage(command => $"Not a valid RowVersion! RowVersion={command.RowVersion}");
 
             async Task<bool> BeAnExistingJourneyAsync(int journeyId, CancellationToken token)
                 => await journeyValidator.ExistsAsync(journeyId, token);
             async Task<bool> BeAVoidedJourneyAsync(int journeyId, CancellationToken token)
                 => await journeyValidator.IsVoidedAsync(journeyId, token);
+            async Task<bool> HaveAValidRowVersion(string rowVersion, CancellationToken token)
+                => await rowVersionValidator.IsValid(rowVersion, token);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/VoidJourney/VoidJourneyCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/VoidJourney/VoidJourneyCommandValidator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.JourneyValidators;
 using FluentValidation;
 
@@ -7,7 +8,9 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.VoidJourney
 {
     public class VoidJourneyCommandValidator : AbstractValidator<VoidJourneyCommand>
     {
-        public VoidJourneyCommandValidator(IJourneyValidator journeyValidator)
+        public VoidJourneyCommandValidator(
+            IJourneyValidator journeyValidator,
+            IRowVersionValidator rowVersionValidator)
         {
             CascadeMode = CascadeMode.StopOnFirstFailure;
 
@@ -15,12 +18,16 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.VoidJourney
                 .MustAsync((command, token) => BeAnExistingJourneyAsync(command.JourneyId, token))
                 .WithMessage(command => $"Journey doesn't exist! Journey={command.JourneyId}")
                 .MustAsync((command, token) => NotBeAVoidedJourneyAsync(command.JourneyId, token))
-                .WithMessage(command => $"Journey is already voided! Journey={command.JourneyId}");
+                .WithMessage(command => $"Journey is already voided! Journey={command.JourneyId}")
+                .MustAsync((command, token) => HaveAValidRowVersion(command.RowVersion, token))
+                .WithMessage(command => $"Not a valid RowVersion! RowVersion={command.RowVersion}");
 
             async Task<bool> BeAnExistingJourneyAsync(int journeyId, CancellationToken token)
                 => await journeyValidator.ExistsAsync(journeyId, token);
             async Task<bool> NotBeAVoidedJourneyAsync(int journeyId, CancellationToken token)
                 => !await journeyValidator.IsVoidedAsync(journeyId, token);
+            async Task<bool> HaveAValidRowVersion(string rowVersion, CancellationToken token)
+                => await rowVersionValidator.IsValid(rowVersion, token);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/VoidStep/VoidStepCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/VoidStep/VoidStepCommandValidator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.StepValidators;
 using FluentValidation;
 
@@ -7,7 +8,9 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.VoidStep
 {
     public class VoidStepCommandValidator : AbstractValidator<VoidStepCommand>
     {
-        public VoidStepCommandValidator(IStepValidator stepValidator)
+        public VoidStepCommandValidator(
+            IStepValidator stepValidator,
+            IRowVersionValidator rowVersionValidator)
         {
             CascadeMode = CascadeMode.StopOnFirstFailure;
 
@@ -15,12 +18,16 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.VoidStep
                 .MustAsync((command, token) => BeAnExistingStepAsync(command.StepId, token))
                 .WithMessage(command => $"Step does not exist! Step={command.StepId}")
                 .MustAsync((command, token) => NotBeAVoidedStepAsync(command.StepId, token))
-                .WithMessage(command => $"Step is already voided! Step={command.StepId}");
+                .WithMessage(command => $"Step is already voided! Step={command.StepId}")
+                .MustAsync((command, token) => HaveAValidRowVersion(command.RowVersion, token))
+                .WithMessage(command => $"Not a valid RowVersion! RowVersion={command.RowVersion}");
 
             async Task<bool> BeAnExistingStepAsync(int stepId, CancellationToken token)
                 => await stepValidator.ExistsAsync(stepId, token);
             async Task<bool> NotBeAVoidedStepAsync(int stepId, CancellationToken token)
                 => !await stepValidator.IsVoidedAsync(stepId, token);
+            async Task<bool> HaveAValidRowVersion(string rowVersion, CancellationToken token)
+                => await rowVersionValidator.IsValid(rowVersion, token);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/ModeCommands/UnvoidMode/UnvoidModeCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/ModeCommands/UnvoidMode/UnvoidModeCommandValidator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.ModeValidators;
 using FluentValidation;
 
@@ -7,7 +8,9 @@ namespace Equinor.Procosys.Preservation.Command.ModeCommands.UnvoidMode
 {
     public class UnvoidModeCommandValidator : AbstractValidator<UnvoidModeCommand>
     {
-        public UnvoidModeCommandValidator(IModeValidator modeValidator)
+        public UnvoidModeCommandValidator(
+            IModeValidator modeValidator,
+            IRowVersionValidator rowVersionValidator)
         {
             CascadeMode = CascadeMode.StopOnFirstFailure;
 
@@ -15,12 +18,16 @@ namespace Equinor.Procosys.Preservation.Command.ModeCommands.UnvoidMode
                 .MustAsync((command, token) => BeAnExistingModeAsync(command.ModeId, token))
                 .WithMessage(command => $"Mode doesn't exist! Mode={command.ModeId}")
                 .MustAsync((command, token) => BeAVoidedModeAsync(command.ModeId, token))
-                .WithMessage(command => $"Mode is not voided! Mode={command.ModeId}");
+                .WithMessage(command => $"Mode is not voided! Mode={command.ModeId}")
+                .MustAsync((command, token) => HaveAValidRowVersion(command.RowVersion, token))
+                .WithMessage(command => $"Not a valid RowVersion! RowVersion={command.RowVersion}");
 
             async Task<bool> BeAnExistingModeAsync(int modeId, CancellationToken token)
                 => await modeValidator.ExistsAsync(modeId, token);
             async Task<bool> BeAVoidedModeAsync(int modeId, CancellationToken token)
                 => await modeValidator.IsVoidedAsync(modeId, token);
+            async Task<bool> HaveAValidRowVersion(string rowVersion, CancellationToken token)
+                => await rowVersionValidator.IsValid(rowVersion, token);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/ModeCommands/VoidMode/VoidModeCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/ModeCommands/VoidMode/VoidModeCommandValidator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.ModeValidators;
 using FluentValidation;
 
@@ -7,7 +8,9 @@ namespace Equinor.Procosys.Preservation.Command.ModeCommands.VoidMode
 {
     public class VoidModeCommandValidator : AbstractValidator<VoidModeCommand>
     {
-        public VoidModeCommandValidator(IModeValidator modeValidator)
+        public VoidModeCommandValidator(
+            IModeValidator modeValidator,
+            IRowVersionValidator rowVersionValidator)
         {
             CascadeMode = CascadeMode.StopOnFirstFailure;
 
@@ -15,12 +18,16 @@ namespace Equinor.Procosys.Preservation.Command.ModeCommands.VoidMode
                 .MustAsync((command, token) => BeAnExistingModeAsync(command.ModeId, token))
                 .WithMessage(command => $"Mode doesn't exist! Mode={command.ModeId}")
                 .MustAsync((command, token) => NotBeAVoidedModeAsync(command.ModeId, token))
-                .WithMessage(command => $"Mode is already voided! Mode={command.ModeId}");
+                .WithMessage(command => $"Mode is already voided! Mode={command.ModeId}")
+                .MustAsync((command, token) => HaveAValidRowVersion(command.RowVersion, token))
+                .WithMessage(command => $"Not a valid RowVersion! RowVersion={command.RowVersion}");
 
             async Task<bool> BeAnExistingModeAsync(int modeId, CancellationToken token)
                 => await modeValidator.ExistsAsync(modeId, token);
             async Task<bool> NotBeAVoidedModeAsync(int modeId, CancellationToken token)
                 => !await modeValidator.IsVoidedAsync(modeId, token);
+            async Task<bool> HaveAValidRowVersion(string rowVersion, CancellationToken token)
+                => await rowVersionValidator.IsValid(rowVersion, token);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/DeleteRequirementType/DeleteRequirementTypeCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/DeleteRequirementType/DeleteRequirementTypeCommandValidator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.RequirementTypeValidators;
 using FluentValidation;
 
@@ -7,7 +8,9 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.DeleteRe
 {
     public class DeleteRequirementTypeCommandValidator : AbstractValidator<DeleteRequirementTypeCommand>
     {
-        public DeleteRequirementTypeCommandValidator(IRequirementTypeValidator requirementTypeValidator)
+        public DeleteRequirementTypeCommandValidator(
+            IRequirementTypeValidator requirementTypeValidator,
+            IRowVersionValidator rowVersionValidator)
         {
             CascadeMode = CascadeMode.StopOnFirstFailure;
 
@@ -17,7 +20,9 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.DeleteRe
                 .MustAsync((command, token) => NotHaveAnyRequirementDefinitions(command.RequirementTypeId, token))
                 .WithMessage(command => $"Requirement type has requirement definitions! RequirementType={command.RequirementTypeId}")
                 .MustAsync((command, token) => BeAVoidedRequirementTypeAsync(command.RequirementTypeId, token))
-                .WithMessage(command => $"Requirement type is not voided! RequirementType={command.RequirementTypeId}");
+                .WithMessage(command => $"Requirement type is not voided! RequirementType={command.RequirementTypeId}")
+                .MustAsync((command, token) => HaveAValidRowVersion(command.RowVersion, token))
+                .WithMessage(command => $"Not a valid RowVersion! RowVersion={command.RowVersion}");
 
             async Task<bool> BeAnExistingRequirementTypeAsync(int requirementTypeId, CancellationToken token)
                 => await requirementTypeValidator.ExistsAsync(requirementTypeId, token);
@@ -25,6 +30,8 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.DeleteRe
                 => !await requirementTypeValidator.RequirementDefinitionExistsAsync(requirementTypeId, token);
             async Task<bool> BeAVoidedRequirementTypeAsync(int requirementTypeId, CancellationToken token)
                 => await requirementTypeValidator.IsVoidedAsync(requirementTypeId, token);
+            async Task<bool> HaveAValidRowVersion(string rowVersion, CancellationToken token)
+                => await rowVersionValidator.IsValid(rowVersion, token);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/UpdateRequirementType/UpdateRequirementTypeCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/UpdateRequirementType/UpdateRequirementTypeCommandValidator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.RequirementTypeValidators;
 using FluentValidation;
 
@@ -7,7 +8,9 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.UpdateRe
 {
     public class UpdateRequirementTypeCommandValidator : AbstractValidator<UpdateRequirementTypeCommand>
     {
-        public UpdateRequirementTypeCommandValidator(IRequirementTypeValidator requirementTypeValidator)
+        public UpdateRequirementTypeCommandValidator(
+            IRequirementTypeValidator requirementTypeValidator,
+            IRowVersionValidator rowVersionValidator)
         {
             CascadeMode = CascadeMode.StopOnFirstFailure;
 
@@ -19,7 +22,9 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.UpdateRe
                 .MustAsync((command, token) => BeAUniqueCodeAsync(command.RequirementTypeId, command.Code, token))
                 .WithMessage(command => $"Another requirement type with this code already exists! Code={command.Code}")
                 .MustAsync((command, token) => BeAUniqueTitleAsync(command.RequirementTypeId, command.Title, token))
-                .WithMessage(command => $"Another requirement type with this title already exists! Title={command.Title}");
+                .WithMessage(command => $"Another requirement type with this title already exists! Title={command.Title}")
+                .MustAsync((command, token) => HaveAValidRowVersion(command.RowVersion, token))
+                .WithMessage(command => $"Not a valid RowVersion! RowVersion={command.RowVersion}");
 
             async Task<bool> BeAnExistingRequirementTypeAsync(int requirementTypeId, CancellationToken token)
                 => await requirementTypeValidator.ExistsAsync(requirementTypeId, token);
@@ -29,6 +34,8 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.UpdateRe
                 => !await requirementTypeValidator.IsNotUniqueCodeAsync(requirementTypeId, code, token);
             async Task<bool> BeAUniqueTitleAsync(int requirementTypeId, string title, CancellationToken token)
                 => !await requirementTypeValidator.IsNotUniqueTitleAsync(requirementTypeId, title, token);
+            async Task<bool> HaveAValidRowVersion(string rowVersion, CancellationToken token)
+                => await rowVersionValidator.IsValid(rowVersion, token);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/VoidRequirementDefinition/VoidRequirementDefinitionCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/VoidRequirementDefinition/VoidRequirementDefinitionCommandValidator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.RequirementDefinitionValidators;
 using Equinor.Procosys.Preservation.Command.Validators.RequirementTypeValidators;
 using FluentValidation;
@@ -10,7 +11,8 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.VoidRequ
     {
         public VoidRequirementDefinitionCommandValidator(
             IRequirementTypeValidator requirementTypeValidator,
-            IRequirementDefinitionValidator requirementDefinitionValidator
+            IRequirementDefinitionValidator requirementDefinitionValidator,
+            IRowVersionValidator rowVersionValidator
         )
         {
             CascadeMode = CascadeMode.StopOnFirstFailure;
@@ -21,7 +23,9 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.VoidRequ
                 .MustAsync((command, token) => BeAnExistingRequirementDefinitionAsync(command.RequirementDefinitionId, token))
                 .WithMessage(command => $"Requirement definition does not exist! RequirementDefinition={command.RequirementDefinitionId}")
                 .MustAsync((command, token) => NotBeAVoidedRequirementDefinitionAsync(command.RequirementDefinitionId, token))
-                .WithMessage(command => $"Requirement definition is already voided! RequirementDefinition={command.RequirementDefinitionId}");
+                .WithMessage(command => $"Requirement definition is already voided! RequirementDefinition={command.RequirementDefinitionId}")
+                .MustAsync((command, token) => HaveAValidRowVersion(command.RowVersion, token))
+                .WithMessage(command => $"Not a valid RowVersion! RowVersion={command.RowVersion}");
 
             async Task<bool> BeAnExistingRequirementTypeAsync(int requirementTypeId, CancellationToken token)
                 => await requirementTypeValidator.ExistsAsync(requirementTypeId, token); 
@@ -29,6 +33,8 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.VoidRequ
                 => await requirementDefinitionValidator.ExistsAsync(requirementDefinitionId, token);
             async Task<bool> NotBeAVoidedRequirementDefinitionAsync(int requirementDefinitionId, CancellationToken token)
                 => !await requirementDefinitionValidator.IsVoidedAsync(requirementDefinitionId, token);
+            async Task<bool> HaveAValidRowVersion(string rowVersion, CancellationToken token)
+                => await rowVersionValidator.IsValid(rowVersion, token);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/VoidRequirementType/VoidRequirementTypeCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/VoidRequirementType/VoidRequirementTypeCommandValidator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.RequirementTypeValidators;
 using FluentValidation;
 
@@ -7,7 +8,9 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.VoidRequ
 {
     public class VoidRequirementTypeCommandValidator : AbstractValidator<VoidRequirementTypeCommand>
     {
-        public VoidRequirementTypeCommandValidator(IRequirementTypeValidator requirementTypeValidator)
+        public VoidRequirementTypeCommandValidator(
+            IRequirementTypeValidator requirementTypeValidator,
+            IRowVersionValidator rowVersionValidator)
         {
             CascadeMode = CascadeMode.StopOnFirstFailure;
 
@@ -15,12 +18,16 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.VoidRequ
                 .MustAsync((command, token) => BeAnExistingRequirementTypeAsync(command.RequirementTypeId, token))
                 .WithMessage(command => $"Requirement type doesn't exist! RequirementType={command.RequirementTypeId}")
                 .MustAsync((command, token) => NotBeAVoidedRequirementTypeAsync(command.RequirementTypeId, token))
-                .WithMessage(command => $"Requirement type is already voided! RequirementType={command.RequirementTypeId}");
+                .WithMessage(command => $"Requirement type is already voided! RequirementType={command.RequirementTypeId}")
+                .MustAsync((command, token) => HaveAValidRowVersion(command.RowVersion, token))
+                .WithMessage(command => $"Not a valid RowVersion! RowVersion={command.RowVersion}");
 
             async Task<bool> BeAnExistingRequirementTypeAsync(int requirementTypeId, CancellationToken token)
                 => await requirementTypeValidator.ExistsAsync(requirementTypeId, token);
             async Task<bool> NotBeAVoidedRequirementTypeAsync(int requirementTypeId, CancellationToken token)
                 => !await requirementTypeValidator.IsVoidedAsync(requirementTypeId, token);
+            async Task<bool> HaveAValidRowVersion(string rowVersion, CancellationToken token)
+                => await rowVersionValidator.IsValid(rowVersion, token);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandValidator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.AttachmentValidators;
 using Equinor.Procosys.Preservation.Command.Validators.ProjectValidators;
 using Equinor.Procosys.Preservation.Command.Validators.TagValidators;
@@ -12,7 +13,8 @@ namespace Equinor.Procosys.Preservation.Command.TagAttachmentCommands.Delete
         public DeleteTagAttachmentCommandValidator(
             IProjectValidator projectValidator,
             ITagValidator tagValidator,
-            IAttachmentValidator attachmentValidator)
+            IAttachmentValidator attachmentValidator,
+            IRowVersionValidator rowVersionValidator)
         {
             CascadeMode = CascadeMode.StopOnFirstFailure;
 
@@ -24,7 +26,9 @@ namespace Equinor.Procosys.Preservation.Command.TagAttachmentCommands.Delete
                 .MustAsync((command, token) => NotBeAVoidedTagAsync(command.TagId, token))
                 .WithMessage(command => $"Tag is voided! Tag={command.TagId}")
                 .MustAsync((command, token) => BeAnExistingAttachmentAsync(command.AttachmentId, token))
-                .WithMessage(command => $"Attachment doesn't exist! Attachment={command.AttachmentId}");
+                .WithMessage(command => $"Attachment doesn't exist! Attachment={command.AttachmentId}")
+                .MustAsync((command, token) => HaveAValidRowVersion(command.RowVersion, token))
+                .WithMessage(command => $"Not a valid RowVersion! RowVersion={command.RowVersion}");
 
             async Task<bool> NotBeAClosedProjectForTagAsync(int tagId, CancellationToken token)
                 => !await projectValidator.IsClosedForTagAsync(tagId, token);
@@ -34,6 +38,8 @@ namespace Equinor.Procosys.Preservation.Command.TagAttachmentCommands.Delete
                 => !await tagValidator.IsVoidedAsync(tagId, token);
             async Task<bool> BeAnExistingAttachmentAsync(int attachmentId, CancellationToken token)
                 => await attachmentValidator.ExistsAsync(attachmentId, token);
+            async Task<bool> HaveAValidRowVersion(string rowVersion, CancellationToken token)
+                => await rowVersionValidator.IsValid(rowVersion, token);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/UnvoidTag/UnvoidTagCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/UnvoidTag/UnvoidTagCommandValidator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.ProjectValidators;
 using Equinor.Procosys.Preservation.Command.Validators.TagValidators;
 using FluentValidation;
@@ -10,7 +11,8 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.UnvoidTag
     {
         public UnvoidTagCommandValidator(
             IProjectValidator projectValidator,
-            ITagValidator tagValidator)
+            ITagValidator tagValidator,
+            IRowVersionValidator rowVersionValidator)
         {
             CascadeMode = CascadeMode.StopOnFirstFailure;
 
@@ -20,7 +22,9 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.UnvoidTag
                 .MustAsync((command, token) => BeAnExistingTagAsync(command.TagId, token))
                 .WithMessage(command => $"Tag doesn't exist! Tag={command.TagId}")
                 .MustAsync((command, token) => BeAVoidedTagAsync(command.TagId, token))
-                .WithMessage(command => $"Tag is not voided! Tag={command.TagId}");
+                .WithMessage(command => $"Tag is not voided! Tag={command.TagId}")
+                .MustAsync((command, token) => HaveAValidRowVersion(command.RowVersion, token))
+                .WithMessage(command => $"Not a valid RowVersion! RowVersion={command.RowVersion}");
 
             async Task<bool> NotBeAClosedProjectForTagAsync(int tagId, CancellationToken token)
                 => !await projectValidator.IsClosedForTagAsync(tagId, token);
@@ -28,6 +32,8 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.UnvoidTag
                 => await tagValidator.ExistsAsync(tagId, token);
             async Task<bool> BeAVoidedTagAsync(int tagId, CancellationToken token)
                 => await tagValidator.IsVoidedAsync(tagId, token);
+            async Task<bool> HaveAValidRowVersion(string rowVersion, CancellationToken token)
+                => await rowVersionValidator.IsValid(rowVersion, token);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTag/UpdateTagCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTag/UpdateTagCommandValidator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.ProjectValidators;
 using Equinor.Procosys.Preservation.Command.Validators.TagValidators;
 using FluentValidation;
@@ -10,7 +11,8 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.UpdateTag
     {
         public UpdateTagCommandValidator(
              IProjectValidator projectValidator,
-             ITagValidator tagValidator)
+             ITagValidator tagValidator,
+             IRowVersionValidator rowVersionValidator)
         {
             CascadeMode = CascadeMode.StopOnFirstFailure;
 
@@ -20,7 +22,9 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.UpdateTag
                 .MustAsync((command, token) => BeAnExistingTagAsync(command.TagId, token))
                 .WithMessage(command => $"Tag doesn't exist! Tag={command.TagId}")
                 .MustAsync((command, token) => NotBeAVoidedTagAsync(command.TagId, token))
-                .WithMessage(command => $"Tag is voided! Tag={command.TagId}");
+                .WithMessage(command => $"Tag is voided! Tag={command.TagId}")
+                .MustAsync((command, token) => HaveAValidRowVersion(command.RowVersion, token))
+                .WithMessage(command => $"Not a valid RowVersion! RowVersion={command.RowVersion}");
 
             async Task<bool> NotBeAClosedProjectForTagAsync(int tagId, CancellationToken token)
                 => !await projectValidator.IsClosedForTagAsync(tagId, token);
@@ -28,6 +32,8 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.UpdateTag
                 => await tagValidator.ExistsAsync(tagId, token);
             async Task<bool> NotBeAVoidedTagAsync(int tagId, CancellationToken token)
                 => !await tagValidator.IsVoidedAsync(tagId, token);
+            async Task<bool> HaveAValidRowVersion(string rowVersion, CancellationToken token)
+                => await rowVersionValidator.IsValid(rowVersion, token);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/TagFunctionCommands/UnvoidTagFunction/UnvoidTagFunctionCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagFunctionCommands/UnvoidTagFunction/UnvoidTagFunctionCommandValidator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.TagFunctionValidators;
 using FluentValidation;
 
@@ -7,7 +8,9 @@ namespace Equinor.Procosys.Preservation.Command.TagFunctionCommands.UnvoidTagFun
 {
     public class UnvoidTagFunctionCommandValidator : AbstractValidator<UnvoidTagFunctionCommand>
     {
-        public UnvoidTagFunctionCommandValidator(ITagFunctionValidator tagFunctionValidator)
+        public UnvoidTagFunctionCommandValidator(
+            ITagFunctionValidator tagFunctionValidator,
+            IRowVersionValidator rowVersionValidator)
         {
             CascadeMode = CascadeMode.StopOnFirstFailure;
 
@@ -15,12 +18,16 @@ namespace Equinor.Procosys.Preservation.Command.TagFunctionCommands.UnvoidTagFun
                 .MustAsync((command, token) => BeAnExistingTagFunctionAsync(command.TagFunctionCode, token))
                 .WithMessage(command => $"Tag function doesn't exist! TagFunction={command.TagFunctionCode}")
                 .MustAsync((command, token) => BeAVoidedTagFunctionAsync(command.TagFunctionCode, token))
-                .WithMessage(command => $"Tag function is not voided! TagFunction={command.TagFunctionCode}");
+                .WithMessage(command => $"Tag function is not voided! TagFunction={command.TagFunctionCode}")
+                .MustAsync((command, token) => HaveAValidRowVersion(command.RowVersion, token))
+                .WithMessage(command => $"Not a valid RowVersion! RowVersion={command.RowVersion}");
 
             async Task<bool> BeAnExistingTagFunctionAsync(string tagFunctionCode, CancellationToken token)
                 => await tagFunctionValidator.ExistsAsync(tagFunctionCode, token);
             async Task<bool> BeAVoidedTagFunctionAsync(string tagFunctionCode, CancellationToken token)
                 => await tagFunctionValidator.IsVoidedAsync(tagFunctionCode, token);
+            async Task<bool> HaveAValidRowVersion(string rowVersion, CancellationToken token)
+                => await rowVersionValidator.IsValid(rowVersion, token);
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/Validators/IRowVersionValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/IRowVersionValidator.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Equinor.Procosys.Preservation.Command.Validators
+{
+    public interface IRowVersionValidator
+    {
+        Task<bool> IsValid(string rowVersion, CancellationToken cancellationToken);
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Command/Validators/RowVersionValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/RowVersionValidator.cs
@@ -6,21 +6,20 @@ namespace Equinor.Procosys.Preservation.Command.Validators
 {
     public class RowVersionValidator : IRowVersionValidator
     {
-        public async Task<bool> IsValid(string rowVersion, CancellationToken cancellationToken) 
-            => TryConvertBase64StringToByteArray(rowVersion, out _);
+        public async Task<bool> IsValid(string rowVersion, CancellationToken cancellationToken)
+            => !string.IsNullOrWhiteSpace(rowVersion) && TryConvertBase64StringToByteArray(rowVersion);
 
-        private static bool TryConvertBase64StringToByteArray(string input, out byte[] output)
+        private static bool TryConvertBase64StringToByteArray(string input)
+        {
+            try
             {
-                output = null;
-                try
-                {
-                    output = Convert.FromBase64String(input);
-                    return true;
-                }
-                catch (FormatException)
-                {
-                    return false;
-                }
+                Convert.FromBase64String(input);
+                return true;
             }
+            catch (FormatException)
+            {
+                return false;
+            }
+        }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/Validators/RowVersionValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/RowVersionValidator.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Equinor.Procosys.Preservation.Command.Validators
+{
+    public class RowVersionValidator : IRowVersionValidator
+    {
+        public async Task<bool> IsValid(string rowVersion, CancellationToken cancellationToken) 
+            => TryConvertBase64StringToByteArray(rowVersion, out _);
+
+        private static bool TryConvertBase64StringToByteArray(string input, out byte[] output)
+            {
+                output = null;
+                try
+                {
+                    output = Convert.FromBase64String(input);
+                    return true;
+                }
+                catch (FormatException)
+                {
+                    return false;
+                }
+            }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.WebApi/DiModules/ApplicationModule.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/DiModules/ApplicationModule.cs
@@ -1,5 +1,6 @@
 ﻿using Equinor.Procosys.Preservation.BlobStorage;
 using Equinor.Procosys.Preservation.Command.EventHandlers;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.ActionValidators;
 using Equinor.Procosys.Preservation.Command.Validators.AttachmentValidators;
 using Equinor.Procosys.Preservation.Command.Validators.FieldValidators;
@@ -135,6 +136,7 @@ namespace Equinor.Procosys.Preservation.WebApi.DIModules
             services.AddScoped<IAttachmentValidator, AttachmentValidator>();
             services.AddScoped<IRequirementTypeValidator, RequirementTypeValidator>();
             services.AddScoped<ITagFunctionValidator, TagFunctionValidator>();
+            services.AddScoped<IRowVersionValidator, RowVersionValidator>();
 
             // Singleton - Created the first time they are requested
             services.AddSingleton<ICacheManager, CacheManager>();

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionAttachmentCommands/Delete/DeleteActionAttachmentCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionAttachmentCommands/Delete/DeleteActionAttachmentCommandValidatorTests.cs
@@ -16,7 +16,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionAttachmentCommands.D
         private const int _tagId = 1;
         private const int _actionId = 2;
         private const int _attachmentId = 3;
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
         private DeleteActionAttachmentCommandValidator _dut;
         private Mock<IProjectValidator> _projectValidatorMock;
         private Mock<ITagValidator> _tagValidatorMock;

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionAttachmentCommands/Delete/DeleteActionAttachmentCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionAttachmentCommands/Delete/DeleteActionAttachmentCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.ActionAttachmentCommands.Delete;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.ActionValidators;
 using Equinor.Procosys.Preservation.Command.Validators.AttachmentValidators;
 using Equinor.Procosys.Preservation.Command.Validators.ProjectValidators;
@@ -12,12 +13,16 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionAttachmentCommands.D
     [TestClass]
     public class DeleteActionAttachmentCommandValidatorTests
     {
+        private const int _tagId = 1;
         private const int _actionId = 2;
+        private const int _attachmentId = 3;
+        private string _rowVersion = "AAAAAAAAJ00=";
         private DeleteActionAttachmentCommandValidator _dut;
         private Mock<IProjectValidator> _projectValidatorMock;
         private Mock<ITagValidator> _tagValidatorMock;
         private Mock<IActionValidator> _actionValidatorMock;
         private Mock<IAttachmentValidator> _attachmentValidatorMock;
+        private Mock<IRowVersionValidator> _rowVersionValidatorMock;
         private DeleteActionAttachmentCommand _command;
 
         [TestInitialize]
@@ -25,7 +30,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionAttachmentCommands.D
         {
             _projectValidatorMock = new Mock<IProjectValidator>();
 
-            _command = new DeleteActionAttachmentCommand(1, _actionId, 3, null);
+            _command = new DeleteActionAttachmentCommand(_tagId, _actionId, _attachmentId, _rowVersion);
 
             _tagValidatorMock = new Mock<ITagValidator>();
             _tagValidatorMock.Setup(r => r.ExistsAsync(_command.TagId, default)).Returns(Task.FromResult(true));
@@ -36,11 +41,15 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionAttachmentCommands.D
             _attachmentValidatorMock = new Mock<IAttachmentValidator>();
             _attachmentValidatorMock.Setup(r => r.ExistsAsync(_command.AttachmentId, default)).Returns(Task.FromResult(true));
 
+            _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion, default)).Returns(Task.FromResult(true));
+
             _dut = new DeleteActionAttachmentCommandValidator(
                 _projectValidatorMock.Object,
                 _tagValidatorMock.Object,
                 _attachmentValidatorMock.Object,
-                _actionValidatorMock.Object);
+                _actionValidatorMock.Object,
+                _rowVersionValidatorMock.Object);
         }
 
         [TestMethod]
@@ -121,6 +130,21 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionAttachmentCommands.D
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Attachment doesn't exist!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvalidRowVersion()
+        {
+            const string invalidRowVersion = "String";
+
+            var command = new DeleteActionAttachmentCommand(_tagId, _actionId, _attachmentId, invalidRowVersion);
+            _rowVersionValidatorMock.Setup(r => r.IsValid(invalidRowVersion, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid RowVersion!"));
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionCommands/CloseAction/CloseActionCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionCommands/CloseAction/CloseActionCommandValidatorTests.cs
@@ -21,7 +21,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionCommands.CloseAction
 
         private readonly int _tagId = 2;
         private readonly int _actionId = 3;
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionCommands/CloseAction/CloseActionCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionCommands/CloseAction/CloseActionCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.ActionCommands.CloseAction;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.ActionValidators;
 using Equinor.Procosys.Preservation.Command.Validators.ProjectValidators;
 using Equinor.Procosys.Preservation.Command.Validators.TagValidators;
@@ -15,10 +16,12 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionCommands.CloseAction
         private Mock<IProjectValidator> _projectValidatorMock;
         private Mock<ITagValidator> _tagValidatorMock;
         private Mock<IActionValidator> _actionValidatorMock;
+        private Mock<IRowVersionValidator> _rowVersionValidatorMock;
         private CloseActionCommand _command;
 
         private readonly int _tagId = 2;
         private readonly int _actionId = 3;
+        private string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()
@@ -31,12 +34,16 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionCommands.CloseAction
             _actionValidatorMock = new Mock<IActionValidator>();
             _actionValidatorMock.Setup(r => r.ExistsAsync(_actionId, default)).Returns(Task.FromResult(true));
 
-            _command = new CloseActionCommand(_tagId, _actionId, null);
+            _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion, default)).Returns(Task.FromResult(true));
+
+            _command = new CloseActionCommand(_tagId, _actionId, _rowVersion);
 
             _dut = new CloseActionCommandValidator(
                 _projectValidatorMock.Object,
                 _tagValidatorMock.Object,
-                _actionValidatorMock.Object
+                _actionValidatorMock.Object,
+                _rowVersionValidatorMock.Object
                 );
         }
 
@@ -106,6 +113,21 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionCommands.CloseAction
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Action doesn't exist!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvalidRowVersion()
+        {
+            const string invalidRowVersion = "String";
+
+            var command = new CloseActionCommand(_tagId, _actionId, invalidRowVersion);
+            _rowVersionValidatorMock.Setup(r => r.IsValid(invalidRowVersion, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid RowVersion!"));
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionCommands/UpdateAction/UpdateActionCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ActionCommands/UpdateAction/UpdateActionCommandValidatorTests.cs
@@ -21,7 +21,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ActionCommands.UpdateActio
 
         private readonly int _tagId = 2;
         private readonly int _actionId = 3;
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/DeleteJourney/DeleteJourneyCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/DeleteJourney/DeleteJourneyCommandValidatorTests.cs
@@ -28,7 +28,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.DeleteJour
             _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
             _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion, default)).Returns(Task.FromResult(true));
 
-            _command = new DeleteJourneyCommand(_id, null);
+            _command = new DeleteJourneyCommand(_id, _rowVersion);
 
             _dut = new DeleteJourneyCommandValidator(_journeyValidatorMock.Object, _rowVersionValidatorMock.Object);
         }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/DeleteJourney/DeleteJourneyCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/DeleteJourney/DeleteJourneyCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.JourneyCommands.DeleteJourney;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.JourneyValidators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -11,9 +12,11 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.DeleteJour
     {
         private DeleteJourneyCommandValidator _dut;
         private Mock<IJourneyValidator> _journeyValidatorMock;
+        private Mock<IRowVersionValidator> _rowVersionValidatorMock;
         private DeleteJourneyCommand _command;
 
         private int _id = 1;
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()
@@ -21,9 +24,13 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.DeleteJour
             _journeyValidatorMock = new Mock<IJourneyValidator>();
             _journeyValidatorMock.Setup(r => r.ExistsAsync(_id, default)).Returns(Task.FromResult(true));
             _journeyValidatorMock.Setup(r => r.IsVoidedAsync(_id, default)).Returns(Task.FromResult(true));
+
+            _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion, default)).Returns(Task.FromResult(true));
+
             _command = new DeleteJourneyCommand(_id, null);
 
-            _dut = new DeleteJourneyCommandValidator(_journeyValidatorMock.Object);
+            _dut = new DeleteJourneyCommandValidator(_journeyValidatorMock.Object, _rowVersionValidatorMock.Object);
         }
 
         [TestMethod]
@@ -68,6 +75,21 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.DeleteJour
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Journey is used!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvalidRowVersion()
+        {
+            const string invalidRowVersion = "String";
+
+            var command = new DeleteJourneyCommand(_id, invalidRowVersion);
+            _rowVersionValidatorMock.Setup(r => r.IsValid(invalidRowVersion, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid RowVersion!"));
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/DeleteStep/DeleteStepCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/DeleteStep/DeleteStepCommandValidatorTests.cs
@@ -32,7 +32,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.DeleteStep
             _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
             _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion, default)).Returns(Task.FromResult(true));
 
-            _command = new DeleteStepCommand(_journeyId, _stepId, null);
+            _command = new DeleteStepCommand(_journeyId, _stepId, _rowVersion);
 
             _dut = new DeleteStepCommandValidator(
                 _journeyValidatorMock.Object,

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/DeleteStep/DeleteStepCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/DeleteStep/DeleteStepCommandValidatorTests.cs
@@ -18,7 +18,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.DeleteStep
 
         private int _journeyId = 1;
         private int _stepId = 2;
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
         private Mock<IStepValidator> _stepValidatorMock;
 
         [TestInitialize]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/SwapSteps/SwapStepsCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/SwapSteps/SwapStepsCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.JourneyCommands.SwapSteps;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.JourneyValidators;
 using Equinor.Procosys.Preservation.Command.Validators.StepValidators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -9,15 +10,19 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.SwapSteps
 {
     [TestClass]
     public class SwapStepsCommandValidatorTests
-    {
+    { 
+        private SwapStepsCommand _command;
         private SwapStepsCommandValidator _dut;
         private Mock<IJourneyValidator> _journeyValidatorMock;
         private Mock<IStepValidator> _stepValidatorMock;
-        private SwapStepsCommand _command;
+        private Mock<IRowVersionValidator> _rowVersionValidatorMock;
 
         private int _journeyId = 1;
         private int _stepAId = 2;
         private int _stepBId = 3;
+        private readonly string _stepARowVersion = "AAAAAAAAJ00=";
+        private readonly string _stepBRowVersion = "AAAAAAAAB00=";
+        private readonly string _invalidRowVersion = "String";
 
         [TestInitialize]
         public void Setup_OkState()
@@ -29,11 +34,15 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.SwapSteps
             _journeyValidatorMock.Setup(r => r.StepExistsAsync(_journeyId, _stepAId, default)).Returns(Task.FromResult(true));
             _journeyValidatorMock.Setup(r => r.StepExistsAsync(_journeyId, _stepBId, default)).Returns(Task.FromResult(true));
 
+            _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_stepARowVersion, default)).Returns(Task.FromResult(true));
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_stepBRowVersion, default)).Returns(Task.FromResult(true));
+
             _stepValidatorMock = new Mock<IStepValidator>();
 
-            _command = new SwapStepsCommand(_journeyId, _stepAId, null, _stepBId, null);
+            _command = new SwapStepsCommand(_journeyId, _stepAId, _stepARowVersion, _stepBId, _stepBRowVersion);
 
-            _dut = new SwapStepsCommandValidator(_journeyValidatorMock.Object, _stepValidatorMock.Object);
+            _dut = new SwapStepsCommandValidator(_journeyValidatorMock.Object, _stepValidatorMock.Object, _rowVersionValidatorMock.Object);
         }
 
         [TestMethod]
@@ -108,6 +117,32 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.SwapSteps
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Supplier steps cannot be swapped!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvalidRowVersionForStepA()
+        {
+            var command = new SwapStepsCommand(_journeyId, _stepAId, _invalidRowVersion, _stepBId, _stepBRowVersion);
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_invalidRowVersion, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid RowVersion for Step A!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvalidRowVersionForStepB()
+        {
+            var command = new SwapStepsCommand(_journeyId, _stepAId, _stepARowVersion, _stepBId, _invalidRowVersion);
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_invalidRowVersion, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid RowVersion for Step B!"));
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UnvoidJourney/UnvoidJourneyCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UnvoidJourney/UnvoidJourneyCommandValidatorTests.cs
@@ -16,7 +16,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UnvoidJour
         private UnvoidJourneyCommandValidator _dut;
         private Mock<IRowVersionValidator> _rowVersionValidatorMock;
 
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
         private readonly int _journeyId = 2;
 
         [TestInitialize]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UnvoidJourney/UnvoidJourneyCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UnvoidJourney/UnvoidJourneyCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.JourneyCommands.UnvoidJourney;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.JourneyValidators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -13,6 +14,9 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UnvoidJour
 
         private UnvoidJourneyCommand _command;
         private UnvoidJourneyCommandValidator _dut;
+        private Mock<IRowVersionValidator> _rowVersionValidatorMock;
+
+        private string _rowVersion = "AAAAAAAAJ00=";
         private readonly int _journeyId = 2;
 
         [TestInitialize]
@@ -22,8 +26,11 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UnvoidJour
             _journeyValidatorMock.Setup(r => r.ExistsAsync(_journeyId, default)).Returns(Task.FromResult(true));
             _journeyValidatorMock.Setup(r => r.IsVoidedAsync(_journeyId, default)).Returns(Task.FromResult(true));
 
-            _command = new UnvoidJourneyCommand(_journeyId, null);
-            _dut = new UnvoidJourneyCommandValidator(_journeyValidatorMock.Object);
+            _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion, default)).Returns(Task.FromResult(true));
+
+            _command = new UnvoidJourneyCommand(_journeyId, _rowVersion);
+            _dut = new UnvoidJourneyCommandValidator(_journeyValidatorMock.Object, _rowVersionValidatorMock.Object);
         }
 
         [TestMethod]
@@ -56,6 +63,21 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UnvoidJour
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Journey is not voided!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvalidRowVersion()
+        {
+            const string invalidRowVersion = "String";
+
+            var command = new UnvoidJourneyCommand(_journeyId, invalidRowVersion);
+            _rowVersionValidatorMock.Setup(r => r.IsValid(invalidRowVersion, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid RowVersion!"));
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UnvoidStep/UnvoidStepCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UnvoidStep/UnvoidStepCommandValidatorTests.cs
@@ -17,7 +17,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UnvoidStep
 
         private int _journeyId = 2;
         private int _stepId = 1;
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UnvoidStep/UnvoidStepCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UnvoidStep/UnvoidStepCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.JourneyCommands.UnvoidStep;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.StepValidators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -11,10 +12,12 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UnvoidStep
     {
         private UnvoidStepCommandValidator _dut;
         private Mock<IStepValidator> _stepValidatorMock;
+        private Mock<IRowVersionValidator> _rowVersionValidatorMock;
         private UnvoidStepCommand _command;
 
         private int _journeyId = 2;
         private int _stepId = 1;
+        private string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()
@@ -23,8 +26,11 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UnvoidStep
             _stepValidatorMock.Setup(r => r.ExistsAsync(_stepId, default)).Returns(Task.FromResult(true));
             _stepValidatorMock.Setup(r => r.IsVoidedAsync(_stepId, default)).Returns(Task.FromResult(true));
 
-            _command = new UnvoidStepCommand(_journeyId, _stepId, null);
-            _dut = new UnvoidStepCommandValidator(_stepValidatorMock.Object);
+            _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion, default)).Returns(Task.FromResult(true));
+
+            _command = new UnvoidStepCommand(_journeyId, _stepId, _rowVersion);
+            _dut = new UnvoidStepCommandValidator(_stepValidatorMock.Object, _rowVersionValidatorMock.Object);
         }
 
         [TestMethod]
@@ -58,6 +64,21 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UnvoidStep
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Step is not voided!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvalidRowVersion()
+        {
+            const string invalidRowVersion = "String";
+
+            var command = new UnvoidStepCommand(_journeyId, _stepId, invalidRowVersion);
+            _rowVersionValidatorMock.Setup(r => r.IsValid(invalidRowVersion, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid RowVersion!"));
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateJourney/UpdateJourneyCommandValidatorTests.cs
@@ -17,7 +17,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UpdateJour
 
         private int _id = 1;
         private string _title = "Title";
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateStep/UpdateStepCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateStep/UpdateStepCommandValidatorTests.cs
@@ -27,7 +27,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UpdateStep
         private int _modeId = 3;
         private string _responsibleCode = "TestCode";
         private string _title = "Title";
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/VoidJourney/VoidJourneyCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/VoidJourney/VoidJourneyCommandValidatorTests.cs
@@ -16,7 +16,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.VoidJourne
         private VoidJourneyCommand _command;
         private VoidJourneyCommandValidator _dut;
         private readonly int _journeyId = 2;
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/VoidJourney/VoidJourneyCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/VoidJourney/VoidJourneyCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.JourneyCommands.VoidJourney;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.JourneyValidators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -10,10 +11,12 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.VoidJourne
     public class VoidJourneyCommandValidatorTests
     {
         private Mock<IJourneyValidator> _journeyValidatorMock;
+        private Mock<IRowVersionValidator> _rowVersionValidatorMock;
 
         private VoidJourneyCommand _command;
         private VoidJourneyCommandValidator _dut;
         private readonly int _journeyId = 2;
+        private string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()
@@ -21,8 +24,11 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.VoidJourne
             _journeyValidatorMock = new Mock<IJourneyValidator>();
             _journeyValidatorMock.Setup(r => r.ExistsAsync(_journeyId, default)).Returns(Task.FromResult(true));
 
-            _command = new VoidJourneyCommand(_journeyId, null);
-            _dut = new VoidJourneyCommandValidator(_journeyValidatorMock.Object);
+            _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion, default)).Returns(Task.FromResult(true));
+
+            _command = new VoidJourneyCommand(_journeyId, _rowVersion);
+            _dut = new VoidJourneyCommandValidator(_journeyValidatorMock.Object, _rowVersionValidatorMock.Object);
         }
 
         [TestMethod]
@@ -55,6 +61,21 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.VoidJourne
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Journey is already voided!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvalidRowVersion()
+        {
+            const string invalidRowVersion = "String";
+
+            var command = new VoidJourneyCommand(_journeyId, invalidRowVersion);
+            _rowVersionValidatorMock.Setup(r => r.IsValid(invalidRowVersion, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid RowVersion!"));
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/VoidStep/VoidStepCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/VoidStep/VoidStepCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.JourneyCommands.VoidStep;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.StepValidators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -9,12 +10,14 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.VoidStep
     [TestClass]
     public class VoidStepCommandValidatorTests
     {
+        private VoidStepCommand _command;
         private VoidStepCommandValidator _dut;
         private Mock<IStepValidator> _stepValidatorMock;
-        private VoidStepCommand _command;
-
+        private Mock<IRowVersionValidator> _rowVersionValidatorMock;
+        
         private int _journeyId = 2;
         private int _stepId = 1;
+        private string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()
@@ -22,8 +25,11 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.VoidStep
             _stepValidatorMock = new Mock<IStepValidator>();
             _stepValidatorMock.Setup(r => r.ExistsAsync(_stepId, default)).Returns(Task.FromResult(true));
 
-            _command = new VoidStepCommand(_journeyId, _stepId, null);
-            _dut = new VoidStepCommandValidator(_stepValidatorMock.Object);
+            _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion, default)).Returns(Task.FromResult(true));
+
+            _command = new VoidStepCommand(_journeyId, _stepId, _rowVersion);
+            _dut = new VoidStepCommandValidator(_stepValidatorMock.Object, _rowVersionValidatorMock.Object);
         }
 
         [TestMethod]
@@ -57,6 +63,21 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.VoidStep
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Step is already voided!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvalidRowVersion()
+        {
+            const string invalidRowVersion = "String";
+
+            var command = new VoidStepCommand(_journeyId, _stepId, invalidRowVersion);
+            _rowVersionValidatorMock.Setup(r => r.IsValid(invalidRowVersion, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid RowVersion!"));
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/VoidStep/VoidStepCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/VoidStep/VoidStepCommandValidatorTests.cs
@@ -17,7 +17,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.VoidStep
         
         private int _journeyId = 2;
         private int _stepId = 1;
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/DeleteMode/DeleteModeCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/DeleteMode/DeleteModeCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.ModeCommands.DeleteMode;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.ModeValidators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -11,9 +12,11 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.DeleteMode
     {
         private DeleteModeCommandValidator _dut;
         private Mock<IModeValidator> _modeValidatorMock;
+        private Mock<IRowVersionValidator> _rowVersionValidatorMock;
         private DeleteModeCommand _command;
 
         private int _id = 1;
+        private string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()
@@ -21,9 +24,13 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.DeleteMode
             _modeValidatorMock = new Mock<IModeValidator>();
             _modeValidatorMock.Setup(r => r.ExistsAsync(_id, default)).Returns(Task.FromResult(true));
             _modeValidatorMock.Setup(r => r.IsVoidedAsync(_id, default)).Returns(Task.FromResult(true));
-            _command = new DeleteModeCommand(_id, null);
+            
+            _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion, default)).Returns(Task.FromResult(true));
+            
+            _command = new DeleteModeCommand(_id, _rowVersion);
 
-            _dut = new DeleteModeCommandValidator(_modeValidatorMock.Object);
+            _dut = new DeleteModeCommandValidator(_modeValidatorMock.Object, _rowVersionValidatorMock.Object);
         }
 
         [TestMethod]
@@ -68,6 +75,21 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.DeleteMode
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Mode is used in step(s)!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvalidRowVersion()
+        {
+            const string invalidRowVersion = "String";
+
+            var command = new DeleteModeCommand(_id, invalidRowVersion);
+            _rowVersionValidatorMock.Setup(r => r.IsValid(invalidRowVersion, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid RowVersion!"));
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/DeleteMode/DeleteModeCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/DeleteMode/DeleteModeCommandValidatorTests.cs
@@ -16,7 +16,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.DeleteMode
         private DeleteModeCommand _command;
 
         private int _id = 1;
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UnvoidMode/UnvoidModeCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UnvoidMode/UnvoidModeCommandValidatorTests.cs
@@ -16,7 +16,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.UnvoidMode
         private UnvoidModeCommand _command;
         private UnvoidModeCommandValidator _dut;
         private readonly int _modeId = 2;
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandValidatorTests.cs
@@ -18,7 +18,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.UpdateMode
         private int _id = 1;
         private string _title = "Title";
         private bool _forSupplier = true;
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/UpdateMode/UpdateModeCommandValidatorTests.cs
@@ -29,7 +29,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.UpdateMode
             _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
             _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion, default)).Returns(Task.FromResult(true));
 
-            _command = new UpdateModeCommand(_id, _title, _forSupplier, null);
+            _command = new UpdateModeCommand(_id, _title, _forSupplier, _rowVersion);
 
             _dut = new UpdateModeCommandValidator(_modeValidatorMock.Object, _rowVersionValidatorMock.Object);
         }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/VoidMode/VoidModeCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/VoidMode/VoidModeCommandValidatorTests.cs
@@ -16,7 +16,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.VoidMode
         private VoidModeCommand _command;
         private VoidModeCommandValidator _dut;
         private readonly int _modeId = 2;
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/VoidMode/VoidModeCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/ModeCommands/VoidMode/VoidModeCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.ModeCommands.VoidMode;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.ModeValidators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -10,10 +11,12 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.VoidMode
     public class VoidModeCommandValidatorTests
     {
         private Mock<IModeValidator> _modeValidatorMock;
+        private Mock<IRowVersionValidator> _rowVersionValidatorMock;
 
         private VoidModeCommand _command;
         private VoidModeCommandValidator _dut;
         private readonly int _modeId = 2;
+        private string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()
@@ -21,8 +24,11 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.VoidMode
             _modeValidatorMock = new Mock<IModeValidator>();
             _modeValidatorMock.Setup(r => r.ExistsAsync(_modeId, default)).Returns(Task.FromResult(true));
 
-            _command = new VoidModeCommand(_modeId, null);
-            _dut = new VoidModeCommandValidator(_modeValidatorMock.Object);
+            _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion, default)).Returns(Task.FromResult(true));
+
+            _command = new VoidModeCommand(_modeId, _rowVersion);
+            _dut = new VoidModeCommandValidator(_modeValidatorMock.Object, _rowVersionValidatorMock.Object);
         }
 
         [TestMethod]
@@ -55,6 +61,21 @@ namespace Equinor.Procosys.Preservation.Command.Tests.ModeCommands.VoidMode
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Mode is already voided!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvalidRowVersion()
+        {
+            const string invalidRowVersion = "String";
+
+            var command = new VoidModeCommand(_modeId, invalidRowVersion);
+            _rowVersionValidatorMock.Setup(r => r.IsValid(invalidRowVersion, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid RowVersion!"));
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/DeleteRequirementType/DeleteRequirementTypeCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/DeleteRequirementType/DeleteRequirementTypeCommandValidatorTests.cs
@@ -16,7 +16,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.De
         private DeleteRequirementTypeCommand _command;
 
         private int _id = 1;
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/DeleteRequirementType/DeleteRequirementTypeCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/DeleteRequirementType/DeleteRequirementTypeCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.RequirementTypeCommands.DeleteRequirementType;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.RequirementTypeValidators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -11,9 +12,11 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.De
     {
         private DeleteRequirementTypeCommandValidator _dut;
         private Mock<IRequirementTypeValidator> _requirementTypeValidatorMock;
+        private Mock<IRowVersionValidator> _rowVersionValidatorMock;
         private DeleteRequirementTypeCommand _command;
 
         private int _id = 1;
+        private string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()
@@ -21,9 +24,13 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.De
             _requirementTypeValidatorMock = new Mock<IRequirementTypeValidator>();
             _requirementTypeValidatorMock.Setup(r => r.ExistsAsync(_id, default)).Returns(Task.FromResult(true));
             _requirementTypeValidatorMock.Setup(r => r.IsVoidedAsync(_id, default)).Returns(Task.FromResult(true));
-            _command = new DeleteRequirementTypeCommand(_id, null);
 
-            _dut = new DeleteRequirementTypeCommandValidator(_requirementTypeValidatorMock.Object);
+            _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion, default)).Returns(Task.FromResult(true));
+
+            _command = new DeleteRequirementTypeCommand(_id, _rowVersion);
+
+            _dut = new DeleteRequirementTypeCommandValidator(_requirementTypeValidatorMock.Object, _rowVersionValidatorMock.Object);
         }
 
         [TestMethod]
@@ -68,6 +75,21 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.De
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirement type has requirement definitions!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvalidRowVersion()
+        {
+            const string invalidRowVersion = "String";
+
+            var command = new DeleteRequirementTypeCommand(_id, invalidRowVersion);
+            _rowVersionValidatorMock.Setup(r => r.IsValid(invalidRowVersion, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid RowVersion!"));
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/UnvoidRequirementDefinition/UnvoidRequirementDefinitionCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/UnvoidRequirementDefinition/UnvoidRequirementDefinitionCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.RequirementTypeCommands.UnvoidRequirementDefinition;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.RequirementDefinitionValidators;
 using Equinor.Procosys.Preservation.Command.Validators.RequirementTypeValidators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -12,11 +13,13 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.Un
     {
         private Mock<IRequirementDefinitionValidator> _reqDefinitionValidatorMock;
         private Mock<IRequirementTypeValidator> _reqTypeValidatorMock;
+        private Mock<IRowVersionValidator> _rowVersionValidatorMock;
         private UnvoidRequirementDefinitionCommand _command;
         private UnvoidRequirementDefinitionCommandValidator _dut;
 
         private readonly int _requirementTypeId = 1;
         private readonly int _requirementDefinitionId = 2;
+        private string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()
@@ -29,8 +32,12 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.Un
             _reqDefinitionValidatorMock.Setup(r => r.IsVoidedAsync(_requirementDefinitionId, default))
                 .Returns(Task.FromResult(true));
 
-            _command = new UnvoidRequirementDefinitionCommand(_requirementTypeId, _requirementDefinitionId, null);
-            _dut = new UnvoidRequirementDefinitionCommandValidator(_reqTypeValidatorMock.Object, _reqDefinitionValidatorMock.Object);
+            _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion, default)).Returns(Task.FromResult(true));
+
+            _command = new UnvoidRequirementDefinitionCommand(_requirementTypeId, _requirementDefinitionId, _rowVersion);
+            _dut = new UnvoidRequirementDefinitionCommandValidator(_reqTypeValidatorMock.Object,
+                _reqDefinitionValidatorMock.Object, _rowVersionValidatorMock.Object);
         }
 
         [TestMethod]
@@ -75,6 +82,21 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.Un
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirement definition is not voided!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvalidRowVersion()
+        {
+            const string invalidRowVersion = "String";
+
+            var command = new UnvoidRequirementDefinitionCommand(_requirementTypeId, _requirementDefinitionId, invalidRowVersion);
+            _rowVersionValidatorMock.Setup(r => r.IsValid(invalidRowVersion, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid RowVersion!"));
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/UnvoidRequirementDefinition/UnvoidRequirementDefinitionCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/UnvoidRequirementDefinition/UnvoidRequirementDefinitionCommandValidatorTests.cs
@@ -19,7 +19,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.Un
 
         private readonly int _requirementTypeId = 1;
         private readonly int _requirementDefinitionId = 2;
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/UnvoidRequirementType/UnvoidRequirementTypeCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/UnvoidRequirementType/UnvoidRequirementTypeCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.RequirementTypeCommands.UnvoidRequirementType;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.RequirementTypeValidators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -10,10 +11,12 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.Un
     public class UnvoidRequirementTypeCommandValidatorTests
     {
         private Mock<IRequirementTypeValidator> _reqTypeValidatorMock;
+        private Mock<IRowVersionValidator> _rowVersionValidatorMock;
 
         private UnvoidRequirementTypeCommand _command;
         private UnvoidRequirementTypeCommandValidator _dut;
         private readonly int _requirementTypeId = 2;
+        private string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()
@@ -22,8 +25,11 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.Un
             _reqTypeValidatorMock.Setup(r => r.ExistsAsync(_requirementTypeId, default)).Returns(Task.FromResult(true));
             _reqTypeValidatorMock.Setup(r => r.IsVoidedAsync(_requirementTypeId, default)).Returns(Task.FromResult(true));
 
-            _command = new UnvoidRequirementTypeCommand(_requirementTypeId, null);
-            _dut = new UnvoidRequirementTypeCommandValidator(_reqTypeValidatorMock.Object);
+            _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion, default)).Returns(Task.FromResult(true));
+
+            _command = new UnvoidRequirementTypeCommand(_requirementTypeId, _rowVersion);
+            _dut = new UnvoidRequirementTypeCommandValidator(_reqTypeValidatorMock.Object, _rowVersionValidatorMock.Object);
         }
 
         [TestMethod]
@@ -56,6 +62,21 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.Un
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirement type is not voided!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvalidRowVersion()
+        {
+            const string invalidRowVersion = "String";
+
+            var command = new UnvoidRequirementTypeCommand(_requirementTypeId, invalidRowVersion);
+            _rowVersionValidatorMock.Setup(r => r.IsValid(invalidRowVersion, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid RowVersion!"));
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/UnvoidRequirementType/UnvoidRequirementTypeCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/UnvoidRequirementType/UnvoidRequirementTypeCommandValidatorTests.cs
@@ -16,7 +16,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.Un
         private UnvoidRequirementTypeCommand _command;
         private UnvoidRequirementTypeCommandValidator _dut;
         private readonly int _requirementTypeId = 2;
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/UpdateRequirementType/UpdateRequirementTypeCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/UpdateRequirementType/UpdateRequirementTypeCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.RequirementTypeCommands.UpdateRequirementType;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.RequirementTypeValidators;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -11,6 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.Up
     public class UpdateRequirementTypeCommandValidatorTests
     {
         private Mock<IRequirementTypeValidator> _reqTypeValidatorMock;
+        private Mock<IRowVersionValidator> _rowVersionValidatorMock;
 
         private UpdateRequirementTypeCommand _command;
         private UpdateRequirementTypeCommandValidator _dut;
@@ -18,6 +20,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.Up
         private readonly int _sortKey = 1;
         private readonly string _title = "Title test";
         private readonly string _code = "Code test";
+        private string _rowVersion = "AAAAAAAAJ00=";
         private RequirementTypeIcon _icon = RequirementTypeIcon.Other;
 
         [TestInitialize]
@@ -26,8 +29,11 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.Up
             _reqTypeValidatorMock = new Mock<IRequirementTypeValidator>();
             _reqTypeValidatorMock.Setup(r => r.ExistsAsync(_requirementTypeId, default)).Returns(Task.FromResult(true));
 
-            _command = new UpdateRequirementTypeCommand(_requirementTypeId, null, _sortKey, _title, _code, _icon);
-            _dut = new UpdateRequirementTypeCommandValidator(_reqTypeValidatorMock.Object);
+            _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion, default)).Returns(Task.FromResult(true));
+
+            _command = new UpdateRequirementTypeCommand(_requirementTypeId, _rowVersion, _sortKey, _title, _code, _icon);
+            _dut = new UpdateRequirementTypeCommandValidator(_reqTypeValidatorMock.Object, _rowVersionValidatorMock.Object);
         }
 
         [TestMethod]
@@ -84,6 +90,21 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.Up
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Another requirement type with this code already exists!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvalidRowVersion()
+        {
+            const string invalidRowVersion = "String";
+
+            var command = new UpdateRequirementTypeCommand(_requirementTypeId, invalidRowVersion, _sortKey, _title, _code, _icon);
+            _rowVersionValidatorMock.Setup(r => r.IsValid(invalidRowVersion, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid RowVersion!"));
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/UpdateRequirementType/UpdateRequirementTypeCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/UpdateRequirementType/UpdateRequirementTypeCommandValidatorTests.cs
@@ -20,7 +20,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.Up
         private readonly int _sortKey = 1;
         private readonly string _title = "Title test";
         private readonly string _code = "Code test";
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
         private RequirementTypeIcon _icon = RequirementTypeIcon.Other;
 
         [TestInitialize]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/VoidRequirementDefinition/VoidRequirementDefinitionCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/VoidRequirementDefinition/VoidRequirementDefinitionCommandValidatorTests.cs
@@ -19,7 +19,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.Vo
 
         private readonly int _requirementTypeId = 1;
         private readonly int _requirementDefinitionId = 2;
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/VoidRequirementType/VoidRequirementTypeCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/VoidRequirementType/VoidRequirementTypeCommandValidatorTests.cs
@@ -16,7 +16,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.Vo
         private VoidRequirementTypeCommand _command;
         private VoidRequirementTypeCommandValidator _dut;
         private readonly int _requirementTypeId = 2;
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.TagAttachmentCommands.Delete;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.AttachmentValidators;
 using Equinor.Procosys.Preservation.Command.Validators.ProjectValidators;
 using Equinor.Procosys.Preservation.Command.Validators.TagValidators;
@@ -15,14 +16,19 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagAttachmentCommands.Dele
         private Mock<IProjectValidator> _projectValidatorMock;
         private Mock<ITagValidator> _tagValidatorMock;
         private Mock<IAttachmentValidator> _attachmentValidatorMock;
+        private Mock<IRowVersionValidator> _rowVersionValidatorMock;
         private DeleteTagAttachmentCommand _command;
+
+        private int _tagId = 2;
+        private int _attachmentId = 3;
+        private string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()
         {
             _projectValidatorMock = new Mock<IProjectValidator>();
 
-            _command = new DeleteTagAttachmentCommand(2, 3, null);
+            _command = new DeleteTagAttachmentCommand(_tagId, _attachmentId, _rowVersion);
 
             _tagValidatorMock = new Mock<ITagValidator>();
             _tagValidatorMock.Setup(r => r.ExistsAsync(_command.TagId, default)).Returns(Task.FromResult(true));
@@ -30,10 +36,14 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagAttachmentCommands.Dele
             _attachmentValidatorMock = new Mock<IAttachmentValidator>();
             _attachmentValidatorMock.Setup(r => r.ExistsAsync(_command.AttachmentId, default)).Returns(Task.FromResult(true));
 
+            _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion, default)).Returns(Task.FromResult(true));
+
             _dut = new DeleteTagAttachmentCommandValidator(
                 _projectValidatorMock.Object,
                 _tagValidatorMock.Object,
-                _attachmentValidatorMock.Object);
+                _attachmentValidatorMock.Object,
+                _rowVersionValidatorMock.Object);
         }
 
         [TestMethod]
@@ -90,6 +100,21 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagAttachmentCommands.Dele
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Tag is voided!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvalidRowVersion()
+        {
+            const string invalidRowVersion = "String";
+
+            var command = new DeleteTagAttachmentCommand(_tagId, _attachmentId, invalidRowVersion);
+            _rowVersionValidatorMock.Setup(r => r.IsValid(invalidRowVersion, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid RowVersion!"));
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandValidatorTests.cs
@@ -21,7 +21,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagAttachmentCommands.Dele
 
         private int _tagId = 2;
         private int _attachmentId = 3;
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UnvoidTag/UnvoidTagCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UnvoidTag/UnvoidTagCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.TagCommands.UnvoidTag;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.TagValidators;
 using Equinor.Procosys.Preservation.Command.Validators.ProjectValidators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -12,20 +13,27 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UnvoidTag
     {
         private Mock<IProjectValidator> _projectValidatorMock;
         private Mock<ITagValidator> _tagValidatorMock;
+        private Mock<IRowVersionValidator> _rowVersionValidatorMock;
 
         private UnvoidTagCommand _command;
         private UnvoidTagCommandValidator _dut;
         private readonly int _tagId = 2;
+        private string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()
         {
             _projectValidatorMock = new Mock<IProjectValidator>();
+
             _tagValidatorMock = new Mock<ITagValidator>();
             _tagValidatorMock.Setup(r => r.ExistsAsync(_tagId, default)).Returns(Task.FromResult(true));
             _tagValidatorMock.Setup(r => r.IsVoidedAsync(_tagId, default)).Returns(Task.FromResult(true));
-            _command = new UnvoidTagCommand(_tagId, null);
-            _dut = new UnvoidTagCommandValidator(_projectValidatorMock.Object, _tagValidatorMock.Object);
+
+            _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion, default)).Returns(Task.FromResult(true));
+
+            _command = new UnvoidTagCommand(_tagId, _rowVersion);
+            _dut = new UnvoidTagCommandValidator(_projectValidatorMock.Object, _tagValidatorMock.Object, _rowVersionValidatorMock.Object);
         }
 
         [TestMethod]
@@ -70,6 +78,21 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UnvoidTag
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Tag is not voided!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvalidRowVersion()
+        {
+            const string invalidRowVersion = "String";
+
+            var command = new UnvoidTagCommand(_tagId, invalidRowVersion);
+            _rowVersionValidatorMock.Setup(r => r.IsValid(invalidRowVersion, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid RowVersion!"));
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UnvoidTag/UnvoidTagCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UnvoidTag/UnvoidTagCommandValidatorTests.cs
@@ -18,7 +18,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UnvoidTag
         private UnvoidTagCommand _command;
         private UnvoidTagCommandValidator _dut;
         private readonly int _tagId = 2;
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandValidatorTests.cs
@@ -21,7 +21,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTag
         private readonly int _tagId = 2;
         private readonly string _remark = "Remark";
         private readonly string _storageArea = "StorageArea";
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.TagCommands.UpdateTag;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.TagValidators;
 using Equinor.Procosys.Preservation.Command.Validators.ProjectValidators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -12,6 +13,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTag
     {
         private Mock<IProjectValidator> _projectValidatorMock;
         private Mock<ITagValidator> _tagValidatorMock;
+        private Mock<IRowVersionValidator> _rowVersionValidatorMock;
 
         private UpdateTagCommand _command;
         private UpdateTagCommandValidator _dut;
@@ -19,16 +21,21 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTag
         private readonly int _tagId = 2;
         private readonly string _remark = "Remark";
         private readonly string _storageArea = "StorageArea";
+        private string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()
         {
             _projectValidatorMock = new Mock<IProjectValidator>();
+
             _tagValidatorMock = new Mock<ITagValidator>();
             _tagValidatorMock.Setup(r => r.ExistsAsync(_tagId, default)).Returns(Task.FromResult(true));
 
-            _command = new UpdateTagCommand(_tagId, _remark, _storageArea, null);
-            _dut = new UpdateTagCommandValidator(_projectValidatorMock.Object, _tagValidatorMock.Object);
+            _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion, default)).Returns(Task.FromResult(true));
+
+            _command = new UpdateTagCommand(_tagId, _remark, _storageArea, _rowVersion);
+            _dut = new UpdateTagCommandValidator(_projectValidatorMock.Object, _tagValidatorMock.Object, _rowVersionValidatorMock.Object);
         }
 
         [TestMethod]
@@ -73,6 +80,21 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTag
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Tag is voided!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvalidRowVersion()
+        {
+            const string invalidRowVersion = "String";
+
+            var command = new UpdateTagCommand(_tagId, _remark, _storageArea, invalidRowVersion);
+            _rowVersionValidatorMock.Setup(r => r.IsValid(invalidRowVersion, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid RowVersion!"));
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/VoidTag/VoidTagCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/VoidTag/VoidTagCommandValidatorTests.cs
@@ -18,7 +18,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.VoidTag
         private VoidTagCommand _command;
         private VoidTagCommandValidator _dut;
         private readonly int _tagId = 2;
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/VoidTag/VoidTagCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/VoidTag/VoidTagCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.TagCommands.VoidTag;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.TagValidators;
 using Equinor.Procosys.Preservation.Command.Validators.ProjectValidators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -12,10 +13,12 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.VoidTag
     {
         private Mock<IProjectValidator> _projectValidatorMock;
         private Mock<ITagValidator> _tagValidatorMock;
+        private Mock<IRowVersionValidator> _rowVersionValidatorMock;
 
         private VoidTagCommand _command;
         private VoidTagCommandValidator _dut;
         private readonly int _tagId = 2;
+        private string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()
@@ -24,8 +27,11 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.VoidTag
             _tagValidatorMock = new Mock<ITagValidator>();
             _tagValidatorMock.Setup(r => r.ExistsAsync(_tagId, default)).Returns(Task.FromResult(true));
 
-            _command = new VoidTagCommand(_tagId, null);
-            _dut = new VoidTagCommandValidator(_projectValidatorMock.Object, _tagValidatorMock.Object);
+            _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion, default)).Returns(Task.FromResult(true));
+
+            _command = new VoidTagCommand(_tagId, _rowVersion);
+            _dut = new VoidTagCommandValidator(_projectValidatorMock.Object, _tagValidatorMock.Object, _rowVersionValidatorMock.Object);
         }
 
         [TestMethod]
@@ -70,6 +76,21 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.VoidTag
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Tag is voided!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvalidRowVersion()
+        {
+            const string invalidRowVersion = "String";
+
+            var command = new VoidTagCommand(_tagId, invalidRowVersion);
+            _rowVersionValidatorMock.Setup(r => r.IsValid(invalidRowVersion, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid RowVersion!"));
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagFunctionCommands/UnvoidTagFunction/UnvoidTagFunctionCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagFunctionCommands/UnvoidTagFunction/UnvoidTagFunctionCommandValidatorTests.cs
@@ -17,7 +17,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagFunctionCommands.Unvoid
 
         private readonly string _tagFunctionCode = "TFC";
         private readonly string _registerCode = "RC";
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagFunctionCommands/UpdateRequirements/UpdateRequirementsCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagFunctionCommands/UpdateRequirements/UpdateRequirementsCommandValidatorTests.cs
@@ -17,7 +17,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagFunctionCommands.Update
         private UpdateRequirementsCommand _command;
         private int _rd1Id = 2;
         private int _rd2Id = 3;
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagFunctionCommands/UpdateRequirements/UpdateRequirementsCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagFunctionCommands/UpdateRequirements/UpdateRequirementsCommandValidatorTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.TagFunctionCommands.UpdateRequirements;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.RequirementDefinitionValidators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -12,9 +13,11 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagFunctionCommands.Update
     {
         private UpdateRequirementsCommandValidator _dut;
         private Mock<IRequirementDefinitionValidator> _rdValidatorMock;
+        private Mock<IRowVersionValidator> _rowVersionValidatorMock;
         private UpdateRequirementsCommand _command;
         private int _rd1Id = 2;
         private int _rd2Id = 3;
+        private string _rowVersion = "AAAAAAAAJ00=";
 
         [TestInitialize]
         public void Setup_OkState()
@@ -24,15 +27,18 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagFunctionCommands.Update
             _rdValidatorMock.Setup(r => r.ExistsAsync(_rd2Id, default)).Returns(Task.FromResult(true));
             _rdValidatorMock.Setup(r => r.UsageCoversBothForSupplierAndOtherAsync(new List<int>{_rd1Id, _rd2Id}, default)).Returns(Task.FromResult(true));
 
+            _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion, default)).Returns(Task.FromResult(true));
+
             _command = new UpdateRequirementsCommand("", "",
                 new List<RequirementForCommand>
                 {
                     new RequirementForCommand(_rd1Id, 1),
                     new RequirementForCommand(_rd2Id, 1)
                 },
-                null);
+                _rowVersion);
 
-            _dut = new UpdateRequirementsCommandValidator(_rdValidatorMock.Object);
+            _dut = new UpdateRequirementsCommandValidator(_rdValidatorMock.Object, _rowVersionValidatorMock.Object);
         }
 
         [TestMethod]
@@ -46,7 +52,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagFunctionCommands.Update
         [TestMethod]
         public void Validate_ShouldBeValid_WithoutRequirements()
         {
-            var command = new UpdateRequirementsCommand("", "", new List<RequirementForCommand>(), null);
+            var command = new UpdateRequirementsCommand("", "", new List<RequirementForCommand>(), _rowVersion);
             var result = _dut.Validate(command);
 
             Assert.IsTrue(result.IsValid);
@@ -100,7 +106,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagFunctionCommands.Update
                     new RequirementForCommand(_rd1Id, 1),
                     new RequirementForCommand(_rd1Id, 1)
                 },
-                null);
+                _rowVersion);
             
             var result = _dut.Validate(command);
 
@@ -119,6 +125,30 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagFunctionCommands.Update
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvalidRowVersion()
+        {
+            const string invalidRowVersion = "String";
+
+            var command = new UpdateRequirementsCommand(
+                "",
+                "",
+                new List<RequirementForCommand>
+                {
+                    new RequirementForCommand(_rd1Id, 1),
+                    new RequirementForCommand(_rd2Id, 1)
+                },
+                invalidRowVersion);
+
+            _rowVersionValidatorMock.Setup(r => r.IsValid(invalidRowVersion, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid RowVersion!"));
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagFunctionCommands/VoidTagFunction/VoidTagFunctionCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagFunctionCommands/VoidTagFunction/VoidTagFunctionCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Command.TagFunctionCommands.VoidTagFunction;
+using Equinor.Procosys.Preservation.Command.Validators;
 using Equinor.Procosys.Preservation.Command.Validators.TagFunctionValidators;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -10,21 +11,25 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagFunctionCommands.VoidTa
     public class VoidTagFunctionCommandValidatorTests
     {
         private Mock<ITagFunctionValidator> _tagFunctionValidatorMock;
+        private Mock<IRowVersionValidator> _rowVersionValidatorMock;
         private VoidTagFunctionCommand _command;
         private VoidTagFunctionCommandValidator _dut;
 
         private readonly string _tagFunctionCode = "TFC";
+        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _registerCode = "RC";
 
         [TestInitialize]
         public void Setup_OkState()
         {
-            const string RegisterCode = "RC";
-
             _tagFunctionValidatorMock = new Mock<ITagFunctionValidator>();
             _tagFunctionValidatorMock.Setup(r => r.ExistsAsync(_tagFunctionCode, default)).Returns(Task.FromResult(true));
 
-            _command = new VoidTagFunctionCommand(_tagFunctionCode, RegisterCode, null);
-            _dut = new VoidTagFunctionCommandValidator(_tagFunctionValidatorMock.Object);
+            _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
+            _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion, default)).Returns(Task.FromResult(true));
+
+            _command = new VoidTagFunctionCommand(_tagFunctionCode, _registerCode, _rowVersion);
+            _dut = new VoidTagFunctionCommandValidator(_tagFunctionValidatorMock.Object, _rowVersionValidatorMock.Object);
         }
 
         [TestMethod]
@@ -57,6 +62,21 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagFunctionCommands.VoidTa
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Tag function is already voided!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_WhenInvalidRowVersion()
+        {
+            const string invalidRowVersion = "String";
+
+            var command = new VoidTagFunctionCommand(_tagFunctionCode, _registerCode, invalidRowVersion);
+            _rowVersionValidatorMock.Setup(r => r.IsValid(invalidRowVersion, default)).Returns(Task.FromResult(false));
+
+            var result = _dut.Validate(command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid RowVersion!"));
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagFunctionCommands/VoidTagFunction/VoidTagFunctionCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagFunctionCommands/VoidTagFunction/VoidTagFunctionCommandValidatorTests.cs
@@ -16,7 +16,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagFunctionCommands.VoidTa
         private VoidTagFunctionCommandValidator _dut;
 
         private readonly string _tagFunctionCode = "TFC";
-        private string _rowVersion = "AAAAAAAAJ00=";
+        private readonly string _rowVersion = "AAAAAAAAJ00=";
         private readonly string _registerCode = "RC";
 
         [TestInitialize]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RowVersionValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RowVersionValidatorTests.cs
@@ -29,5 +29,19 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
             var result = await _dut.IsValid(invalidRowVersion, default);
             Assert.IsFalse(result);
         }
+
+        [TestMethod]
+        public async Task IsValid_EmptyString_ReturnsFalse()
+        {
+            var result = await _dut.IsValid(string.Empty, default);
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public async Task IsValid_Null_ReturnsFalse()
+        {
+            var result = await _dut.IsValid(null, default);
+            Assert.IsFalse(result);
+        }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RowVersionValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RowVersionValidatorTests.cs
@@ -1,0 +1,33 @@
+﻿using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Command.Validators;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.Procosys.Preservation.Command.Tests.Validators
+{
+    [TestClass]
+    public class RowVersionValidatorTests
+    {
+        private RowVersionValidator _dut;
+
+        [TestInitialize]
+        public void SetUp() => _dut = new RowVersionValidator();
+
+        [TestMethod]
+        public async Task IsValid_ValidRowVersion_ReturnsTrue()
+        { 
+            const string validRowVersion = "AAAAAAAAABA=";
+
+            var result = await _dut.IsValid(validRowVersion, default);
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public async Task IsValid_InvalidRowVersion_ReturnsFalse()
+        {
+            const string invalidRowVersion = "String";
+
+            var result = await _dut.IsValid(invalidRowVersion, default);
+            Assert.IsFalse(result);
+        }
+    }
+}


### PR DESCRIPTION
Validate incoming rowversion to verify that it can be converted to byte array and is thereby valid. Give relevant validation error message.