### PR TITLE
Automatic update of 20 packages

### DIFF
--- a/src/Equinor.Procosys.Preservation.BlobStorage/Equinor.Procosys.Preservation.BlobStorage.csproj
+++ b/src/Equinor.Procosys.Preservation.BlobStorage/Equinor.Procosys.Preservation.BlobStorage.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.2.2" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.5.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.8" />
   </ItemGroup>
 

--- a/src/Equinor.Procosys.Preservation.BlobStorage/Equinor.Procosys.Preservation.BlobStorage.csproj
+++ b/src/Equinor.Procosys.Preservation.BlobStorage/Equinor.Procosys.Preservation.BlobStorage.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.2.2" />
+    <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.8" />
   </ItemGroup>

--- a/src/Equinor.Procosys.Preservation.BlobStorage/Equinor.Procosys.Preservation.BlobStorage.csproj
+++ b/src/Equinor.Procosys.Preservation.BlobStorage/Equinor.Procosys.Preservation.BlobStorage.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.2.2" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.5.1" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.8" />
   </ItemGroup>
 
 </Project>

--- a/src/Equinor.Procosys.Preservation.Command/Equinor.Procosys.Preservation.Command.csproj
+++ b/src/Equinor.Procosys.Preservation.Command/Equinor.Procosys.Preservation.Command.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="9.1.2" />
     <PackageReference Include="MediatR" Version="8.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>

--- a/src/Equinor.Procosys.Preservation.Command/Equinor.Procosys.Preservation.Command.csproj
+++ b/src/Equinor.Procosys.Preservation.Command/Equinor.Procosys.Preservation.Command.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="9.1.2" />
+    <PackageReference Include="FluentValidation" Version="9.2.2" />
     <PackageReference Include="MediatR" Version="8.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Equinor.Procosys.Preservation.Infrastructure.csproj
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Equinor.Procosys.Preservation.Infrastructure.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Equinor.Procosys.Preservation.Infrastructure.csproj
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Equinor.Procosys.Preservation.Infrastructure.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Equinor.Procosys.Preservation.Infrastructure.csproj
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Equinor.Procosys.Preservation.Infrastructure.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.7">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Equinor.Procosys.Preservation.Infrastructure/Equinor.Procosys.Preservation.Infrastructure.csproj
+++ b/src/Equinor.Procosys.Preservation.Infrastructure/Equinor.Procosys.Preservation.Infrastructure.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.6" />
   </ItemGroup>
 

--- a/src/Equinor.Procosys.Preservation.MainApi/Equinor.Procosys.Preservation.MainApi.csproj
+++ b/src/Equinor.Procosys.Preservation.MainApi/Equinor.Procosys.Preservation.MainApi.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.8" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 

--- a/src/Equinor.Procosys.Preservation.MainApi/Equinor.Procosys.Preservation.MainApi.csproj
+++ b/src/Equinor.Procosys.Preservation.MainApi/Equinor.Procosys.Preservation.MainApi.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.8" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>

--- a/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
+++ b/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="4.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.15.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />

--- a/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
+++ b/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.15.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.7">

--- a/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
+++ b/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.95.3" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="9.1.2" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="9.2.0" />
     <PackageReference Include="MediatR" Version="8.1.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="4.0.0" />

--- a/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
+++ b/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="4.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.14.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.15.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.7" />

--- a/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
+++ b/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.15.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.7">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
+++ b/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />
     <PackageReference Include="ServiceResult.ApiExtensions" Version="1.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 

--- a/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
+++ b/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
+++ b/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
@@ -24,7 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.8" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.17.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />

--- a/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
+++ b/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="MediatR" Version="8.1.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="4.0.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.15.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="3.1.7" />

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Equinor.Procosys.Preservation.Command.Tests.csproj
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Equinor.Procosys.Preservation.Command.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="9.1.2" />
+    <PackageReference Include="FluentValidation" Version="9.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />

--- a/src/tests/Equinor.Procosys.Preservation.Infrastructure.Tests/Equinor.Procosys.Preservation.Infrastructure.Tests.csproj
+++ b/src/tests/Equinor.Procosys.Preservation.Infrastructure.Tests/Equinor.Procosys.Preservation.Infrastructure.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="MockQueryable.Moq" Version="3.1.3" />
     <PackageReference Include="Moq" Version="4.14.5" />

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/Equinor.Procosys.Preservation.Query.Tests.csproj
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/Equinor.Procosys.Preservation.Query.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />

