### PR TITLE
Tech refactor obsolete enum CascadeMode.StopOnFirstFailure

### DIFF
--- a/src/Equinor.Procosys.Preservation.Command/ActionAttachmentCommands/Delete/DeleteActionAttachmentCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/ActionAttachmentCommands/Delete/DeleteActionAttachmentCommandValidator.cs
@@ -18,7 +18,7 @@ namespace Equinor.Procosys.Preservation.Command.ActionAttachmentCommands.Delete
             IActionValidator actionValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => NotBeAClosedProjectForTagAsync(command.TagId, token))

--- a/src/Equinor.Procosys.Preservation.Command/ActionAttachmentCommands/Upload/UploadActionAttachmentCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/ActionAttachmentCommands/Upload/UploadActionAttachmentCommandValidator.cs
@@ -14,7 +14,7 @@ namespace Equinor.Procosys.Preservation.Command.ActionAttachmentCommands.Upload
             ITagValidator tagValidator,
             IActionValidator actionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => NotBeAClosedProjectForTagAsync(command.TagId, token))

--- a/src/Equinor.Procosys.Preservation.Command/ActionCommands/CloseAction/CloseActionCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/ActionCommands/CloseAction/CloseActionCommandValidator.cs
@@ -16,7 +16,7 @@ namespace Equinor.Procosys.Preservation.Command.ActionCommands.CloseAction
             IActionValidator actionValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => NotBeAClosedProjectForTagAsync(command.TagId, token))

--- a/src/Equinor.Procosys.Preservation.Command/ActionCommands/CreateAction/CreateActionCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/ActionCommands/CreateAction/CreateActionCommandValidator.cs
@@ -12,7 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.ActionCommands.CreateAction
             IProjectValidator projectValidator,
             ITagValidator tagValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => NotBeAClosedProjectForTagAsync(command.TagId, token))

--- a/src/Equinor.Procosys.Preservation.Command/ActionCommands/UpdateAction/UpdateActionCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/ActionCommands/UpdateAction/UpdateActionCommandValidator.cs
@@ -16,7 +16,7 @@ namespace Equinor.Procosys.Preservation.Command.ActionCommands.UpdateAction
             IActionValidator actionValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => NotBeAClosedProjectForTagAsync(command.TagId, token))

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/CreateJourney/CreateJourneyCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/CreateJourney/CreateJourneyCommandValidator.cs
@@ -9,7 +9,7 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.CreateJourney
     {
         public CreateJourneyCommandValidator(IJourneyValidator journeyValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => HaveUniqueJourneyTitleAsync(command.Title, token))

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/CreateStep/CreateStepCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/CreateStep/CreateStepCommandValidator.cs
@@ -15,7 +15,7 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.CreateStep
             IModeValidator modeValidator,
             IResponsibleValidator responsibleValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingJourney(command.JourneyId, token))

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/DeleteJourney/DeleteJourneyCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/DeleteJourney/DeleteJourneyCommandValidator.cs
@@ -12,7 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.DeleteJourney
             IJourneyValidator journeyValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
             
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingJourneyAsync(command.JourneyId, token))

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/DeleteStep/DeleteStepCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/DeleteStep/DeleteStepCommandValidator.cs
@@ -14,7 +14,7 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.DeleteStep
             IStepValidator stepValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
             
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingJourneyAsync(command.JourneyId, token))

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/DuplicateJourney/DuplicateJourneyCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/DuplicateJourney/DuplicateJourneyCommandValidator.cs
@@ -9,7 +9,7 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.DuplicateJourney
     {
         public DuplicateJourneyCommandValidator(IJourneyValidator journeyValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingJourneyAsync(command.JourneyId, token))

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/SwapSteps/SwapStepsCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/SwapSteps/SwapStepsCommandValidator.cs
@@ -14,7 +14,7 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.SwapSteps
             IStepValidator stepValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingJourneyAsync(command.JourneyId, token))

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UnvoidJourney/UnvoidJourneyCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UnvoidJourney/UnvoidJourneyCommandValidator.cs
@@ -12,7 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.UnvoidJourney
             IJourneyValidator journeyValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingJourneyAsync(command.JourneyId, token))

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UnvoidStep/UnvoidStepCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UnvoidStep/UnvoidStepCommandValidator.cs
@@ -12,7 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.UnvoidStep
             IStepValidator stepValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingStepAsync(command.StepId, token))

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UpdateJourney/UpdateJourneyCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UpdateJourney/UpdateJourneyCommandValidator.cs
@@ -12,7 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.UpdateJourney
             IJourneyValidator journeyValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingJourneyAsync(command.JourneyId, token))

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UpdateStep/UpdateStepCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UpdateStep/UpdateStepCommandValidator.cs
@@ -19,7 +19,7 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.UpdateStep
             IResponsibleValidator responsibleValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingJourneyAsync(command.JourneyId, token))

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/VoidJourney/VoidJourneyCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/VoidJourney/VoidJourneyCommandValidator.cs
@@ -12,7 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.VoidJourney
             IJourneyValidator journeyValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingJourneyAsync(command.JourneyId, token))

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/VoidStep/VoidStepCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/VoidStep/VoidStepCommandValidator.cs
@@ -12,7 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.VoidStep
             IStepValidator stepValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingStepAsync(command.StepId, token))

--- a/src/Equinor.Procosys.Preservation.Command/MiscCommands/Clone/CloneCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/MiscCommands/Clone/CloneCommandValidator.cs
@@ -11,7 +11,7 @@ namespace Equinor.Procosys.Preservation.Command.MiscCommands.Clone
 
         public CloneCommandValidator(IPlantCache plantCache)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command.SourcePlant)
                 .MustAsync((_, sourcePlant, token) => BeAValidPlantAsync(sourcePlant.ToUpperInvariant()))

--- a/src/Equinor.Procosys.Preservation.Command/ModeCommands/DeleteMode/DeleteModeCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/ModeCommands/DeleteMode/DeleteModeCommandValidator.cs
@@ -12,7 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.ModeCommands.DeleteMode
             IModeValidator modeValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
             
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingMode(command.ModeId, token))

--- a/src/Equinor.Procosys.Preservation.Command/ModeCommands/UnvoidMode/UnvoidModeCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/ModeCommands/UnvoidMode/UnvoidModeCommandValidator.cs
@@ -12,7 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.ModeCommands.UnvoidMode
             IModeValidator modeValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingModeAsync(command.ModeId, token))

--- a/src/Equinor.Procosys.Preservation.Command/ModeCommands/UpdateMode/UpdateModeCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/ModeCommands/UpdateMode/UpdateModeCommandValidator.cs
@@ -12,7 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.ModeCommands.UpdateMode
             IModeValidator modeValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingModeAsync(command.ModeId, token))

--- a/src/Equinor.Procosys.Preservation.Command/ModeCommands/VoidMode/VoidModeCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/ModeCommands/VoidMode/VoidModeCommandValidator.cs
@@ -12,7 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.ModeCommands.VoidMode
             IModeValidator modeValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingModeAsync(command.ModeId, token))

--- a/src/Equinor.Procosys.Preservation.Command/PersonCommands/CreateSavedFilter/CreateSavedFilterCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/PersonCommands/CreateSavedFilter/CreateSavedFilterCommandValidator.cs
@@ -12,7 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.PersonCommands.CreateSavedFilter
             ISavedFilterValidator savedFilterValidator,
             IProjectValidator projectValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => NotExistsASavedFilterWithSameTitleForPerson(command.Title, command.ProjectName, token))

--- a/src/Equinor.Procosys.Preservation.Command/PersonCommands/DeleteSavedFilter/DeleteSavedFilterCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/PersonCommands/DeleteSavedFilter/DeleteSavedFilterCommandValidator.cs
@@ -12,7 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.PersonCommands.DeleteSavedFilter
             ISavedFilterValidator savedFilterValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingSavedFilterAsync(command.SavedFilterId, token))

--- a/src/Equinor.Procosys.Preservation.Command/PersonCommands/UpdateSavedFilter/UpdateSavedFilterCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/PersonCommands/UpdateSavedFilter/UpdateSavedFilterCommandValidator.cs
@@ -12,7 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.PersonCommands.UpdateSavedFilter
             ISavedFilterValidator savedFilterValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingSavedFilterAsync(command.SavedFilterId, token))

--- a/src/Equinor.Procosys.Preservation.Command/RequirementCommands/DeleteAttachment/DeleteFieldValueAttachmentCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementCommands/DeleteAttachment/DeleteFieldValueAttachmentCommandValidator.cs
@@ -14,7 +14,7 @@ namespace Equinor.Procosys.Preservation.Command.RequirementCommands.DeleteAttach
             ITagValidator tagValidator,
             IFieldValidator fieldValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => NotBeAClosedProjectForTagAsync(command.TagId, token))

--- a/src/Equinor.Procosys.Preservation.Command/RequirementCommands/Preserve/PreserveCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementCommands/Preserve/PreserveCommandValidator.cs
@@ -11,7 +11,7 @@ namespace Equinor.Procosys.Preservation.Command.RequirementCommands.Preserve
     {
         public PreserveCommandValidator(IProjectValidator projectValidator, ITagValidator tagValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
             
             RuleFor(command => command)
                 .MustAsync((command, token) => NotBeAClosedProjectForTagAsync(command.TagId, token))

--- a/src/Equinor.Procosys.Preservation.Command/RequirementCommands/RecordValues/RecordValuesCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementCommands/RecordValues/RecordValuesCommandValidator.cs
@@ -15,7 +15,7 @@ namespace Equinor.Procosys.Preservation.Command.RequirementCommands.RecordValues
             ITagValidator tagValidator,
             IFieldValidator fieldValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => NotBeAClosedProjectForTagAsync(command.TagId, token))

--- a/src/Equinor.Procosys.Preservation.Command/RequirementCommands/Upload/UploadFieldValueAttachmentCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementCommands/Upload/UploadFieldValueAttachmentCommandValidator.cs
@@ -14,7 +14,7 @@ namespace Equinor.Procosys.Preservation.Command.RequirementCommands.Upload
             ITagValidator tagValidator,
             IFieldValidator fieldValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => NotBeAClosedProjectForTagAsync(command.TagId, token))

