### PR TITLE
75233 - Unknown Error when uploading large files

### DIFF
--- a/src/Equinor.Procosys.Preservation.WebApi/Program.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Program.cs
@@ -26,7 +26,11 @@ namespace Equinor.Procosys.Preservation.WebApi
                 })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
-                    webBuilder.UseKestrel(options => options.AddServerHeader = false);
+                    webBuilder.UseKestrel(options =>
+                    {
+                        options.AddServerHeader = false;
+                        options.Limits.MaxRequestBodySize = null;
+                    });
                     webBuilder.UseStartup<Startup>();
                 });
     }


### PR DESCRIPTION
Before fix, application throw exception (413 request entity too large) before our endpoint is reached and the response caused CORS error in client (Therefore "Unknown error")
The new codeline turn off the verification of request body size and we can verify uploaded file our self. We check for valid file type + filesize < 100Mb

limit seemed to be approx 20-30Mb in localhost, only 1Mb Dev and Test 

