### PR TITLE
Handling users without firstname and lastname

### DIFF
--- a/src/Equinor.Procosys.Preservation.WebApi/Authorizations/ClaimsExtensions.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Authorizations/ClaimsExtensions.cs
@@ -10,6 +10,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Authorizations
         public const string OidType = "http://schemas.microsoft.com/identity/claims/objectidentifier";
         public const string GivenNameType = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname";
         public const string SurNameType = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname";
+        public const string FullName = "name";
 
         public static Guid? TryGetOid(this IEnumerable<Claim> claims)
         {
@@ -34,6 +35,13 @@ namespace Equinor.Procosys.Preservation.WebApi.Authorizations
             var surName = claims.SingleOrDefault(c => c.Type == SurNameType);
 
             return surName?.Value;
+        }
+
+        public static string TryGetFullName(this IEnumerable<Claim> claims)
+        {
+            var fullName = claims.SingleOrDefault(c => c.Type == FullName);
+
+            return fullName?.Value;
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.WebApi/Middleware/VerifyOidInDbMiddleware.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Middleware/VerifyOidInDbMiddleware.cs
@@ -27,6 +27,15 @@ namespace Equinor.Procosys.Preservation.WebApi.Middleware
                 var givenName = httpContextUser.Claims.TryGetGivenName();
                 var surName = httpContextUser.Claims.TryGetSurName();
 
+                if (string.IsNullOrEmpty(givenName) && string.IsNullOrEmpty(surName))
+                {
+                    var fullName = httpContextUser.Claims.TryGetFullName();
+                    // Last name will be set to the last part of the name, regardless of any middle-name variants (best effort).
+                    var indexOfLastSpace = fullName.LastIndexOf(" ", StringComparison.InvariantCulture);
+                    givenName = fullName.Substring(0, indexOfLastSpace);
+                    surName = fullName.Substring(indexOfLastSpace + 1);
+                }
+
                 var command = new CreatePersonCommand(oid.Value, givenName, surName);
                 try
                 {

--- a/src/Equinor.Procosys.Preservation.WebApi/Middleware/VerifyOidInDbMiddleware.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Middleware/VerifyOidInDbMiddleware.cs
@@ -31,6 +31,11 @@ namespace Equinor.Procosys.Preservation.WebApi.Middleware
                 {
                     var fullName = httpContextUser.Claims.TryGetFullName();
 
+                    if (string.IsNullOrEmpty(fullName))
+                    {
+                        throw new Exception("Not able to resolve user info for " + oid);
+                    }
+
                     if (fullName.Contains(","))
                     {
                         // A naming error in Azure sometimes cause DisplayName to be formatted "Lastname, Firstname".


### PR DESCRIPTION
Doing the same "magic" as ad sync when handling affiliate user without first name and last name