--- a/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/CreateRequirementDefinition/CreateRequirementDefinitionCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/CreateRequirementDefinition/CreateRequirementDefinitionCommandValidator.cs
@@ -11,7 +11,7 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.CreateRe
     {
         public CreateRequirementDefinitionCommandValidator(IRequirementTypeValidator requirementTypeValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => RequirementTypeMustExists(command.RequirementTypeId, token))

--- a/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/CreateRequirementType/CreateRequirementTypeCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/CreateRequirementType/CreateRequirementTypeCommandValidator.cs
@@ -9,7 +9,7 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.CreateRe
     {
         public CreateRequirementTypeCommandValidator(IRequirementTypeValidator requirementTypeValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => NotExistsARequirementTypeWithSameCode(command.Code, token))

--- a/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/DeleteRequirementDefinition/DeleteRequirementDefinitionCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/DeleteRequirementDefinition/DeleteRequirementDefinitionCommandValidator.cs
@@ -14,7 +14,7 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.DeleteRe
             IRequirementDefinitionValidator requirementDefinitionValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingRequirementTypeAsync(command.RequirementTypeId, token))

--- a/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/DeleteRequirementType/DeleteRequirementTypeCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/DeleteRequirementType/DeleteRequirementTypeCommandValidator.cs
@@ -12,7 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.DeleteRe
             IRequirementTypeValidator requirementTypeValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingRequirementTypeAsync(command.RequirementTypeId, token))

--- a/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/UnvoidRequirementDefinition/UnvoidRequirementDefinitionCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/UnvoidRequirementDefinition/UnvoidRequirementDefinitionCommandValidator.cs
@@ -15,7 +15,7 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.UnvoidRe
             IRowVersionValidator rowVersionValidator
         )
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingRequirementTypeAsync(command.RequirementTypeId, token))

--- a/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/UnvoidRequirementType/UnvoidRequirementTypeCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/UnvoidRequirementType/UnvoidRequirementTypeCommandValidator.cs
@@ -12,7 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.UnvoidRe
             IRequirementTypeValidator requirementTypeValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingRequirementTypeAsync(command.RequirementTypeId, token))

--- a/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/UpdateRequirementDefinition/UpdateRequirementDefinitionCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/UpdateRequirementDefinition/UpdateRequirementDefinitionCommandValidator.cs
@@ -16,7 +16,7 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.UpdateRe
             IRequirementDefinitionValidator requirementDefinitionValidator,
             IFieldValidator fieldValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingRequirementTypeAsync(command.RequirementTypeId, token))

--- a/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/UpdateRequirementType/UpdateRequirementTypeCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/UpdateRequirementType/UpdateRequirementTypeCommandValidator.cs
@@ -12,7 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.UpdateRe
             IRequirementTypeValidator requirementTypeValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingRequirementTypeAsync(command.RequirementTypeId, token))

--- a/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/VoidRequirementDefinition/VoidRequirementDefinitionCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/VoidRequirementDefinition/VoidRequirementDefinitionCommandValidator.cs
@@ -15,7 +15,7 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.VoidRequ
             IRowVersionValidator rowVersionValidator
         )
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingRequirementTypeAsync(command.RequirementTypeId, token))

--- a/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/VoidRequirementType/VoidRequirementTypeCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/VoidRequirementType/VoidRequirementTypeCommandValidator.cs
@@ -12,7 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.VoidRequ
             IRequirementTypeValidator requirementTypeValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingRequirementTypeAsync(command.RequirementTypeId, token))

--- a/src/Equinor.Procosys.Preservation.Command/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandValidator.cs
@@ -16,7 +16,7 @@ namespace Equinor.Procosys.Preservation.Command.TagAttachmentCommands.Delete
             IAttachmentValidator attachmentValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => NotBeAClosedProjectForTagAsync(command.TagId, token))

--- a/src/Equinor.Procosys.Preservation.Command/TagAttachmentCommands/Upload/UploadTagAttachmentCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagAttachmentCommands/Upload/UploadTagAttachmentCommandValidator.cs
@@ -12,7 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.TagAttachmentCommands.Upload
             IProjectValidator projectValidator,
             ITagValidator tagValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => NotBeAClosedProjectForTagAsync(command.TagId, token))

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/AutoScopeTags/AutoScopeTagsCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/AutoScopeTags/AutoScopeTagsCommandValidator.cs
@@ -16,7 +16,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.AutoScopeTags
             IStepValidator stepValidator,
             IProjectValidator projectValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command.TagNos)
                 .Must(r => r.Any())

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/BulkPreserve/BulkPreserveCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/BulkPreserve/BulkPreserveCommandValidator.cs
@@ -15,7 +15,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.BulkPreserve
             IProjectValidator projectValidator,
             ITagValidator tagValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
                         
             RuleFor(command => command.TagIds)
                 .Must(ids => ids != null && ids.Any())

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/CompletePreservation/CompletePreservationCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/CompletePreservation/CompletePreservationCommandValidator.cs
@@ -15,7 +15,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.CompletePreservation
             IProjectValidator projectValidator,
             ITagValidator tagValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
                         
             RuleFor(command => command.Tags)
                 .Must(ids => ids != null && ids.Any())

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateAreaTag/CreateAreaTagCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateAreaTag/CreateAreaTagCommandValidator.cs
@@ -19,7 +19,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.CreateAreaTag
             IProjectValidator projectValidator,
             IRequirementDefinitionValidator requirementDefinitionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
             
             WhenAsync((command, token) => BeASupplierStepAsync(command.StepId, token), () =>
             {

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateTags/CreateTagsCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateTags/CreateTagsCommandValidator.cs
@@ -18,7 +18,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.CreateTags
             IProjectValidator projectValidator,
             IRequirementDefinitionValidator requirementDefinitionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command.TagNos)
                 .Must(r => r.Any())

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/DeleteTag/DeleteTagCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/DeleteTag/DeleteTagCommandValidator.cs
@@ -13,7 +13,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.DeleteTag
             ITagValidator tagValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingTagAsync(command.TagId, token))

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/Preserve/PreserveCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/Preserve/PreserveCommandValidator.cs
@@ -14,7 +14,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.Preserve
             IProjectValidator projectValidator,
             ITagValidator tagValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
             
             RuleFor(command => command)
                 .MustAsync((command, token) => NotBeAClosedProjectForTagAsync(command.TagId, token))

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/StartPreservation/StartPreservationCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/StartPreservation/StartPreservationCommandValidator.cs
@@ -14,7 +14,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.StartPreservation
             IProjectValidator projectValidator,
             ITagValidator tagValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
                         
             RuleFor(command => command.TagIds)
                 .Must(ids => ids != null && ids.Any())

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/Transfer/TransferCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/Transfer/TransferCommandValidator.cs
@@ -14,7 +14,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.Transfer
             IProjectValidator projectValidator,
             ITagValidator tagValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
                         
             RuleFor(command => command.Tags)
                 .Must(ids => ids != null && ids.Any())

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/UnvoidTag/UnvoidTagCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/UnvoidTag/UnvoidTagCommandValidator.cs
@@ -14,7 +14,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.UnvoidTag
             ITagValidator tagValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => NotBeAClosedProjectForTagAsync(command.TagId, token))

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTag/UpdateTagCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTag/UpdateTagCommandValidator.cs
@@ -14,7 +14,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.UpdateTag
              ITagValidator tagValidator,
              IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => NotBeAClosedProjectForTagAsync(command.TagId, token))

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandValidator.cs
@@ -20,7 +20,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.UpdateTagStepAndRequ
              IRequirementDefinitionValidator requirementDefinitionValidator,
              IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             WhenAsync((command, token) => BeASupplierStepAsync(command.StepId, token), () =>
             {

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/VoidTag/VoidTagCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/VoidTag/VoidTagCommandValidator.cs
@@ -14,7 +14,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.VoidTag
             ITagValidator tagValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => NotBeAClosedProjectForTagAsync(command.TagId, token))

--- a/src/Equinor.Procosys.Preservation.Command/TagFunctionCommands/UnvoidTagFunction/UnvoidTagFunctionCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagFunctionCommands/UnvoidTagFunction/UnvoidTagFunctionCommandValidator.cs
@@ -12,7 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.TagFunctionCommands.UnvoidTagFun
             ITagFunctionValidator tagFunctionValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingTagFunctionAsync(command.TagFunctionCode, token))