--- a/src/tests/Equinor.Procosys.Preservation.Test.Common/Equinor.Procosys.Preservation.Test.Common.csproj
+++ b/src/tests/Equinor.Procosys.Preservation.Test.Common/Equinor.Procosys.Preservation.Test.Common.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />

--- a/src/tests/Equinor.Procosys.Preservation.Test.Common/Equinor.Procosys.Preservation.Test.Common.csproj
+++ b/src/tests/Equinor.Procosys.Preservation.Test.Common/Equinor.Procosys.Preservation.Test.Common.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
   </ItemGroup>


### PR DESCRIPTION
20 packages were updated in 9 projects:
`Microsoft.Extensions.Options`, `Microsoft.Extensions.Logging.Abstractions`, `Microsoft.Extensions.Caching.Memory`, `Microsoft.EntityFrameworkCore`, `Microsoft.EntityFrameworkCore.InMemory`, `FluentValidation`, `FluentValidation.AspNetCore`, `Azure.Storage.Blobs`, `Microsoft.ApplicationInsights.PerfCounterCollector`, `Microsoft.ApplicationInsights.AspNetCore`, `Microsoft.AspNetCore.Authentication.JwtBearer`, `Microsoft.AspNetCore.Authentication.MicrosoftAccount`, `Microsoft.AspNetCore.Authentication.OpenIdConnect`, `Microsoft.EntityFrameworkCore.Design`, `Microsoft.Extensions.Configuration.AzureKeyVault`, `Microsoft.EntityFrameworkCore.SqlServer`, `Microsoft.EntityFrameworkCore.Tools`, `Microsoft.Extensions.Http`, `Azure.Identity`, `Swashbuckle.AspNetCore`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a patch update of `Microsoft.Extensions.Options` to `3.1.8` from `3.1.7`
`Microsoft.Extensions.Options 3.1.8` was published at `2020-09-08T14:10:34Z`, 23 days ago

1 project update:
Updated `src/Equinor.Procosys.Preservation.BlobStorage/Equinor.Procosys.Preservation.BlobStorage.csproj` to `Microsoft.Extensions.Options` `3.1.8` from `3.1.7`

[Microsoft.Extensions.Options 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Options/3.1.8)

NuKeeper has generated a patch update of `Microsoft.Extensions.Logging.Abstractions` to `3.1.8` from `3.1.7`
`Microsoft.Extensions.Logging.Abstractions 3.1.8` was published at `2020-09-08T14:11:29Z`, 23 days ago

1 project update:
Updated `src/Equinor.Procosys.Preservation.MainApi/Equinor.Procosys.Preservation.MainApi.csproj` to `Microsoft.Extensions.Logging.Abstractions` `3.1.8` from `3.1.7`

[Microsoft.Extensions.Logging.Abstractions 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions/3.1.8)

NuKeeper has generated a patch update of `Microsoft.Extensions.Caching.Memory` to `3.1.8` from `3.1.7`
`Microsoft.Extensions.Caching.Memory 3.1.8` was published at `2020-09-08T14:10:30Z`, 23 days ago

1 project update:
Updated `src/Equinor.Procosys.Preservation.Infrastructure/Equinor.Procosys.Preservation.Infrastructure.csproj` to `Microsoft.Extensions.Caching.Memory` `3.1.8` from `3.1.7`

[Microsoft.Extensions.Caching.Memory 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Caching.Memory/3.1.8)

NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore` to `3.1.8` from `3.1.7`
`Microsoft.EntityFrameworkCore 3.1.8` was published at `2020-09-08T14:10:01Z`, 23 days ago

3 project updates:
Updated `src/Equinor.Procosys.Preservation.Command/Equinor.Procosys.Preservation.Command.csproj` to `Microsoft.EntityFrameworkCore` `3.1.8` from `3.1.7`
Updated `src/Equinor.Procosys.Preservation.Infrastructure/Equinor.Procosys.Preservation.Infrastructure.csproj` to `Microsoft.EntityFrameworkCore` `3.1.8` from `3.1.7`
Updated `src/tests/Equinor.Procosys.Preservation.Test.Common/Equinor.Procosys.Preservation.Test.Common.csproj` to `Microsoft.EntityFrameworkCore` `3.1.8` from `3.1.7`

[Microsoft.EntityFrameworkCore 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/3.1.8)

NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore.InMemory` to `3.1.8` from `3.1.7`
`Microsoft.EntityFrameworkCore.InMemory 3.1.8` was published at `2020-09-08T14:09:46Z`, 23 days ago