--- a/src/Equinor.Procosys.Preservation.Command/TagFunctionCommands/UpdateRequirements/UpdateRequirementsCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagFunctionCommands/UpdateRequirements/UpdateRequirementsCommandValidator.cs
@@ -14,7 +14,7 @@ namespace Equinor.Procosys.Preservation.Command.TagFunctionCommands.UpdateRequir
             IRequirementDefinitionValidator requirementDefinitionValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             When(command => command.Requirements.Any(), () =>
             {

--- a/src/Equinor.Procosys.Preservation.Command/TagFunctionCommands/VoidTagFunction/VoidTagFunctionCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagFunctionCommands/VoidTagFunction/VoidTagFunctionCommandValidator.cs
@@ -12,7 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.TagFunctionCommands.VoidTagFunct
             ITagFunctionValidator tagFunctionValidator,
             IRowVersionValidator rowVersionValidator)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingTagFunctionAsync(command.TagFunctionCode, token))

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Tags/UploadBaseDtoValidator.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Tags/UploadBaseDtoValidator.cs
@@ -10,7 +10,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Tags
     {
         public UploadBaseDtoValidator(IOptionsMonitor<AttachmentOptions> options)
         {
-            CascadeMode = CascadeMode.StopOnFirstFailure;
+            CascadeMode = CascadeMode.Stop;
 
             RuleFor(x => x)
                 .NotNull();

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementCommands/RecordValues/RecordValuesCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementCommands/RecordValues/RecordValuesCommandValidatorTests.cs
@@ -174,7 +174,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementCommands.Record
         }
  
         [TestMethod]
-        public void Validate_ShouldFailWith3Errors_WhenErrorsInDifferentRules()
+        public void Validate_ShouldFailWith1Error_WhenErrorsInDifferentRules()
         {
             _projectValidatorMock.Setup(r => r.IsClosedForTagAsync(TagId, default)).Returns(Task.FromResult(true));
             _fieldValidatorMock.Setup(v => v.ExistsAsync(NumberFieldId, default)).Returns(Task.FromResult(false));
@@ -183,7 +183,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementCommands.Record
             var result = _dut.Validate(_recordValuesCommand);
             
             Assert.IsFalse(result.IsValid);
-            Assert.AreEqual(3, result.Errors.Count);
+            Assert.AreEqual(1, result.Errors.Count);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/AutoScopeTags/AutoScopeTagsCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/AutoScopeTags/AutoScopeTagsCommandValidatorTests.cs
@@ -149,7 +149,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.AutoScopeTags
         }
 
         [TestMethod]
-        public void Validate_ShouldFailWith2Errors_WhenErrorsInDifferentRules()
+        public void Validate_ShouldFailWith1Error_WhenErrorsInDifferentRules()
         {
             _tagValidatorMock.Setup(r => r.ExistsAsync(_tagNo2, _projectName, default)).Returns(Task.FromResult(true));
             
@@ -163,7 +163,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.AutoScopeTags
             var result = _dut.Validate(command);
 
             Assert.IsFalse(result.IsValid);
-            Assert.AreEqual(2, result.Errors.Count);
+            Assert.AreEqual(1, result.Errors.Count);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/BulkPreserve/BulkPreserveCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/BulkPreserve/BulkPreserveCommandValidatorTests.cs
@@ -160,7 +160,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.BulkPreserve
         }
 
         [TestMethod]
-        public void Validate_ShouldFailWith2Errors_WhenErrorsInDifferentRules()
+        public void Validate_ShouldFailWith1Error_WhenErrorsInDifferentRules()
         {
             _projectValidatorMock.Setup(r => r.IsClosedForTagAsync(TagId1, default)).Returns(Task.FromResult(true));
             _tagValidatorMock.Setup(r => r.ExistsAsync(TagId2, default)).Returns(Task.FromResult(false));
@@ -168,7 +168,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.BulkPreserve
             var result = _dut.Validate(_command);
 
             Assert.IsFalse(result.IsValid);
-            Assert.AreEqual(2, result.Errors.Count);
+            Assert.AreEqual(1, result.Errors.Count);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CompletePreservation/CompletePreservationCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CompletePreservation/CompletePreservationCommandValidatorTests.cs
@@ -154,7 +154,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CompletePreser
         }
 
         [TestMethod]
-        public void Validate_ShouldFailWith2Errors_WhenErrorsInDifferentRules()
+        public void Validate_ShouldFailWith1Error_WhenErrorsInDifferentRules()
         {
             _projectValidatorMock.Setup(r => r.IsClosedForTagAsync(TagId1, default)).Returns(Task.FromResult(true));
             _tagValidatorMock.Setup(r => r.ExistsAsync(TagId2, default)).Returns(Task.FromResult(false));
@@ -162,7 +162,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CompletePreser
             var result = _dut.Validate(_command);
 
             Assert.IsFalse(result.IsValid);
-            Assert.AreEqual(2, result.Errors.Count);
+            Assert.AreEqual(1, result.Errors.Count);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateAreaTag/CreateAreaTagCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateAreaTag/CreateAreaTagCommandValidatorTests.cs
@@ -285,7 +285,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateAreaTag
         }
 
         [TestMethod]
-        public void Validate_ShouldFailWith2Errors_WhenErrorsInDifferentRules()
+        public void Validate_ShouldFailWith1Error_WhenErrorsInDifferentRules()
         {
             _tagValidatorMock.Setup(r => r.ExistsAsync(_command.GetTagNo(), _projectName, default)).Returns(Task.FromResult(true));
             _rdValidatorMock.Setup(r => r.ExistsAsync(_rd2Id, default)).Returns(Task.FromResult(false));
@@ -293,7 +293,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateAreaTag
             var result = _dut.Validate(_command);
 
             Assert.IsFalse(result.IsValid);
-            Assert.AreEqual(2, result.Errors.Count);
+            Assert.AreEqual(1, result.Errors.Count);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateTags/CreateTagsCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateTags/CreateTagsCommandValidatorTests.cs
@@ -304,7 +304,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateTags
         }
 
         [TestMethod]
-        public void Validate_ShouldFailWith2Errors_WhenErrorsInDifferentRules()
+        public void Validate_ShouldFailWith1Error_WhenErrorsInDifferentRules()
         {
             _tagValidatorMock.Setup(r => r.ExistsAsync(_tagNo1, _projectName, default)).Returns(Task.FromResult(true));
             _rdValidatorMock.Setup(r => r.ExistsAsync(_rd2Id, default)).Returns(Task.FromResult(false));
@@ -312,7 +312,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateTags
             var result = _dut.Validate(_command);
 
             Assert.IsFalse(result.IsValid);
-            Assert.AreEqual(2, result.Errors.Count);
+            Assert.AreEqual(1, result.Errors.Count);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/StartPreservation/StartPreservationCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/StartPreservation/StartPreservationCommandValidatorTests.cs
@@ -158,7 +158,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.StartPreservat
         }
 
         [TestMethod]
-        public void Validate_ShouldFailWith2Errors_WhenErrorsInDifferentRules()
+        public void Validate_ShouldFailWith1Error_WhenErrorsInDifferentRules()
         {
             _projectValidatorMock.Setup(r => r.IsClosedForTagAsync(TagId1, default)).Returns(Task.FromResult(true));
             _tagValidatorMock.Setup(r => r.ExistsAsync(TagId2, default)).Returns(Task.FromResult(false));
@@ -166,7 +166,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.StartPreservat
             var result = _dut.Validate(_command);
 
             Assert.IsFalse(result.IsValid);
-            Assert.AreEqual(2, result.Errors.Count);
+            Assert.AreEqual(1, result.Errors.Count);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/ActionValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/ActionValidatorTests.cs
@@ -44,7 +44,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAsync_KnownIds_ReturnsTrue()
+        public async Task ExistsAsync_KnownIds_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -55,7 +55,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAsync_UnknownActionId_ReturnsFalse()
+        public async Task ExistsAsync_UnknownActionId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -66,7 +66,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsClosedAsync_KnownId_ReturnsFalse_WhenNotClosed()
+        public async Task IsClosedAsync_KnownId_ShouldReturnFalse_WhenNotClosed()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -77,7 +77,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsClosedAsync_KnownId_ReturnsTrue_WhenClosed()
+        public async Task IsClosedAsync_KnownId_ShouldReturnTrue_WhenClosed()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -95,7 +95,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsClosedAsync_UnknownActionId_ReturnsFalse()
+        public async Task IsClosedAsync_UnknownActionId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -106,7 +106,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task AttachmentWithFilenameExistsAsync_KnownFile_ReturnsTrue()
+        public async Task AttachmentWithFilenameExistsAsync_KnownFile_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -117,7 +117,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task AttachmentWithFilenameExistsAsync_UnknownFile_ReturnsFalse()
+        public async Task AttachmentWithFilenameExistsAsync_UnknownFile_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -128,7 +128,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task AttachmentWithFilenameExistsAsync_UnknownActionId_ReturnsFalse()
+        public async Task AttachmentWithFilenameExistsAsync_UnknownActionId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/AttachmentValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/AttachmentValidatorTests.cs
@@ -37,7 +37,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAsync_KnownId_ReturnsTrue()
+        public async Task ExistsAsync_KnownId_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -48,7 +48,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAsync_UnknownId_ReturnsFalse()
+        public async Task ExistsAsync_UnknownId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/FieldValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/FieldValidatorTests.cs
@@ -31,7 +31,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAsync_KnownId_ReturnsTrue()
+        public async Task ExistsAsync_KnownId_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -42,7 +42,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAsync_UnknownId_ReturnsFalse()
+        public async Task ExistsAsync_UnknownId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -53,7 +53,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsVoidedAsync_KnownVoided_ReturnsTrue()
+        public async Task IsVoidedAsync_KnownVoided_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -70,7 +70,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsVoidedAsync_KnownNotVoided_ReturnsFalse()
+        public async Task IsVoidedAsync_KnownNotVoided_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -81,7 +81,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsVoidedAsync_UnknownId_ReturnsFalse()
+        public async Task IsVoidedAsync_UnknownId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -92,7 +92,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsValidForRecordingAsync_ForInfoField_ReturnsFalse()
+        public async Task IsValidForRecordingAsync_ForInfoField_ShouldReturnFalse()
         { 
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -103,7 +103,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsValidForRecordingAsync_ForCheckBoxField_ReturnsTrue()
+        public async Task IsValidForRecordingAsync_ForCheckBoxField_ShouldReturnTrue()
         { 
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -114,7 +114,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsValidForRecordingAsync_ForNumberField_ReturnsTrue()
+        public async Task IsValidForRecordingAsync_ForNumberField_ShouldReturnTrue()
         { 
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -125,7 +125,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsValidForAttachmentAsync_ForAttachmentField_ReturnsTrue()
+        public async Task IsValidForAttachmentAsync_ForAttachmentField_ShouldReturnTrue()
         { 
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -136,7 +136,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsValidForAttachmentAsync_ForInfoField_ReturnsFalse()
+        public async Task IsValidForAttachmentAsync_ForInfoField_ShouldReturnFalse()
         { 
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -147,7 +147,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsValidForAttachmentAsync_ForNumberField_ReturnsFalse()
+        public async Task IsValidForAttachmentAsync_ForNumberField_ShouldReturnFalse()
         { 
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -158,7 +158,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task VerifyFieldTypeAsync_ForInfoField_ReturnsFalseForNumber()
+        public async Task VerifyFieldTypeAsync_ForInfoField_ShouldReturnFalseForNumber()
         { 
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -169,7 +169,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task VerifyFieldTypeAsync_ForInfoField_ReturnsTrueForInfo()
+        public async Task VerifyFieldTypeAsync_ForInfoField_ShouldReturnTrueForInfo()
         { 
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/JourneyValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/JourneyValidatorTests.cs
@@ -52,7 +52,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAsync_KnownId_ReturnsTrue()
+        public async Task ExistsAsync_KnownId_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -63,7 +63,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAsync_UnknownId_ReturnsFalse()
+        public async Task ExistsAsync_UnknownId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -74,7 +74,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task StepExistsAsync_KnownIds_ReturnsTrue()
+        public async Task StepExistsAsync_KnownIds_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -85,7 +85,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task StepExistsAsync_UnknownJourneyId_ReturnsFalse()
+        public async Task StepExistsAsync_UnknownJourneyId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -96,7 +96,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task StepExistsAsync_UnknownStepId_ReturnsFalse()
+        public async Task StepExistsAsync_UnknownStepId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -107,7 +107,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsWithSameTitleAsync_KnownTitle_ReturnsTrue()
+        public async Task ExistsWithSameTitleAsync_KnownTitle_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -118,7 +118,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsWithSameTitleAsync_UnknownTitle_ReturnsFalse()
+        public async Task ExistsWithSameTitleAsync_UnknownTitle_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -129,7 +129,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsWithSameTitleInAnotherJourneyAsync_SameTitleAsAnotherJourney_ReturnsTrue()
+        public async Task ExistsWithSameTitleInAnotherJourneyAsync_SameTitleAsAnotherJourney_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -140,7 +140,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsWithSameTitleInAnotherJourneyAsync_NewTitle_ReturnsFalse()
+        public async Task ExistsWithSameTitleInAnotherJourneyAsync_NewTitle_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -151,7 +151,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsWithSameTitleInAnotherJourneyAsync_SameTitle_ReturnsFalse()
+        public async Task ExistsWithSameTitleInAnotherJourneyAsync_SameTitle_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -162,7 +162,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsVoidedAsync_KnownVoided_ReturnsTrue()
+        public async Task IsVoidedAsync_KnownVoided_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -179,7 +179,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsVoidedAsync_KnownNotVoided_ReturnsFalse()
+        public async Task IsVoidedAsync_KnownNotVoided_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -190,7 +190,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsVoidedAsync_UnknownId_ReturnsFalse()
+        public async Task IsVoidedAsync_UnknownId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -201,7 +201,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task HasAnyStepsAsync_JorneyWithNoSteps_ReturnsFalse()
+        public async Task HasAnyStepsAsync_JorneyWithNoSteps_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -212,7 +212,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task HasAnyStepsAsync_UnknownId_ReturnsFalse()
+        public async Task HasAnyStepsAsync_UnknownId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -223,7 +223,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task HasAnyStepsAsync_JorneyWithSteps_ReturnsTrue()
+        public async Task HasAnyStepsAsync_JorneyWithSteps_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -234,7 +234,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
         
         [TestMethod]
-        public async Task IsInUseAsync_NoSteps_ReturnsFalse()
+        public async Task IsInUseAsync_NoSteps_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -245,7 +245,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
         
         [TestMethod]
-        public async Task IsInUseAsync_NoTagsUsesAnySteps_ReturnsFalse()
+        public async Task IsInUseAsync_NoTagsUsesAnySteps_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -256,7 +256,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
         
         [TestMethod]
-        public async Task IsInUseAsync_UnknownJourney_ReturnsFalse()
+        public async Task IsInUseAsync_UnknownJourney_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -267,7 +267,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
         
         [TestMethod]
-        public async Task IsInUseAsync_ReturnsTrue_AfterTagAddedToAStep()
+        public async Task IsInUseAsync_ShouldReturnTrue_AfterTagAddedToAStep()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -286,7 +286,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsWithDuplicateTitleAsync_KnownDuplicate_ReturnsTrue()
+        public async Task ExistsWithDuplicateTitleAsync_KnownDuplicate_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -297,7 +297,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsWithDuplicateTitleAsync_KnownNotDuplicate_ReturnsFalse()
+        public async Task ExistsWithDuplicateTitleAsync_KnownNotDuplicate_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -308,7 +308,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsWithDuplicateTitleAsync_UnknownKnownId_ReturnsFalse()
+        public async Task ExistsWithDuplicateTitleAsync_UnknownKnownId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -319,7 +319,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
         
         [TestMethod]
-        public async Task HasOtherStepWithAutoTransferMethodAsync_NoSteps_ReturnsFalse()
+        public async Task HasOtherStepWithAutoTransferMethodAsync_NoSteps_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -330,7 +330,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
         
         [TestMethod]
-        public async Task HasOtherStepWithAutoTransferMethodAsync_NoStepsHasSameAutoTransferMethodSign_ReturnsFalse()
+        public async Task HasOtherStepWithAutoTransferMethodAsync_NoStepsHasSameAutoTransferMethodSign_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -341,7 +341,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
         
         [TestMethod]
-        public async Task HasOtherStepWithAutoTransferMethodAsync_UnknownJourney_ReturnsFalse()
+        public async Task HasOtherStepWithAutoTransferMethodAsync_UnknownJourney_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -352,7 +352,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
         
         [TestMethod]
-        public async Task HasOtherStepWithAutoTransferMethodAsync_ReturnsTrue_WhenOtherStepHasSameAutoTransferMethod()
+        public async Task HasOtherStepWithAutoTransferMethodAsync_ShouldReturnTrue_WhenOtherStepHasSameAutoTransferMethod()
         {
             var autoTransferMethod = AutoTransferMethod.OnRfccSign;
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
@@ -375,7 +375,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
         
         [TestMethod]
-        public async Task HasOtherStepWithAutoTransferMethodAsync_ReturnsFalse_WhenSameStepHasSameAutoTransferMethod()
+        public async Task HasOtherStepWithAutoTransferMethodAsync_ShouldReturnFalse_WhenSameStepHasSameAutoTransferMethod()
         {
             int stepId;
             var autoTransferMethod = AutoTransferMethod.OnRfccSign;
@@ -401,7 +401,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
         
         [TestMethod]
-        public async Task AnyStepExistsWithSameTitleAsync_KnownTitleInJourney_ReturnsTrue()
+        public async Task AnyStepExistsWithSameTitleAsync_KnownTitleInJourney_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -412,7 +412,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task AnyStepExistsWithSameTitleAsync_NewTitle_ReturnsFalse()
+        public async Task AnyStepExistsWithSameTitleAsync_NewTitle_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -423,7 +423,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task AnyStepExistsWithSameTitleAsync_KnownTitleInAnotherJourney_ReturnsFalse()
+        public async Task AnyStepExistsWithSameTitleAsync_KnownTitleInAnotherJourney_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -434,7 +434,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task OtherStepExistsWithSameTitleAsync_SameTitleAsExisting_ReturnsFalse()
+        public async Task OtherStepExistsWithSameTitleAsync_SameTitleAsExisting_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -445,7 +445,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task OtherStepExistsWithSameTitleAsync_SameTitleAsAnotherStepInSameJourney_ReturnsFalse()
+        public async Task OtherStepExistsWithSameTitleAsync_SameTitleAsAnotherStepInSameJourney_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -456,7 +456,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task OtherStepExistsWithSameTitleAsync_SameTitleAsStepInAnotherJourney_ReturnsFalse()
+        public async Task OtherStepExistsWithSameTitleAsync_SameTitleAsStepInAnotherJourney_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/ModeValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/ModeValidatorTests.cs
@@ -28,7 +28,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAsync_KnownTitle_ReturnsTrue()
+        public async Task ExistsAsync_KnownTitle_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -39,7 +39,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAsync_KnownId_ReturnsTrue()
+        public async Task ExistsAsync_KnownId_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -50,7 +50,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAsync_UnknownTitle_ReturnsFalse()
+        public async Task ExistsAsync_UnknownTitle_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -61,7 +61,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAsync_UnknownId_ReturnsFalse()
+        public async Task ExistsAsync_UnknownId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -72,7 +72,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsVoidedAsync_KnownVoided_ReturnsTrue()
+        public async Task IsVoidedAsync_KnownVoided_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -90,7 +90,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsVoidedAsync_KnownNotVoided_ReturnsFalse()
+        public async Task IsVoidedAsync_KnownNotVoided_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -101,7 +101,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsVoidedAsync_UnknownId_ReturnsFalse()
+        public async Task IsVoidedAsync_UnknownId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -112,7 +112,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsUsedInStepAsync_KnownId_ReturnsTrue()
+        public async Task IsUsedInStepAsync_KnownId_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -123,7 +123,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsUsedInStepAsync_UnknownId_ReturnsFalse()
+        public async Task IsUsedInStepAsync_UnknownId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -134,7 +134,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAnotherModeForSupplierAsync_KnownId_ReturnsTrue()
+        public async Task ExistsAnotherModeForSupplierAsync_KnownId_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -145,7 +145,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAnotherModeForSupplierAsync_UnknownId_ReturnsTrue()
+        public async Task ExistsAnotherModeForSupplierAsync_UnknownId_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -156,7 +156,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsModeForSupplierAsync_ReturnsTrue()
+        public async Task ExistsModeForSupplierAsync_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -167,7 +167,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsForSupplierAsync_ReturnsTrue()
+        public async Task IsForSupplierAsync_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -178,7 +178,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsForSupplierAsync_ReturnsFalse()
+        public async Task IsForSupplierAsync_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/ProjectValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/ProjectValidatorTests.cs
@@ -41,7 +41,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAsync_KnownName_ReturnsTrue()
+        public async Task ExistsAsync_KnownName_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -52,7 +52,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAsync_UnknownName_ReturnsFalse()
+        public async Task ExistsAsync_UnknownName_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -63,7 +63,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsExistingAndClosedAsync_KnownClosed_ReturnsTrue()
+        public async Task IsExistingAndClosedAsync_KnownClosed_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -74,7 +74,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsExistingAndClosedAsync_KnownNotClosed_ReturnsFalse()
+        public async Task IsExistingAndClosedAsync_KnownNotClosed_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -85,7 +85,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsExistingAndClosedAsync_UnknownName_ReturnsFalse()
+        public async Task IsExistingAndClosedAsync_UnknownName_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -96,7 +96,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsClosedForTagAsync_KnownTag_ReturnsFalse()
+        public async Task IsClosedForTagAsync_KnownTag_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -107,7 +107,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsClosedForTagAsync_KnownTag_ReturnsTrue()
+        public async Task IsClosedForTagAsync_KnownTag_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -118,7 +118,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsClosedForTagAsync_UnknownTag_ReturnsFalse()
+        public async Task IsClosedForTagAsync_UnknownTag_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -129,7 +129,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task AllTagsInSameProjectAsync_TagsInSameProject_ReturnsTrue()
+        public async Task AllTagsInSameProjectAsync_TagsInSameProject_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -140,7 +140,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task AllTagsInSameProjectAsync_TagsNotInSameProject_ReturnsFalse()
+        public async Task AllTagsInSameProjectAsync_TagsNotInSameProject_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -151,7 +151,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task AllTagsInSameProjectAsync_KnownAndUnknownTag_ReturnsFalse()
+        public async Task AllTagsInSameProjectAsync_KnownAndUnknownTag_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -162,7 +162,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task AllTagsInSameProjectAsync_UnknownTag_ReturnsFalse()
+        public async Task AllTagsInSameProjectAsync_UnknownTag_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RequirementDefinitionValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RequirementDefinitionValidatorTests.cs
@@ -37,7 +37,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAsync_KnownId_ReturnsTrue()
+        public async Task ExistsAsync_KnownId_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -48,7 +48,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAsync_UnknownId_ReturnsFalse()
+        public async Task ExistsAsync_UnknownId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -59,7 +59,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsVoidedAsync_KnownVoided_ReturnsTrue()
+        public async Task IsVoidedAsync_KnownVoided_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -76,7 +76,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsVoidedAsync_KnownNotVoided_ReturnsFalse()
+        public async Task IsVoidedAsync_KnownNotVoided_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -87,7 +87,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
         
         [TestMethod]
-        public async Task IsVoidedAsync_UnknownId_ReturnsFalse()
+        public async Task IsVoidedAsync_UnknownId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -98,7 +98,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task HasAnyForSupplierOnlyUsageAsync_UsageForAllRequirement_ReturnsFalse()
+        public async Task HasAnyForSupplierOnlyUsageAsync_UsageForAllRequirement_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -110,7 +110,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task HasAnyForSupplierOnlyUsageAsync_UsageForOtherRequirement_ReturnsFalse()
+        public async Task HasAnyForSupplierOnlyUsageAsync_UsageForOtherRequirement_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -122,7 +122,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task HasAnyForSupplierOnlyUsageAsync_UsageForSupplierRequirement_ReturnsTrue()
+        public async Task HasAnyForSupplierOnlyUsageAsync_UsageForSupplierRequirement_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -134,7 +134,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task HasAnyForSupplierOnlyUsageAsync_UsageForSupplierAndOtherAndForAllRequirement_ReturnsTrue()
+        public async Task HasAnyForSupplierOnlyUsageAsync_UsageForSupplierAndOtherAndForAllRequirement_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -146,7 +146,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task HasAnyForSupplierOnlyUsageAsync_UnknownRequirement_ReturnsFalse()
+        public async Task HasAnyForSupplierOnlyUsageAsync_UnknownRequirement_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -158,7 +158,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task HasAnyForSupplierOnlyUsageAsync_NoRequirements_ReturnsFalse()
+        public async Task HasAnyForSupplierOnlyUsageAsync_NoRequirements_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -170,7 +170,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task UsageCoversForOtherThanSuppliersAsync_UsageForAllRequirement_ReturnsTrue()
+        public async Task UsageCoversForOtherThanSuppliersAsync_UsageForAllRequirement_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -182,7 +182,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task UsageCoversForOtherThanSuppliersAsync_UsageForOtherRequirement_ReturnsTrue()
+        public async Task UsageCoversForOtherThanSuppliersAsync_UsageForOtherRequirement_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -194,7 +194,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task UsageCoversForOtherThanSuppliersAsync_UsageForSupplierRequirement_ReturnsFalse()
+        public async Task UsageCoversForOtherThanSuppliersAsync_UsageForSupplierRequirement_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -206,7 +206,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task UsageCoversForOtherThanSuppliersAsync_UsageForSupplierAndOtherAndForAllRequirement_ReturnsTrue()
+        public async Task UsageCoversForOtherThanSuppliersAsync_UsageForSupplierAndOtherAndForAllRequirement_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -218,7 +218,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task UsageCoversForOtherThanSuppliersAsync_UnknownRequirement_ReturnsFalse()
+        public async Task UsageCoversForOtherThanSuppliersAsync_UnknownRequirement_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -230,7 +230,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task UsageCoversForOtherThanSuppliersAsync_NoRequirements_ReturnsFalse()
+        public async Task UsageCoversForOtherThanSuppliersAsync_NoRequirements_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -242,7 +242,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task UsageCoversBothForSupplierAndOtherAsync_UsageForAllRequirement_ReturnsTrue()
+        public async Task UsageCoversBothForSupplierAndOtherAsync_UsageForAllRequirement_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -254,7 +254,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task UsageCoversBothForSupplierAndOtherAsync_UsageForOtherRequirement_ReturnsFalse()
+        public async Task UsageCoversBothForSupplierAndOtherAsync_UsageForOtherRequirement_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -266,7 +266,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task UsageCoversBothForSupplierAndOtherAsync_UsageForSupplierRequirement_ReturnsFalse()
+        public async Task UsageCoversBothForSupplierAndOtherAsync_UsageForSupplierRequirement_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -278,7 +278,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task UsageCoversBothForSupplierAndOtherAsync_UsageForSupplierAndOtherAndForAllRequirement_ReturnsTrue()
+        public async Task UsageCoversBothForSupplierAndOtherAsync_UsageForSupplierAndOtherAndForAllRequirement_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -290,7 +290,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task UsageCoversBothForSupplierAndOtherAsync_UsageForSupplierAndOtherRequirement_ReturnsTrue()
+        public async Task UsageCoversBothForSupplierAndOtherAsync_UsageForSupplierAndOtherRequirement_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -302,7 +302,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task UsageCoversBothForSupplierAndOtherAsync_UnknownRequirement_ReturnsFalse()
+        public async Task UsageCoversBothForSupplierAndOtherAsync_UnknownRequirement_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -314,7 +314,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task UsageCoversBothForSupplierAndOtherAsync_NoRequirements_ReturnsFalse()
+        public async Task UsageCoversBothForSupplierAndOtherAsync_NoRequirements_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RequirementTypeValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RequirementTypeValidatorTests.cs
@@ -41,7 +41,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAsync_KnownId_ReturnsTrue()
+        public async Task ExistsAsync_KnownId_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -52,7 +52,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAsync_UnknownId_ReturnsFalse()
+        public async Task ExistsAsync_UnknownId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -63,7 +63,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsVoidedAsync_KnownVoided_ReturnsTrue()
+        public async Task IsVoidedAsync_KnownVoided_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -80,7 +80,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsVoidedAsync_KnownNotVoided_ReturnsFalse()
+        public async Task IsVoidedAsync_KnownNotVoided_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -91,7 +91,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsVoidedAsync_UnknownId_ReturnsFalse()
+        public async Task IsVoidedAsync_UnknownId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -102,7 +102,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsWithSameTitleAsync_KnownTitle_ReturnsTrue()
+        public async Task ExistsWithSameTitleAsync_KnownTitle_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -113,7 +113,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsWithSameTitleAsync_KnownTitle_ReturnsFalse()
+        public async Task ExistsWithSameTitleAsync_KnownTitle_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -124,7 +124,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsWithSameTitleInAnotherTypeAsync_SameTitleAsAnotherType_ReturnsTrue()
+        public async Task ExistsWithSameTitleInAnotherTypeAsync_SameTitleAsAnotherType_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -135,7 +135,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsWithSameTitleInAnotherTypeAsync_NewTitle_ReturnsFalse()
+        public async Task ExistsWithSameTitleInAnotherTypeAsync_NewTitle_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -145,7 +145,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
             }
         }
         [TestMethod]
-        public async Task ExistsWithSameCodeAsync_KnownCode_ReturnsTrue()
+        public async Task ExistsWithSameCodeAsync_KnownCode_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -156,7 +156,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsWithSameCodeAsync_KnownCode_ReturnsFalse()
+        public async Task ExistsWithSameCodeAsync_KnownCode_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -167,7 +167,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsWithSameCodeInAnotherTypeAsync_SameCodeAsAnotherType_ReturnsTrue()
+        public async Task ExistsWithSameCodeInAnotherTypeAsync_SameCodeAsAnotherType_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -178,7 +178,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsWithSameCodeInAnotherTypeAsync_NewCode_ReturnsFalse()
+        public async Task ExistsWithSameCodeInAnotherTypeAsync_NewCode_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -189,7 +189,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task AnyRequirementDefinitionExistsWithSameTitleAsync_WhenSameTitle_AndNeedUserInputAreEqual_ReturnsTrue()
+        public async Task AnyRequirementDefinitionExistsWithSameTitleAsync_WhenSameTitle_AndNeedUserInputAreEqual_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -201,7 +201,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task AnyRequirementDefinitionExistsWithSameTitleAsync_WhenSameTitle_ButNeedUserInputDiffer_ReturnsFalse()
+        public async Task AnyRequirementDefinitionExistsWithSameTitleAsync_WhenSameTitle_ButNeedUserInputDiffer_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -213,7 +213,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task AnyRequirementDefinitionExistsWithSameTitleAsync_WhenNewTitle_ReturnsFalse()
+        public async Task AnyRequirementDefinitionExistsWithSameTitleAsync_WhenNewTitle_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -225,7 +225,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task OtherRequirementDefinitionExistsWithSameTitleAsync_WhenSameTitleInOtherDefinition_AndNeedUserInputAreEqual_ReturnsTrue()
+        public async Task OtherRequirementDefinitionExistsWithSameTitleAsync_WhenSameTitleInOtherDefinition_AndNeedUserInputAreEqual_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -237,7 +237,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task OtherRequirementDefinitionExistsWithSameTitleAsync_WhenSameTitleInOtherDefinition_ButNeedUserInputDiffer_ReturnsFalse()
+        public async Task OtherRequirementDefinitionExistsWithSameTitleAsync_WhenSameTitleInOtherDefinition_ButNeedUserInputDiffer_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -249,7 +249,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task OtherRequirementDefinitionExistsWithSameTitleAsync_WhenNewTitle_ReturnsFalse()
+        public async Task OtherRequirementDefinitionExistsWithSameTitleAsync_WhenNewTitle_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/ResponsibleValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/ResponsibleValidatorTests.cs
@@ -23,7 +23,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAndIsVoidedAsync_KnownCode_Voided_ReturnsTrue()
+        public async Task ExistsAndIsVoidedAsync_KnownCode_Voided_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -42,7 +42,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAndIsVoidedAsync_KnownCode_NotVoided_ReturnsFalse()
+        public async Task ExistsAndIsVoidedAsync_KnownCode_NotVoided_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher,
                 _currentUserProvider))
@@ -54,7 +54,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAndIsVoidedAsync_UnknownCode_ReturnsFalse()
+        public async Task ExistsAndIsVoidedAsync_UnknownCode_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher,
                 _currentUserProvider))

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RowVersionValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RowVersionValidatorTests.cs
@@ -12,7 +12,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         public void SetUp() => _dut = new RowVersionValidator();
 
         [TestMethod]
-        public void IsValid_ValidRowVersion_ReturnsTrue()
+        public void IsValid_ValidRowVersion_ShouldReturnTrue()
         { 
             const string validRowVersion = "AAAAAAAAABA=";
 
@@ -21,7 +21,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public void IsValid_InvalidRowVersion_ReturnsFalse()
+        public void IsValid_InvalidRowVersion_ShouldReturnFalse()
         {
             const string invalidRowVersion = "String";
 
@@ -30,14 +30,14 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public void IsValid_EmptyString_ReturnsFalse()
+        public void IsValid_EmptyString_ShouldReturnFalse()
         {
             var result = _dut.IsValid(string.Empty);
             Assert.IsFalse(result);
         }
 
         [TestMethod]
-        public void IsValid_Null_ReturnsFalse()
+        public void IsValid_Null_ShouldReturnFalse()
         {
             var result = _dut.IsValid(null);
             Assert.IsFalse(result);

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/SavedFilterValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/SavedFilterValidatorTests.cs
@@ -51,7 +51,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsWithSameTitleForPersonInProjectAsync_UnknownTitle_ReturnsFalse()
+        public async Task ExistsWithSameTitleForPersonInProjectAsync_UnknownTitle_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher,
                 _currentUserProvider))
@@ -64,7 +64,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsWithSameTitleForPersonInProjectAsync_KnownTitle_ReturnsTrue()
+        public async Task ExistsWithSameTitleForPersonInProjectAsync_KnownTitle_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher,
                 _currentUserProvider))
@@ -77,7 +77,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAnotherWithSameTitleForPersonInProjectAsync_NewTitle_ReturnsFalse()
+        public async Task ExistsAnotherWithSameTitleForPersonInProjectAsync_NewTitle_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher,
                 _currentUserProvider))
@@ -90,7 +90,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAnotherWithSameTitleForPersonInProjectAsync_SameTitleAsAnotherSavedFilter_ReturnsTrue()
+        public async Task ExistsAnotherWithSameTitleForPersonInProjectAsync_SameTitleAsAnotherSavedFilter_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher,
                 _currentUserProvider))

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/StepValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/StepValidatorTests.cs
@@ -39,7 +39,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task Exists_KnownId_ReturnsTrue()
+        public async Task Exists_KnownId_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -50,7 +50,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task Exists_UnknownId_ReturnsFalse()
+        public async Task Exists_UnknownId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -61,7 +61,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsVoided_KnownVoided_ReturnsTrue()
+        public async Task IsVoided_KnownVoided_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -79,7 +79,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsVoided_KnownNotVoided_ReturnsFalse()
+        public async Task IsVoided_KnownNotVoided_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -90,7 +90,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsVoided_UnknownId_ReturnsFalse()
+        public async Task IsVoided_UnknownId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -101,7 +101,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsAnyStepForSupplier_IncludesSupplierStep_ReturnsTrue()
+        public async Task IsAnyStepForSupplier_IncludesSupplierStep_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -112,7 +112,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsAnyStepForSupplier_NotIncludesSupplierStep_ReturnsFalse()
+        public async Task IsAnyStepForSupplier_NotIncludesSupplierStep_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -123,7 +123,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsFirstStepOrModeIsNotForSupplier_UpdatingFirstStepToSupplierStep_ReturnsTrue()
+        public async Task IsFirstStepOrModeIsNotForSupplier_UpdatingFirstStepToSupplierStep_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -134,7 +134,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsFirstStepOrModeIsNotForSupplier_UpdatingNotFirstStepToSupplierStep_ReturnsFalse()
+        public async Task IsFirstStepOrModeIsNotForSupplier_UpdatingNotFirstStepToSupplierStep_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -145,7 +145,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsForSupplier_KnownForSupplier_ReturnsTrue()
+        public async Task IsForSupplier_KnownForSupplier_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -156,7 +156,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsForSupplier_KnownNotForSupplier_ReturnsFalse()
+        public async Task IsForSupplier_KnownNotForSupplier_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -167,7 +167,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsForSupplier_UnknownId_ReturnsFalse()
+        public async Task IsForSupplier_UnknownId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/TagValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/TagValidatorTests.cs
@@ -107,7 +107,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAsync_KnownTag_ReturnsTrue()
+        public async Task ExistsAsync_KnownTag_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -118,7 +118,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ExistsAsync_UnknownTag_ReturnsTrue()
+        public async Task ExistsAsync_UnknownTag_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -129,7 +129,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsVoidedAsync_NotVoidedTag_ReturnsFalse()
+        public async Task IsVoidedAsync_NotVoidedTag_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -140,7 +140,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsVoidedAsync_VoidedTag_ReturnsTrue()
+        public async Task IsVoidedAsync_VoidedTag_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -157,7 +157,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsVoidedAsync_UnknownTag_ReturnsFalse()
+        public async Task IsVoidedAsync_UnknownTag_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -168,7 +168,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task HasANonVoidedRequirementAsync_KnownTag_ReturnsTrue()
+        public async Task HasANonVoidedRequirementAsync_KnownTag_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -179,7 +179,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task HasANonVoidedRequirementAsync_KnownTag_ReturnsTrue_AfterVoidingOne()
+        public async Task HasANonVoidedRequirementAsync_KnownTag_ShouldReturnTrue_AfterVoidingOne()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -197,7 +197,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task VerifyPreservationStatusAsync_KnownTag_ReturnsFalse()
+        public async Task VerifyPreservationStatusAsync_KnownTag_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -208,7 +208,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task VerifyPreservationStatusAsync_KnownTag_ReturnsTrue()
+        public async Task VerifyPreservationStatusAsync_KnownTag_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -219,7 +219,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ReadyToBePreservedAsync_KnownTag_ReturnsFalse()
+        public async Task ReadyToBePreservedAsync_KnownTag_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -231,7 +231,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task ReadyToBePreservedAsync_KnownTag_ReturnsTrue()
+        public async Task ReadyToBePreservedAsync_KnownTag_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -243,7 +243,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task RequirementIsReadyToBePreservedAsync_KnownTag_ReturnsFalse()
+        public async Task RequirementIsReadyToBePreservedAsync_KnownTag_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -256,7 +256,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task RequirementIsReadyToBePreservedAsync_KnownTag_ReturnsTrue()
+        public async Task RequirementIsReadyToBePreservedAsync_KnownTag_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -269,7 +269,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task RequirementIsReadyToBePreservedAsync_KnownTag_ReturnsTrue_WhenStartedInSeparateContext()
+        public async Task RequirementIsReadyToBePreservedAsync_KnownTag_ShouldReturnTrue_WhenStartedInSeparateContext()
         {
             int reqId;
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
@@ -288,7 +288,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task HasRequirementWithActivePeriodAsync_KnownTag_ReturnsTrue()
+        public async Task HasRequirementWithActivePeriodAsync_KnownTag_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -301,7 +301,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task HasRequirementAsync_KnownTag_ReturnsTrue()
+        public async Task HasRequirementAsync_KnownTag_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -314,7 +314,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task HasRequirementAsync_UnknownTag_ReturnsTrue()
+        public async Task HasRequirementAsync_UnknownTag_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -327,7 +327,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task HasRequirementAsync_UnknownReq_ReturnsTrue()
+        public async Task HasRequirementAsync_UnknownReq_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -338,7 +338,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
         
         [TestMethod]
-        public async Task IsReadyToBeTransferredAsync_StandardTagNotStarted_ReturnsFalse()
+        public async Task IsReadyToBeTransferredAsync_StandardTagNotStarted_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -349,7 +349,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsReadyToBeTransferredAsync_StandardTagInLastStep_ReturnsFalse()
+        public async Task IsReadyToBeTransferredAsync_StandardTagInLastStep_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -360,7 +360,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsReadyToBeTransferredAsync_PreAreaTagNotStarted_ReturnsFalse()
+        public async Task IsReadyToBeTransferredAsync_PreAreaTagNotStarted_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -371,7 +371,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsReadyToBeTransferredAsync_PreAreaTagInFirstStep_ReturnsTrue()
+        public async Task IsReadyToBeTransferredAsync_PreAreaTagInFirstStep_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -415,7 +415,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
  
         [TestMethod]
-        public async Task IsReadyToBeCompletedAsync_StandardTagNotStarted_ReturnsFalse()
+        public async Task IsReadyToBeCompletedAsync_StandardTagNotStarted_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -426,7 +426,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsReadyToBeCompletedAsync_StandardTagInLastStep_ReturnsTrue()
+        public async Task IsReadyToBeCompletedAsync_StandardTagInLastStep_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -437,7 +437,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsReadyToBeCompletedAsync_PreAreaTagNotStarted_ReturnsFalse()
+        public async Task IsReadyToBeCompletedAsync_PreAreaTagNotStarted_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -448,7 +448,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsReadyToBeCompletedAsync_PreAreaTagInFirstStep_ReturnsFalse()
+        public async Task IsReadyToBeCompletedAsync_PreAreaTagInFirstStep_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -459,7 +459,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsReadyToBeCompletedAsync_SiteAreaTagInAnyStep_ReturnsTrue()
+        public async Task IsReadyToBeCompletedAsync_SiteAreaTagInAnyStep_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -470,7 +470,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsReadyToBeCompletedAsync_PoAreaTagInAnyStep_ReturnsTrue()
+        public async Task IsReadyToBeCompletedAsync_PoAreaTagInAnyStep_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -481,7 +481,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsReadyToBeCompletedAsync_UnknownTag_ReturnsFalse()
+        public async Task IsReadyToBeCompletedAsync_UnknownTag_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -492,7 +492,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
  
         [TestMethod]
-        public async Task IsReadyToBeStartedAsync_StandardTagNotStarted_ReturnsTrue()
+        public async Task IsReadyToBeStartedAsync_StandardTagNotStarted_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -503,7 +503,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsReadyToBeStartedAsync_StandardTagAlreadyStarted_ReturnsFalse()
+        public async Task IsReadyToBeStartedAsync_StandardTagAlreadyStarted_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -514,7 +514,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsReadyToBeStartedAsync_PreAreaTagNotStarted_ReturnsTrue()
+        public async Task IsReadyToBeStartedAsync_PreAreaTagNotStarted_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -525,7 +525,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsReadyToBeStartedAsync_PreAreaTagAlreadyStarted_ReturnsFalse()
+        public async Task IsReadyToBeStartedAsync_PreAreaTagAlreadyStarted_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -536,7 +536,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsReadyToBeStartedAsync_SiteAreaTagNotStarted_ReturnsTrue()
+        public async Task IsReadyToBeStartedAsync_SiteAreaTagNotStarted_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -547,7 +547,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsReadyToBeStartedAsync_SiteAreaTagAlreadyStarted_ReturnsFalse()
+        public async Task IsReadyToBeStartedAsync_SiteAreaTagAlreadyStarted_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -558,7 +558,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsReadyToBeStartedAsync_PoAreaTagNotStarted_ReturnsTrue()
+        public async Task IsReadyToBeStartedAsync_PoAreaTagNotStarted_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -569,7 +569,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsReadyToBeStartedAsync_PoAreaTagAlreadyStarted_ReturnsFalse()
+        public async Task IsReadyToBeStartedAsync_PoAreaTagAlreadyStarted_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -580,7 +580,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsReadyToBeStartedAsync_UnknownTag_ReturnsFalse()
+        public async Task IsReadyToBeStartedAsync_UnknownTag_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -591,7 +591,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task AttachmentWithFilenameExistsAsync_UnknownTag_ReturnsFalse()
+        public async Task AttachmentWithFilenameExistsAsync_UnknownTag_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -602,7 +602,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task AttachmentWithFilenameExistsAsync_UnknownFilename_ReturnsFalse()
+        public async Task AttachmentWithFilenameExistsAsync_UnknownFilename_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -613,7 +613,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task AttachmentWithFilenameExistsAsync_KnownFilename_ReturnsTrue()
+        public async Task AttachmentWithFilenameExistsAsync_KnownFilename_ShouldReturnTrue()
         {
             var fileName = "A.txt";
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
@@ -765,7 +765,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsInUseAsync_StatusActive_ReturnsTrue()
+        public async Task IsInUseAsync_StatusActive_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -782,7 +782,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsInUseAsync_StatusCompleted_ReturnsTrue()
+        public async Task IsInUseAsync_StatusCompleted_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -799,7 +799,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsInUseAsync_HasAction_ReturnsTrue()
+        public async Task IsInUseAsync_HasAction_ShouldReturnTrue()
         {
             var dueTimeUtc = new DateTime(2020, 1, 1, 1, 1, 1, DateTimeKind.Utc);
 
@@ -823,7 +823,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsInUseAsync_HasAttachment_ReturnsTrue()
+        public async Task IsInUseAsync_HasAttachment_ShouldReturnTrue()
         {
             var fileName = "A.txt";
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
@@ -846,7 +846,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsInUseAsync_NotInUse_ReturnsFalse()
+        public async Task IsInUseAsync_NotInUse_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -862,7 +862,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task IsInUseAsync_UnknownTag_ReturnsFalse()
+        public async Task IsInUseAsync_UnknownTag_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Infrastructure.Tests/Repositories/JourneyRepositoryTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Infrastructure.Tests/Repositories/JourneyRepositoryTests.cs
@@ -55,7 +55,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.Tests.Repositories
         }
 
         [TestMethod]
-        public async Task GetStepByStepId_KnownId_ReturnsStep()
+        public async Task GetStepByStepId_KnownId_ShouldReturnStep()
         {
             var result = await _dut.GetStepByStepIdAsync(StepId);
 
@@ -63,7 +63,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.Tests.Repositories
         }
 
         [TestMethod]
-        public async Task GetStepByStepId_UnknownId_ReturnsNull()
+        public async Task GetStepByStepId_UnknownId_ShouldReturnNull()
         {
             var result = await _dut.GetStepByStepIdAsync(99);
 

--- a/src/tests/Equinor.Procosys.Preservation.Infrastructure.Tests/Repositories/ProjectRepositoryTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Infrastructure.Tests/Repositories/ProjectRepositoryTests.cs
@@ -69,7 +69,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.Tests.Repositories
         }
 
         [TestMethod]
-        public async Task GetTagByTagId_ReturnsTag()
+        public async Task GetTagByTagId_ShouldReturnTag()
         {
             var result = await _dut.GetTagByTagIdAsync(TestTagId);
 
@@ -77,7 +77,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.Tests.Repositories
         }
 
         [TestMethod]
-        public async Task GetTagByTagIds_ReturnsTag()
+        public async Task GetTagByTagIds_ShouldReturnTag()
         {
             var result = await _dut.GetTagsByTagIdsAsync(new List<int>{ TestTagId });
 

--- a/src/tests/Equinor.Procosys.Preservation.Infrastructure.Tests/Repositories/ResponsibleRepositoryTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Infrastructure.Tests/Repositories/ResponsibleRepositoryTests.cs
@@ -34,7 +34,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.Tests.Repositories
         }
 
         [TestMethod]
-        public async Task GetByCode_ReturnsResponsible_WhenResponsibleExists()
+        public async Task GetByCode_ShouldReturnResponsible_WhenResponsibleExists()
         {
             var result = await _dut.GetByCodeAsync(ResponsibleCode);
 
@@ -43,7 +43,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.Tests.Repositories
         }
 
         [TestMethod]
-        public async Task GetByCode_ReturnsNull_WhenResponsibleNotExists()
+        public async Task GetByCode_ShouldReturnNull_WhenResponsibleNotExists()
         {
             var result = await _dut.GetByCodeAsync("XYZ");
 

--- a/src/tests/Equinor.Procosys.Preservation.Infrastructure.Tests/Repositories/SettingRepositoryTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Infrastructure.Tests/Repositories/SettingRepositoryTests.cs
@@ -32,7 +32,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.Tests.Repositories
         }
 
         [TestMethod]
-        public async Task GetByCode_ReturnsSetting_WhenSettingExists()
+        public async Task GetByCode_ShouldReturnSetting_WhenSettingExists()
         {
             var result = await _dut.GetByCodeAsync(_settingCode);
 
@@ -41,7 +41,7 @@ namespace Equinor.Procosys.Preservation.Infrastructure.Tests.Repositories
         }
 
         [TestMethod]
-        public async Task GetByCode_ReturnsNull_WhenSettingNotExists()
+        public async Task GetByCode_ShouldReturnNull_WhenSettingNotExists()
         {
             var result = await _dut.GetByCodeAsync("XYZ");
 

--- a/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Area/MainApiAreaServiceTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Area/MainApiAreaServiceTests.cs
@@ -47,7 +47,7 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Area
             => await Assert.ThrowsExceptionAsync<ArgumentException>(async () => await _dut.TryGetAreaAsync("INVALIDPLANT", "C"));
 
         [TestMethod]
-        public async Task TryGetAreaCode_ReturnsAreaCode()
+        public async Task TryGetAreaCode_ShouldReturnAreaCode()
         {
             // Arrange
             _mainApiClient

--- a/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Client/BearerTokenApiClientTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Client/BearerTokenApiClientTests.cs
@@ -23,7 +23,7 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Client
         }
 
         [TestMethod]
-        public async Task QueryAndDeserialize_ReturnsDeserialized_Object_TestAsync()
+        public async Task QueryAndDeserialize_ShouldReturnDeserialized_Object_TestAsync()
         {
             var httpClientFactory = HttpHelper.GetHttpClientFactory(HttpStatusCode.OK, "{\"Id\": 123}");
             var dut = new BearerTokenApiClient(httpClientFactory, _bearerTokenProvider.Object, _logger.Object);

--- a/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Permission/MainApiPermissionServiceTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Permission/MainApiPermissionServiceTests.cs
@@ -29,7 +29,7 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Permission
         }
 
         [TestMethod]
-        public async Task GetPermissions_ReturnsThreePermissions_OnValidPlant()
+        public async Task GetPermissions_ShouldReturnThreePermissions_OnValidPlant()
         {
             // Arrange
             _mainApiClient
@@ -43,7 +43,7 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Permission
         }
 
         [TestMethod]
-        public async Task GetPermissions_ReturnsNoPermissions_OnValidPlant()
+        public async Task GetPermissions_ShouldReturnNoPermissions_OnValidPlant()
         {
             // Arrange
             _mainApiClient
@@ -57,7 +57,7 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Permission
         }
 
         [TestMethod]
-        public async Task GetPermissions_ReturnsNoPermissions_OnInValidPlant()
+        public async Task GetPermissions_ShouldReturnNoPermissions_OnInValidPlant()
         {
             // Act
             var result = await _dut.GetPermissionsAsync("INVALIDPLANT");
@@ -67,7 +67,7 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Permission
         }
 
         [TestMethod]
-        public async Task GetContentRestrictions_ReturnsThreePermissions_OnValidPlant()
+        public async Task GetContentRestrictions_ShouldReturnThreePermissions_OnValidPlant()
         {
             // Arrange
             _mainApiClient
@@ -81,7 +81,7 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Permission
         }
 
         [TestMethod]
-        public async Task GetContentRestrictions_ReturnsNoPermissions_OnValidPlant()
+        public async Task GetContentRestrictions_ShouldReturnNoPermissions_OnValidPlant()
         {
             // Arrange
             _mainApiClient
@@ -95,7 +95,7 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Permission
         }
 
         [TestMethod]
-        public async Task GetContentRestrictions_ReturnsNoPermissions_OnInValidPlant()
+        public async Task GetContentRestrictions_ShouldReturnNoPermissions_OnInValidPlant()
         {
             // Act
             var result = await _dut.GetContentRestrictionsAsync("INVALIDPLANT");

--- a/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Project/MainApiProjectServiceTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Project/MainApiProjectServiceTests.cs
@@ -38,7 +38,7 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Project
         }
 
         [TestMethod]
-        public async Task TryGetProject_ReturnsProject()
+        public async Task TryGetProject_ShouldReturnProject()
         {
             // Arrange
             _mainApiClient

--- a/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Responsible/MainApiResponsibleServiceTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Responsible/MainApiResponsibleServiceTests.cs
@@ -38,7 +38,7 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Responsible
             => await Assert.ThrowsExceptionAsync<ArgumentException>(async () => await _dut.TryGetResponsibleAsync("INVALIDPLANT", "C"));
 
         [TestMethod]
-        public async Task TryGetResponsibleCode_ReturnsResponsibleCode()
+        public async Task TryGetResponsibleCode_ShouldReturnResponsibleCode()
         {
             // Arrange
             var procosysResponsible = new ProcosysResponsible

--- a/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Tag/MainApiTagServiceTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Tag/MainApiTagServiceTests.cs
@@ -188,7 +188,7 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Tag
                 await _dut.GetTagDetailsAsync("INVALIDPLANT", "TestProject", new List<string> {"TagNo1"}));
 
         [TestMethod]
-        public async Task GetTagDetails_ReturnsEmptyList_WhenResultIsEmptyList()
+        public async Task GetTagDetails_ShouldReturnEmptyList_WhenResultIsEmptyList()
         {
             // Arrange
             _mainApiClient

--- a/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/TagFunction/MainApiTagFunctionServiceTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/TagFunction/MainApiTagFunctionServiceTests.cs
@@ -47,7 +47,7 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.TagFunction
         }
 
         [TestMethod]
-        public async Task TryGetTagFunction_ReturnsTagFunction()
+        public async Task TryGetTagFunction_ShouldReturnTagFunction()
         {
             // Arrange
             _mainApiClient

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetActionAttachment/GetActionAttachmentQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetActionAttachment/GetActionAttachmentQueryHandlerTests.cs
@@ -69,7 +69,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetActionAttachment
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsAttachmentUri()
+        public async Task Handler_ShouldReturnAttachmentUri()
         {
             await using var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider);
 
@@ -84,7 +84,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetActionAttachment
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsNotFound_IfActionIsNotFound()
+        public async Task Handler_ShouldReturnNotFound_IfActionIsNotFound()
         {
             await using var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider);
 

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetActionAttachments/GetActionAttachmentsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetActionAttachments/GetActionAttachmentsQueryHandlerTests.cs
@@ -43,7 +43,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetActionAttachments
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsAttachments()
+        public async Task Handler_ShouldReturnAttachments()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -65,7 +65,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetActionAttachments
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsNotFound_IfTagIsNotFound()
+        public async Task Handler_ShouldReturnNotFound_IfTagIsNotFound()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -81,7 +81,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetActionAttachments
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsNotFound_IfActionIsNotFound()
+        public async Task Handler_ShouldReturnNotFound_IfActionIsNotFound()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetActionDetails/GetActionDetailsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetActionDetails/GetActionDetailsQueryHandlerTests.cs
@@ -50,7 +50,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetActionDetails
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsClosedAction()
+        public async Task Handler_ShouldReturnClosedAction()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -70,7 +70,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetActionDetails
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsModifiedAction()
+        public async Task Handler_ShouldReturnModifiedAction()
         {
             DateTime? modifiedTime;
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
@@ -99,7 +99,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetActionDetails
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsOpenAction()
+        public async Task Handler_ShouldReturnOpenAction()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -118,7 +118,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetActionDetails
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsNotFound_IfTagIsNotFound()
+        public async Task Handler_ShouldReturnNotFound_IfTagIsNotFound()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -134,7 +134,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetActionDetails
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsNotFound_IfActionIsNotFound()
+        public async Task Handler_ShouldReturnNotFound_IfActionIsNotFound()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetActions/GetActionsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetActions/GetActionsQueryHandlerTests.cs
@@ -83,7 +83,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetActions
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsActions()
+        public async Task Handler_ShouldReturnActions()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -104,7 +104,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetActions
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsNotFound_IfTagIsNotFound()
+        public async Task Handler_ShouldReturnNotFound_IfTagIsNotFound()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -120,7 +120,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetActions
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsActionsInCorrectOrder()
+        public async Task Handler_ShouldReturnActionsInCorrectOrder()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher,
                 _currentUserProvider))

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetFieldValueAttachment/GetFieldValueAttachmentQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetFieldValueAttachment/GetFieldValueAttachmentQueryHandlerTests.cs
@@ -81,7 +81,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetFieldValueAttachment
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsAttachmentUri()
+        public async Task Handler_ShouldReturnAttachmentUri()
         {
             await using var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider);
 
@@ -97,7 +97,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetFieldValueAttachment
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsNotFound_IfTagIsNotFound()
+        public async Task Handler_ShouldReturnNotFound_IfTagIsNotFound()
         {
             await using var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider);
 

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetHistoricalFieldValueAttachment/GetHistoricalFieldValueAttachmentQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetHistoricalFieldValueAttachment/GetHistoricalFieldValueAttachmentQueryHandlerTests.cs
@@ -125,7 +125,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetHistoricalFieldValueAttac
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsAttachmentUri()
+        public async Task Handler_ShouldReturnAttachmentUri()
         {
             await using var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider);
 
@@ -174,7 +174,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetHistoricalFieldValueAttac
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsNotFound_IfTagIsNotFound()
+        public async Task Handler_ShouldReturnNotFound_IfTagIsNotFound()
         {
             await using var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider);
 

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetProjectDetails/GetProjectDetailsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetProjectDetails/GetProjectDetailsQueryHandlerTests.cs
@@ -23,7 +23,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetProjectDetails
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsProjectDetails()
+        public async Task Handler_ShouldReturnProjectDetails()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -43,7 +43,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetProjectDetails
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsNotFound_IfProjectIsNotFound()
+        public async Task Handler_ShouldReturnNotFound_IfProjectIsNotFound()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagAttachment/GetTagAttachmentQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagAttachment/GetTagAttachmentQueryHandlerTests.cs
@@ -62,7 +62,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagAttachment
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsAttachmentUri()
+        public async Task Handler_ShouldReturnAttachmentUri()
         {
             await using var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider);
 
@@ -78,7 +78,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagAttachment
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsNotFound_IfTagIsNotFound()
+        public async Task Handler_ShouldReturnNotFound_IfTagIsNotFound()
         {
             await using var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider);
 

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagAttachments/GetTagAttachmentsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagAttachments/GetTagAttachmentsQueryHandlerTests.cs
@@ -36,7 +36,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagAttachments
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsAttachments()
+        public async Task Handler_ShouldReturnAttachments()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -58,7 +58,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagAttachments
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsNotFound_IfTagIsNotFound()
+        public async Task Handler_ShouldReturnNotFound_IfTagIsNotFound()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagDetails/GetTagDetailsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagDetails/GetTagDetailsQueryHandlerTests.cs
@@ -30,7 +30,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagDetails
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsTagDetails()
+        public async Task Handler_ShouldReturnTagDetails()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -68,7 +68,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagDetails
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsNotFound_IfTagIsNotFound()
+        public async Task Handler_ShouldReturnNotFound_IfTagIsNotFound()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagRequirements/GetTagRequirementsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagRequirements/GetTagRequirementsQueryHandlerTests.cs
@@ -484,7 +484,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagRequirements
         }
 
         [TestMethod]
-        public async Task Handler_ReturnsNotFound_IfTagIsNotFound()
+        public async Task Handler_ShouldReturnNotFound_IfTagIsNotFound()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProviderMock.Object, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/TagApiQueries/SearchTags/SearchTagsByTagFunctionQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/TagApiQueries/SearchTags/SearchTagsByTagFunctionQueryHandlerTests.cs
@@ -85,7 +85,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.TagApiQueries.SearchTags
         }
 
         [TestMethod]
-        public async Task Handle_ReturnsOkResult()
+        public async Task Handle_ShouldReturnOkResult()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -97,7 +97,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.TagApiQueries.SearchTags
         }
 
         [TestMethod]
-        public async Task Handle_ReturnsNotFound_WhenNoTagFunctionWithRequirement()
+        public async Task Handle_ShouldReturnNotFound_WhenNoTagFunctionWithRequirement()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -117,7 +117,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.TagApiQueries.SearchTags
         }
         
         [TestMethod]
-        public async Task Handle_ReturnsNotFound_WhenNoTagFunctionWithRequirement_BecauseOfVoidedTagFunction()
+        public async Task Handle_ShouldReturnNotFound_WhenNoTagFunctionWithRequirement_BecauseOfVoidedTagFunction()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -136,7 +136,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.TagApiQueries.SearchTags
         }
 
         [TestMethod]
-        public async Task Handle_ReturnsCorrectItems()
+        public async Task Handle_ShouldReturnCorrectItems()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -168,7 +168,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.TagApiQueries.SearchTags
         }
 
         [TestMethod]
-        public async Task Handle_ReturnsEmptyList_WhenTagApiReturnsNull()
+        public async Task Handle_ShouldReturnEmptyList_WhenTagApiReturnsNull()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -185,7 +185,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.TagApiQueries.SearchTags
         }
 
         [TestMethod]
-        public async Task Handle_ReturnsApiTags_WhenProjectRepositoryReturnsNull()
+        public async Task Handle_ShouldReturnApiTags_WhenProjectRepositoryReturnsNull()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/TagApiQueries/SearchTags/SearchTagsByTagNoQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/TagApiQueries/SearchTags/SearchTagsByTagNoQueryHandlerTests.cs
@@ -74,7 +74,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.TagApiQueries.SearchTags
         }
 
         [TestMethod]
-        public async Task Handle_ReturnsOkResult()
+        public async Task Handle_ShouldReturnOkResult()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -86,7 +86,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.TagApiQueries.SearchTags
         }
 
         [TestMethod]
-        public async Task Handle_ReturnsCorrectItems()
+        public async Task Handle_ShouldReturnCorrectItems()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -118,7 +118,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.TagApiQueries.SearchTags
         }
 
         [TestMethod]
-        public async Task Handle_ReturnsEmptyList_WhenTagApiReturnsNull()
+        public async Task Handle_ShouldReturnEmptyList_WhenTagApiReturnsNull()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
@@ -135,7 +135,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.TagApiQueries.SearchTags
         }
 
         [TestMethod]