3 project updates:
Updated `src/tests/Equinor.Procosys.Preservation.Test.Common/Equinor.Procosys.Preservation.Test.Common.csproj` to `Microsoft.EntityFrameworkCore.InMemory` `3.1.8` from `3.1.7`
Updated `src/tests/Equinor.Procosys.Preservation.Infrastructure.Tests/Equinor.Procosys.Preservation.Infrastructure.Tests.csproj` to `Microsoft.EntityFrameworkCore.InMemory` `3.1.8` from `3.1.7`
Updated `src/tests/Equinor.Procosys.Preservation.Query.Tests/Equinor.Procosys.Preservation.Query.Tests.csproj` to `Microsoft.EntityFrameworkCore.InMemory` `3.1.8` from `3.1.7`

[Microsoft.EntityFrameworkCore.InMemory 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.InMemory/3.1.8)

NuKeeper has generated a minor update of `FluentValidation` to `9.2.2` from `9.1.2`
`FluentValidation 9.2.2` was published at `2020-09-20T13:06:53Z`, 11 days ago

2 project updates:
Updated `src/Equinor.Procosys.Preservation.Command/Equinor.Procosys.Preservation.Command.csproj` to `FluentValidation` `9.2.2` from `9.1.2`
Updated `src/tests/Equinor.Procosys.Preservation.Command.Tests/Equinor.Procosys.Preservation.Command.Tests.csproj` to `FluentValidation` `9.2.2` from `9.1.2`