-        public async Task Handle_ReturnsApiTags_WhenProjectRepositoryReturnsNull()
+        public async Task Handle_ShouldReturnApiTags_WhenProjectRepositoryReturnsNull()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Controllers/Tags/TagSearchControllerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Controllers/Tags/TagSearchControllerTests.cs
@@ -71,7 +71,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Tests.Controllers.Tags
         }
 
         [TestMethod]
-        public async Task SearchTags_ReturnsCorrectNumberOfElements()
+        public async Task SearchTags_ShouldReturnCorrectNumberOfElements()
         {
             _mediatorMock
                 .Setup(x => x.Send(It.IsAny<SearchTagsByTagNoQuery>(), It.IsAny<CancellationToken>()))

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Misc/CurrentUserProviderTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Misc/CurrentUserProviderTests.cs
@@ -8,7 +8,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Tests.Misc
     public class CurrentUserProviderTests
     {
         [TestMethod]
-        public void GetCurrentUserOid_ReturnsOid_WhenOidExists()
+        public void GetCurrentUserOid_ShouldReturnOid_WhenOidExists()
         {
             var okOid = new Guid("7DFC890F-F82B-4E2D-B81B-41D6C103F83B");
             var dut = new CurrentUserProvider();


### PR DESCRIPTION
After upgrading to latest NuGet pkg of FluentValidation, CascadeMode.StopOnFirstFailure is obsolete. Use CascadeMode.Stop instead.

The behavior is also changed, therefore unit tests failed. However, new behavior is how we want it: Fail on first failure even if a validator have many rules
https://docs.fluentvalidation.net/en/latest/conditions.html#stop-vs-stoponfirstfailure

(also replaced spelling error in unit test method names)