[FluentValidation 9.2.2 on NuGet.org](https://www.nuget.org/packages/FluentValidation/9.2.2)

NuKeeper has generated a minor update of `FluentValidation.AspNetCore` to `9.2.0` from `9.1.2`
`FluentValidation.AspNetCore 9.2.0` was published at `2020-08-26T09:13:59Z`, 2 months ago

1 project update:
Updated `src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj` to `FluentValidation.AspNetCore` `9.2.0` from `9.1.2`

[FluentValidation.AspNetCore 9.2.0 on NuGet.org](https://www.nuget.org/packages/FluentValidation.AspNetCore/9.2.0)

NuKeeper has generated a minor update of `Azure.Storage.Blobs` to `12.6.0` from `12.5.1`
`Azure.Storage.Blobs 12.6.0` was published at `2020-08-31T23:12:09Z`, 2 months ago

1 project update:
Updated `src/Equinor.Procosys.Preservation.BlobStorage/Equinor.Procosys.Preservation.BlobStorage.csproj` to `Azure.Storage.Blobs` `12.6.0` from `12.5.1`

[Azure.Storage.Blobs 12.6.0 on NuGet.org](https://www.nuget.org/packages/Azure.Storage.Blobs/12.6.0)

NuKeeper has generated a minor update of `Microsoft.ApplicationInsights.PerfCounterCollector` to `2.15.0` from `2.14.0`
`Microsoft.ApplicationInsights.PerfCounterCollector 2.15.0` was published at `2020-09-15T22:24:11Z`, 16 days ago

1 project update:
Updated `src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj` to `Microsoft.ApplicationInsights.PerfCounterCollector` `2.15.0` from `2.14.0`

[Microsoft.ApplicationInsights.PerfCounterCollector 2.15.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.ApplicationInsights.PerfCounterCollector/2.15.0)

NuKeeper has generated a minor update of `Microsoft.ApplicationInsights.AspNetCore` to `2.15.0` from `2.14.0`
`Microsoft.ApplicationInsights.AspNetCore 2.15.0` was published at `2020-09-15T22:23:56Z`, 16 days ago

1 project update:
Updated `src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj` to `Microsoft.ApplicationInsights.AspNetCore` `2.15.0` from `2.14.0`

[Microsoft.ApplicationInsights.AspNetCore 2.15.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.ApplicationInsights.AspNetCore/2.15.0)

NuKeeper has generated a patch update of `Microsoft.AspNetCore.Authentication.JwtBearer` to `3.1.8` from `3.1.7`
`Microsoft.AspNetCore.Authentication.JwtBearer 3.1.8` was published at `2020-09-08T14:09:20Z`, 23 days ago

1 project update:
Updated `src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj` to `Microsoft.AspNetCore.Authentication.JwtBearer` `3.1.8` from `3.1.7`

[Microsoft.AspNetCore.Authentication.JwtBearer 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.JwtBearer/3.1.8)

NuKeeper has generated a patch update of `Microsoft.AspNetCore.Authentication.MicrosoftAccount` to `3.1.8` from `3.1.7`
`Microsoft.AspNetCore.Authentication.MicrosoftAccount 3.1.8` was published at `2020-09-08T14:09:01Z`, 23 days ago

1 project update:
Updated `src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj` to `Microsoft.AspNetCore.Authentication.MicrosoftAccount` `3.1.8` from `3.1.7`

[Microsoft.AspNetCore.Authentication.MicrosoftAccount 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.MicrosoftAccount/3.1.8)

NuKeeper has generated a patch update of `Microsoft.AspNetCore.Authentication.OpenIdConnect` to `3.1.8` from `3.1.7`
`Microsoft.AspNetCore.Authentication.OpenIdConnect 3.1.8` was published at `2020-09-08T14:09:26Z`, 23 days ago

1 project update:
Updated `src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj` to `Microsoft.AspNetCore.Authentication.OpenIdConnect` `3.1.8` from `3.1.7`

[Microsoft.AspNetCore.Authentication.OpenIdConnect 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.OpenIdConnect/3.1.8)

NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore.Design` to `3.1.8` from `3.1.7`
`Microsoft.EntityFrameworkCore.Design 3.1.8` was published at `2020-09-08T14:09:55Z`, 23 days ago

1 project update:
Updated `src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj` to `Microsoft.EntityFrameworkCore.Design` `3.1.8` from `3.1.7`

[Microsoft.EntityFrameworkCore.Design 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Design/3.1.8)

NuKeeper has generated a patch update of `Microsoft.Extensions.Configuration.AzureKeyVault` to `3.1.8` from `3.1.7`
`Microsoft.Extensions.Configuration.AzureKeyVault 3.1.8` was published at `2020-09-08T14:10:59Z`, 23 days ago

1 project update:
Updated `src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj` to `Microsoft.Extensions.Configuration.AzureKeyVault` `3.1.8` from `3.1.7`

[Microsoft.Extensions.Configuration.AzureKeyVault 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.AzureKeyVault/3.1.8)

NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore.SqlServer` to `3.1.8` from `3.1.7`
`Microsoft.EntityFrameworkCore.SqlServer 3.1.8` was published at `2020-09-08T14:09:52Z`, 23 days ago

1 project update:
Updated `src/Equinor.Procosys.Preservation.Infrastructure/Equinor.Procosys.Preservation.Infrastructure.csproj` to `Microsoft.EntityFrameworkCore.SqlServer` `3.1.8` from `3.1.7`

[Microsoft.EntityFrameworkCore.SqlServer 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.SqlServer/3.1.8)

NuKeeper has generated a patch update of `Microsoft.EntityFrameworkCore.Tools` to `3.1.8` from `3.1.7`
`Microsoft.EntityFrameworkCore.Tools 3.1.8` was published at `2020-09-08T14:10:07Z`, 23 days ago

1 project update:
Updated `src/Equinor.Procosys.Preservation.Infrastructure/Equinor.Procosys.Preservation.Infrastructure.csproj` to `Microsoft.EntityFrameworkCore.Tools` `3.1.8` from `3.1.7`

[Microsoft.EntityFrameworkCore.Tools 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Tools/3.1.8)

NuKeeper has generated a patch update of `Microsoft.Extensions.Http` to `3.1.8` from `3.1.7`
`Microsoft.Extensions.Http 3.1.8` was published at `2020-09-08T14:10:37Z`, 23 days ago

1 project update:
Updated `src/Equinor.Procosys.Preservation.MainApi/Equinor.Procosys.Preservation.MainApi.csproj` to `Microsoft.Extensions.Http` `3.1.8` from `3.1.7`

[Microsoft.Extensions.Http 3.1.8 on NuGet.org](https://www.nuget.org/packages/Microsoft.Extensions.Http/3.1.8)

NuKeeper has generated a patch update of `Azure.Identity` to `1.2.3` from `1.2.2`
`Azure.Identity 1.2.3` was published at `2020-09-11T17:01:15Z`, 20 days ago

1 project update:
Updated `src/Equinor.Procosys.Preservation.BlobStorage/Equinor.Procosys.Preservation.BlobStorage.csproj` to `Azure.Identity` `1.2.3` from `1.2.2`

[Azure.Identity 1.2.3 on NuGet.org](https://www.nuget.org/packages/Azure.Identity/1.2.3)

NuKeeper has generated a minor update of `Swashbuckle.AspNetCore` to `5.6.3` from `5.5.1`
`Swashbuckle.AspNetCore 5.6.3` was published at `2020-09-23T12:48:45Z`, 8 days ago

1 project update:
Updated `src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj` to `Swashbuckle.AspNetCore` `5.6.3` from `5.5.1`

[Swashbuckle.AspNetCore 5.6.3 on NuGet.org](https://www.nuget.org/packages/Swashbuckle.AspNetCore/5.6.3)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
