### PR TITLE
78680 use new plant features from main api

### DIFF
--- a/src/Equinor.Procosys.Preservation.Command/MiscCommands/Clone/CloneCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/MiscCommands/Clone/CloneCommandValidator.cs
@@ -14,17 +14,17 @@ namespace Equinor.Procosys.Preservation.Command.MiscCommands.Clone
             CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command.SourcePlant)
-                .MustAsync((_, sourcePlant, token) => BeAValidPlantAsync(sourcePlant.ToUpperInvariant()))
-                .WithMessage(command => $"Source plant is not valid! Plant={command.SourcePlant}");
+                .MustAsync((_, sourcePlant, token) => UserHaveAccessToPlantAsync(sourcePlant.ToUpperInvariant()))
+                .WithMessage(command => $"Source plant is not valid or access missing! Plant={command.SourcePlant}");
 
             RuleFor(command => command.TargetPlant)
-                .MustAsync((_, targetPlant, token) => BeAValidPlantAsync(targetPlant.ToUpperInvariant()))
-                .WithMessage(command => $"Target plant is not valid! Plant={command.TargetPlant}")
+                .MustAsync((_, targetPlant, token) => UserHaveAccessToPlantAsync(targetPlant.ToUpperInvariant()))
+                .WithMessage(command => $"Target plant is not valid or access missing! Plant={command.TargetPlant}")
                 .Must((_, targetPlant, token) => NotBeABasisPlant(targetPlant.ToUpperInvariant()))
                 .WithMessage(command => $"Target plant can not be a basis plant! Plant={command.TargetPlant}");
 
-            async Task<bool> BeAValidPlantAsync(string plantId)
-                => await plantCache.IsValidPlantForCurrentUserAsync(plantId);
+            async Task<bool> UserHaveAccessToPlantAsync(string plantId)
+                => await plantCache.HasCurrentUserAccessToPlantAsync(plantId);
             
             bool NotBeABasisPlant(string plantId) => !BasisPlants.Contains(plantId);
         }

--- a/src/Equinor.Procosys.Preservation.MainApi/Area/MainApiAreaService.cs
+++ b/src/Equinor.Procosys.Preservation.MainApi/Area/MainApiAreaService.cs
@@ -2,7 +2,6 @@
 using System.Net;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.MainApi.Client;
-using Equinor.Procosys.Preservation.MainApi.Plant;
 using Microsoft.Extensions.Options;
 
 namespace Equinor.Procosys.Preservation.MainApi.Area
@@ -12,25 +11,17 @@ namespace Equinor.Procosys.Preservation.MainApi.Area
         private readonly string _apiVersion;
         private readonly Uri _baseAddress;
         private readonly IBearerTokenApiClient _mainApiClient;
-        private readonly IPlantCache _plantCache;
 
         public MainApiAreaService(IBearerTokenApiClient mainApiClient,
-            IPlantCache plantCache,
             IOptionsMonitor<MainApiOptions> options)
         {
             _mainApiClient = mainApiClient;
-            _plantCache = plantCache;
             _apiVersion = options.CurrentValue.ApiVersion;
             _baseAddress = new Uri(options.CurrentValue.BaseAddress);
         }
 
         public async Task<ProcosysArea> TryGetAreaAsync(string plant, string code)
         {
-            if (!await _plantCache.IsValidPlantForCurrentUserAsync(plant))
-            {
-                throw new ArgumentException($"Invalid plant: {plant}");
-            }
-
             var url = $"{_baseAddress}Library/Area" +
                       $"?plantId={plant}" +
                       $"&code={WebUtility.UrlEncode(code)}" +

--- a/src/Equinor.Procosys.Preservation.MainApi/Certificate/MainApiCertificateService.cs
+++ b/src/Equinor.Procosys.Preservation.MainApi/Certificate/MainApiCertificateService.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.MainApi.Client;
-using Equinor.Procosys.Preservation.MainApi.Plant;
 using Microsoft.Extensions.Options;
 
 namespace Equinor.Procosys.Preservation.MainApi.Certificate
@@ -13,25 +12,17 @@ namespace Equinor.Procosys.Preservation.MainApi.Certificate
         private readonly string _apiVersion;
         private readonly Uri _baseAddress;
         private readonly IBearerTokenApiClient _mainApiClient;
-        private readonly IPlantCache _plantCache;
 
         public MainApiCertificateService(IBearerTokenApiClient mainApiClient,
-            IPlantCache plantCache,
             IOptionsMonitor<MainApiOptions> options)
         {
             _mainApiClient = mainApiClient;
-            _plantCache = plantCache;
             _apiVersion = options.CurrentValue.ApiVersion;
             _baseAddress = new Uri(options.CurrentValue.BaseAddress);
         }
 
         public async Task<ProcosysCertificateTagsModel> TryGetCertificateTagsAsync(string plant, string projectName, string certificateNo, string certificateType)
         {
-            if (!await _plantCache.IsValidPlantForCurrentUserAsync(plant))
-            {
-                throw new ArgumentException($"Invalid plant: {plant}");
-            }
-
             var url = $"{_baseAddress}Certificate/Tags" +
                       $"?plantId={plant}" +
                       $"&projectName={WebUtility.UrlEncode(projectName)}" +
@@ -44,11 +35,6 @@ namespace Equinor.Procosys.Preservation.MainApi.Certificate
 
         public async Task<IEnumerable<ProcosysCertificateModel>> GetAcceptedCertificatesAsync(string plant, DateTime cutoffAcceptedTime)
         {
-            if (!await _plantCache.IsValidPlantForCurrentUserAsync(plant))
-            {
-                throw new ArgumentException($"Invalid plant: {plant}");
-            }
-
             var url = $"{_baseAddress}Certificate/Accepted" +
                       $"?plantId={plant}" +
                       $"&cutoffAcceptedTime={cutoffAcceptedTime:O}" +

--- a/src/Equinor.Procosys.Preservation.MainApi/Discipline/MainApiDisciplineService.cs
+++ b/src/Equinor.Procosys.Preservation.MainApi/Discipline/MainApiDisciplineService.cs
@@ -2,9 +2,7 @@
 using System.Net;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.MainApi.Client;
-using Equinor.Procosys.Preservation.MainApi.Plant;
 using Microsoft.Extensions.Options;
-
 
 namespace Equinor.Procosys.Preservation.MainApi.Discipline
 {
@@ -13,25 +11,17 @@ namespace Equinor.Procosys.Preservation.MainApi.Discipline
         private readonly string _apiVersion;
         private readonly Uri _baseAddress;
         private readonly IBearerTokenApiClient _mainApiClient;
-        private readonly IPlantCache _plantCache;
 
         public MainApiDisciplineService(IBearerTokenApiClient mainApiClient,
-            IPlantCache plantCache,
             IOptionsMonitor<MainApiOptions> options)
         {
             _mainApiClient = mainApiClient;
-            _plantCache = plantCache;
             _apiVersion = options.CurrentValue.ApiVersion;
             _baseAddress = new Uri(options.CurrentValue.BaseAddress);
         }
 
         public async Task<ProcosysDiscipline> TryGetDisciplineAsync(string plant, string code)
         {
-            if (!await _plantCache.IsValidPlantForCurrentUserAsync(plant))
-            {
-                throw new ArgumentException($"Invalid plant: {plant}");
-            }
-
             var url = $"{_baseAddress}Library/Discipline" +
                       $"?plantId={plant}" +
                       $"&code={WebUtility.UrlEncode(code)}" +

--- a/src/Equinor.Procosys.Preservation.MainApi/Plant/IPlantApiService.cs
+++ b/src/Equinor.Procosys.Preservation.MainApi/Plant/IPlantApiService.cs
@@ -5,6 +5,6 @@ namespace Equinor.Procosys.Preservation.MainApi.Plant
 {
     public interface IPlantApiService
     {
-        Task<List<ProcosysPlant>> GetPlantsAsync();
+        Task<List<ProcosysPlant>> GetAllPlantsAsync();
     }
 }

--- a/src/Equinor.Procosys.Preservation.MainApi/Plant/IPlantCache.cs
+++ b/src/Equinor.Procosys.Preservation.MainApi/Plant/IPlantCache.cs
@@ -6,9 +6,10 @@ namespace Equinor.Procosys.Preservation.MainApi.Plant
 {
     public interface IPlantCache
     {
-        Task<IList<string>> GetPlantIdsForUserOidAsync(Guid userOid);
-        Task<bool> IsValidPlantForUserAsync(string plantId, Guid userOid);
-        Task<bool> IsValidPlantForCurrentUserAsync(string plantId);
+        Task<IList<string>> GetPlantWithAccessForUserAsync(Guid userOid);
+        Task<bool> HasUserAccessToPlantAsync(string plantId, Guid userOid);
+        Task<bool> HasCurrentUserAccessToPlantAsync(string plantId);
+        Task<bool> IsAValidPlant(string plantId);
         void Clear(Guid userOid);
     }
 }

--- a/src/Equinor.Procosys.Preservation.MainApi/Plant/IPlantCache.cs
+++ b/src/Equinor.Procosys.Preservation.MainApi/Plant/IPlantCache.cs
@@ -9,7 +9,7 @@ namespace Equinor.Procosys.Preservation.MainApi.Plant
         Task<IList<string>> GetPlantWithAccessForUserAsync(Guid userOid);
         Task<bool> HasUserAccessToPlantAsync(string plantId, Guid userOid);
         Task<bool> HasCurrentUserAccessToPlantAsync(string plantId);
-        Task<bool> IsAValidPlant(string plantId);
+        Task<bool> IsAValidPlantAsync(string plantId);
         void Clear(Guid userOid);
     }
 }

--- a/src/Equinor.Procosys.Preservation.MainApi/Plant/MainApiPlantService.cs
+++ b/src/Equinor.Procosys.Preservation.MainApi/Plant/MainApiPlantService.cs
@@ -21,9 +21,9 @@ namespace Equinor.Procosys.Preservation.MainApi.Plant
             _baseAddress = new Uri(options.CurrentValue.BaseAddress);
         }
 
-        public async Task<List<ProcosysPlant>> GetPlantsAsync()
+        public async Task<List<ProcosysPlant>> GetAllPlantsAsync()
         {
-            var url = $"{_baseAddress}Plants?api-version={_apiVersion}";
+            var url = $"{_baseAddress}Plants?includePlantsWithoutAccess=true&api-version={_apiVersion}";
             return await _mainApiClient.QueryAndDeserializeAsync<List<ProcosysPlant>>(url);
         }
     }

--- a/src/Equinor.Procosys.Preservation.MainApi/Plant/ProcosysPlant.cs
+++ b/src/Equinor.Procosys.Preservation.MainApi/Plant/ProcosysPlant.cs
@@ -2,10 +2,11 @@
 
 namespace Equinor.Procosys.Preservation.MainApi.Plant
 {
-    [DebuggerDisplay("{Title} ({Id})")]
+    [DebuggerDisplay("{Title} ({Id} {HasAccess)")]
     public class ProcosysPlant
     {
         public string Id { get; set; }
         public string Title { get; set; }
+        public bool HasAccess { get; set; }
     }
 }

--- a/src/Equinor.Procosys.Preservation.MainApi/Plant/ProcosysPlant.cs
+++ b/src/Equinor.Procosys.Preservation.MainApi/Plant/ProcosysPlant.cs
@@ -2,7 +2,7 @@
 
 namespace Equinor.Procosys.Preservation.MainApi.Plant
 {
-    [DebuggerDisplay("{Title} ({Id} {HasAccess)")]
+    [DebuggerDisplay("{Title} {Id} {HasAccess}")]
     public class ProcosysPlant
     {
         public string Id { get; set; }

--- a/src/Equinor.Procosys.Preservation.MainApi/Project/MainApiProjectService.cs
+++ b/src/Equinor.Procosys.Preservation.MainApi/Project/MainApiProjectService.cs
@@ -2,7 +2,6 @@
 using System.Net;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.MainApi.Client;
-using Equinor.Procosys.Preservation.MainApi.Plant;
 using Microsoft.Extensions.Options;
 
 namespace Equinor.Procosys.Preservation.MainApi.Project
@@ -12,25 +11,17 @@ namespace Equinor.Procosys.Preservation.MainApi.Project
         private readonly string _apiVersion;
         private readonly Uri _baseAddress;
         private readonly IBearerTokenApiClient _mainApiClient;
-        private readonly IPlantCache _plantCache;
 
         public MainApiProjectService(IBearerTokenApiClient mainApiClient,
-            IPlantCache plantCache,
             IOptionsMonitor<MainApiOptions> options)
         {
             _mainApiClient = mainApiClient;
-            _plantCache = plantCache;
             _apiVersion = options.CurrentValue.ApiVersion;
             _baseAddress = new Uri(options.CurrentValue.BaseAddress);
         }
 
         public async Task<ProcosysProject> TryGetProjectAsync(string plant, string name)
         {
-            if (!await _plantCache.IsValidPlantForCurrentUserAsync(plant))
-            {
-                throw new ArgumentException($"Invalid plant: {plant}");
-            }
-
             var url = $"{_baseAddress}ProjectByName" +
                 $"?plantId={plant}" +
                 $"&projectName={WebUtility.UrlEncode(name)}" +

--- a/src/Equinor.Procosys.Preservation.MainApi/Responsible/MainApiResposibleService.cs
+++ b/src/Equinor.Procosys.Preservation.MainApi/Responsible/MainApiResposibleService.cs
@@ -2,7 +2,6 @@
 using System.Net;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.MainApi.Client;
-using Equinor.Procosys.Preservation.MainApi.Plant;
 using Microsoft.Extensions.Options;
 
 namespace Equinor.Procosys.Preservation.MainApi.Responsible
@@ -12,25 +11,17 @@ namespace Equinor.Procosys.Preservation.MainApi.Responsible
         private readonly string _apiVersion;
         private readonly Uri _baseAddress;
         private readonly IBearerTokenApiClient _mainApiClient;
-        private readonly IPlantCache _plantCache;
 
         public MainApiResponsibleService(IBearerTokenApiClient mainApiClient,
-            IPlantCache plantCache,
             IOptionsMonitor<MainApiOptions> options)
         {
             _mainApiClient = mainApiClient;
-            _plantCache = plantCache;
             _apiVersion = options.CurrentValue.ApiVersion;
             _baseAddress = new Uri(options.CurrentValue.BaseAddress);
         }
 
         public async Task<ProcosysResponsible> TryGetResponsibleAsync(string plant, string code)
         {
-            if (!await _plantCache.IsValidPlantForCurrentUserAsync(plant))
-            {
-                throw new ArgumentException($"Invalid plant: {plant}");
-            }
-
             var url = $"{_baseAddress}Library/Responsible" +
                       $"?plantId={plant}" +
                       $"&code={WebUtility.UrlEncode(code)}" +

--- a/src/Equinor.Procosys.Preservation.MainApi/Tag/MainApiTagService.cs
+++ b/src/Equinor.Procosys.Preservation.MainApi/Tag/MainApiTagService.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.MainApi.Client;
-using Equinor.Procosys.Preservation.MainApi.Plant;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -18,17 +17,14 @@ namespace Equinor.Procosys.Preservation.MainApi.Tag
         private readonly string _apiVersion;
         private readonly Uri _baseAddress;
         private readonly IBearerTokenApiClient _mainApiClient;
-        private readonly IPlantCache _plantCache;
         private readonly int _tagSearchPageSize;
 
         public MainApiTagService(
             IBearerTokenApiClient mainApiClient,
-            IPlantCache plantCache,
             IOptionsMonitor<MainApiOptions> options,
             ILogger<MainApiTagService> logger)
         {
             _mainApiClient = mainApiClient;
-            _plantCache = plantCache;
             _apiVersion = options.CurrentValue.ApiVersion;
             _baseAddress = new Uri(options.CurrentValue.BaseAddress);
             if (options.CurrentValue.TagSearchPageSize < 1)
@@ -52,10 +48,6 @@ namespace Equinor.Procosys.Preservation.MainApi.Tag
             {
                 throw new ArgumentNullException(nameof(allTagNos));
 
-            }
-            if (!await _plantCache.IsValidPlantForCurrentUserAsync(plant))
-            {
-                throw new ArgumentException($"Invalid plant: {plant}");
             }
 
             var baseUrl = $"{_baseAddress}Tag/ByTagNos" +
@@ -92,11 +84,6 @@ namespace Equinor.Procosys.Preservation.MainApi.Tag
 
         public async Task<IList<ProcosysPreservedTag>> GetPreservedTagsAsync(string plant, string projectName)
         {
-            if (!await _plantCache.IsValidPlantForCurrentUserAsync(plant))
-            {
-                throw new ArgumentException($"Invalid plant: {plant}");
-            }
-
             var url = $"{_baseAddress}PreservationTags" +
                       $"?plantId={plant}" +
                       $"&projectName={WebUtility.UrlEncode(projectName)}" +
@@ -106,11 +93,6 @@ namespace Equinor.Procosys.Preservation.MainApi.Tag
 
         public async Task<IList<ProcosysTagOverview>> SearchTagsByTagNoAsync(string plant, string projectName, string startsWithTagNo)
         {
-            if (!await _plantCache.IsValidPlantForCurrentUserAsync(plant))
-            {
-                throw new ArgumentException($"Invalid plant: {plant}");
-            }
-
             var items = new List<ProcosysTagOverview>();
             var currentPage = 0;
             ProcosysTagSearchResult tagSearchResult;
@@ -134,11 +116,6 @@ namespace Equinor.Procosys.Preservation.MainApi.Tag
 
         public async Task<IList<ProcosysTagOverview>> SearchTagsByTagFunctionsAsync(string plant, string projectName, IList<string> tagFunctionCodeRegisterCodePairs)
         {
-            if (!await _plantCache.IsValidPlantForCurrentUserAsync(plant))
-            {
-                throw new ArgumentException($"Invalid plant: {plant}");
-            }
-
             var items = new List<ProcosysTagOverview>();
             var currentPage = 0;
             ProcosysTagSearchResult tagSearchResult;
@@ -166,11 +143,6 @@ namespace Equinor.Procosys.Preservation.MainApi.Tag
 
         public async Task MarkTagsAsMigratedAsync(string plant, IEnumerable<long> tagIds)
         {
-            if (!await _plantCache.IsValidPlantForCurrentUserAsync(plant))
-            {
-                throw new ArgumentException($"Invalid plant: {plant}");
-            }
-
             var url = $"{_baseAddress}PreservationTags" +
                       $"?plantId={plant}" +
                       $"&api-version={_apiVersion}";

--- a/src/Equinor.Procosys.Preservation.MainApi/TagFunction/MainApiTagFunctionService.cs
+++ b/src/Equinor.Procosys.Preservation.MainApi/TagFunction/MainApiTagFunctionService.cs
@@ -2,7 +2,6 @@
 using System.Net;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.MainApi.Client;
-using Equinor.Procosys.Preservation.MainApi.Plant;
 using Microsoft.Extensions.Options;
 
 namespace Equinor.Procosys.Preservation.MainApi.TagFunction
@@ -12,25 +11,17 @@ namespace Equinor.Procosys.Preservation.MainApi.TagFunction
         private readonly string _apiVersion;
         private readonly Uri _baseAddress;
         private readonly IBearerTokenApiClient _mainApiClient;
-        private readonly IPlantCache _plantCache;
 
         public MainApiTagFunctionService(IBearerTokenApiClient mainApiClient,
-            IPlantCache plantCache,
             IOptionsMonitor<MainApiOptions> options)
         {
             _mainApiClient = mainApiClient;
-            _plantCache = plantCache;
             _apiVersion = options.CurrentValue.ApiVersion;
             _baseAddress = new Uri(options.CurrentValue.BaseAddress);
         }
 
         public async Task<ProcosysTagFunction> TryGetTagFunctionAsync(string plant, string tagFunctionCode, string registerCode)
         {
-            if (!await _plantCache.IsValidPlantForCurrentUserAsync(plant))
-            {
-                throw new ArgumentException($"Invalid plant: {plant}");
-            }
-
             var url = $"{_baseAddress}Library/TagFunction" +
                 $"?plantId={plant}" +
                 $"&tagFunctionCode={WebUtility.UrlEncode(tagFunctionCode)}" +

--- a/src/Equinor.Procosys.Preservation.WebApi/Authorizations/ClaimsTransformation.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Authorizations/ClaimsTransformation.cs
@@ -43,12 +43,11 @@ namespace Equinor.Procosys.Preservation.WebApi.Authorizations
                 return principal;
             }
 
-            if (!await _plantCache.IsValidPlantForUserAsync(plantId, userOid.Value))
+            if (!await _plantCache.HasUserAccessToPlantAsync(plantId, userOid.Value))
             {
                 // not add plant specific claims if plant not among plants for user
                 return principal;
             }
-
 
             var claimsIdentity = GetOrCreateClaimsIdentityForThisIssuer(principal);
 

--- a/src/Equinor.Procosys.Preservation.WebApi/Caches/PlantCache.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Caches/PlantCache.cs
@@ -47,7 +47,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Caches
             return await HasUserAccessToPlantAsync(plantId, userOid);
         }
 
-        public async Task<bool> IsAValidPlant(string plantId)
+        public async Task<bool> IsAValidPlantAsync(string plantId)
         {
             var userOid = _currentUserProvider.GetCurrentUserOid();
             var allPlants = await GetAllPlantsForUserAsync(userOid);

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Misc/CacheController.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Misc/CacheController.cs
@@ -80,7 +80,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Misc
         public async Task<IList<string>> GetPlants()
         {
             var currentUserOid = _currentUserProvider.GetCurrentUserOid();
-            var plants = await _plantCache.GetPlantIdsForUserOidAsync(currentUserOid);
+            var plants = await _plantCache.GetPlantWithAccessForUserAsync(currentUserOid);
             return plants;
         }
     }

--- a/src/Equinor.Procosys.Preservation.WebApi/Middleware/CurrentPlantMiddleware.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Middleware/CurrentPlantMiddleware.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Domain;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 
 namespace Equinor.Procosys.Preservation.WebApi.Middleware
 {
@@ -13,11 +13,28 @@ namespace Equinor.Procosys.Preservation.WebApi.Middleware
 
         public CurrentPlantMiddleware(RequestDelegate next) => _next = next;
 
-        public async Task InvokeAsync(HttpContext context, IHttpContextAccessor httpContextAccessor, IPlantSetter plantSetter)
+        public async Task InvokeAsync(
+            HttpContext context,
+            IHttpContextAccessor httpContextAccessor,
+            IPlantSetter plantSetter,
+            ILogger<CurrentPlantMiddleware> logger)
         {
-            var plant = httpContextAccessor?.HttpContext?.Request?.Headers[PlantHeader].ToString().ToUpperInvariant() ??
-                        throw new Exception("Could not determine current plant");
-            plantSetter.SetPlant(plant);
+            var headers = httpContextAccessor?.HttpContext?.Request?.Headers;
+            if (headers == null)
+            {
+                var error = "Could not determine request headers";
+                logger.LogError(error);
+                context.Response.StatusCode = 400;
+                context.Response.ContentType = "application/text";
+                await context.Response.WriteAsync(error);
+                return;
+            }
+
+            if (headers.Keys.Contains(PlantHeader))
+            {
+                var plant = headers[PlantHeader].ToString().ToUpperInvariant();
+                plantSetter.SetPlant(plant);
+            }
 
             // Call the next delegate/middleware in the pipeline
             await _next(context);

--- a/src/Equinor.Procosys.Preservation.WebApi/Middleware/MiddlewareExtensions.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Middleware/MiddlewareExtensions.cs
@@ -8,6 +8,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Middleware
         public static void UseCurrentUser(this IApplicationBuilder app) => app.UseMiddleware<CurrentUserMiddleware>();
         public static void UseVerifyOidInDb(this IApplicationBuilder app) => app.UseMiddleware<VerifyOidInDbMiddleware>();
         public static void UseCurrentPlant(this IApplicationBuilder app) => app.UseMiddleware<CurrentPlantMiddleware>();
+        public static void UsePlantValidator(this IApplicationBuilder app) => app.UseMiddleware<PlantValidatorMiddleware>();
         public static void UseCurrentBearerToken(this IApplicationBuilder app) => app.UseMiddleware<CurrentBearerTokenMiddleware>();
     }
 }

--- a/src/Equinor.Procosys.Preservation.WebApi/Middleware/PlantValidatorMiddleware.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Middleware/PlantValidatorMiddleware.cs
@@ -1,0 +1,41 @@
+﻿using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Domain;
+using Equinor.Procosys.Preservation.MainApi.Plant;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Equinor.Procosys.Preservation.WebApi.Middleware
+{
+    public class PlantValidatorMiddleware
+    {
+        public const string PlantHeader = "x-plant";
+
+        private readonly RequestDelegate _next;
+
+        public PlantValidatorMiddleware(RequestDelegate next) => _next = next;
+
+        public async Task InvokeAsync(
+            HttpContext context,
+            IPlantProvider plantProvider,
+            IPlantCache plantCache,
+            ILogger<PlantValidatorMiddleware> logger)
+        {
+            var plantId = plantProvider.Plant;
+            if (context.User.Identity.IsAuthenticated && plantId != null)
+            {
+                if (!await plantCache.IsAValidPlantAsync(plantId))
+                {
+                    var error = $"Plant '{plantId}' is not a valid plant";
+                    logger.LogError(error);
+                    context.Response.StatusCode = 400;
+                    context.Response.ContentType = "application/text";
+                    await context.Response.WriteAsync(error);
+                    return;
+                }
+            }
+
+            // Call the next delegate/middleware in the pipeline
+            await _next(context);
+        }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.WebApi/Misc/PlantProvider.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Misc/PlantProvider.cs
@@ -1,14 +1,11 @@
-﻿using System;
-using Equinor.Procosys.Preservation.Domain;
+﻿using Equinor.Procosys.Preservation.Domain;
 
 namespace Equinor.Procosys.Preservation.WebApi.Misc
 {
     public class PlantProvider : IPlantProvider, IPlantSetter
     {
-        private string _plant;
+        public string Plant { get; private set; }
 
-        public string Plant => _plant ?? throw new Exception("Could not determine current plant");
-
-        public void SetPlant(string plant) => _plant = plant;
+        public void SetPlant(string plant) => Plant = plant;
     }
 }

--- a/src/Equinor.Procosys.Preservation.WebApi/Startup.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Startup.cs
@@ -181,9 +181,9 @@ namespace Equinor.Procosys.Preservation.WebApi
 
             app.UseCurrentPlant();
             app.UseCurrentBearerToken();
-
             app.UseAuthentication();
             app.UseCurrentUser();
+            app.UsePlantValidator();
             app.UseVerifyOidInDb();
             app.UseAuthorization();
 

--- a/src/Equinor.Procosys.Preservation.WebApi/Synchronization/SynchronizationService.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Synchronization/SynchronizationService.cs
@@ -83,7 +83,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Synchronization
             claimsIdentity.AddClaim(new Claim(ClaimsExtensions.OidType, _synchronizationUserOid.ToString()));
             currentUser.AddIdentity(claimsIdentity);
 
-            foreach (var plant in await _plantCache.GetPlantIdsForUserOidAsync(_synchronizationUserOid))
+            foreach (var plant in await _plantCache.GetPlantWithAccessForUserAsync(_synchronizationUserOid))
             {
                 _logger.LogInformation($"Synchronizing plant {plant}...");
 

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/MiscCommands/Clone/CloneCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/MiscCommands/Clone/CloneCommandValidatorTests.cs
@@ -19,8 +19,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.MiscCommands.Clone
         public void Setup_OkState()
         {
             _plantCacheMock = new Mock<IPlantCache>();
-            _plantCacheMock.Setup(r => r.IsValidPlantForCurrentUserAsync(_sourcePlant)).Returns(Task.FromResult(true));
-            _plantCacheMock.Setup(r => r.IsValidPlantForCurrentUserAsync(_targetPlant)).Returns(Task.FromResult(true));
+            _plantCacheMock.Setup(r => r.HasCurrentUserAccessToPlantAsync(_sourcePlant)).Returns(Task.FromResult(true));
+            _plantCacheMock.Setup(r => r.HasCurrentUserAccessToPlantAsync(_targetPlant)).Returns(Task.FromResult(true));
 
             _command = new CloneCommand(_sourcePlant, _targetPlant);
             _dut = new CloneCommandValidator(_plantCacheMock.Object);
@@ -37,32 +37,32 @@ namespace Equinor.Procosys.Preservation.Command.Tests.MiscCommands.Clone
         [TestMethod]
         public void Validate_ShouldFail_WhenTargetPlantNotValid()
         {
-            _plantCacheMock.Setup(r => r.IsValidPlantForCurrentUserAsync(_targetPlant)).Returns(Task.FromResult(false));
+            _plantCacheMock.Setup(r => r.HasCurrentUserAccessToPlantAsync(_targetPlant)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Target plant is not valid!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Target plant is not valid or access missing!"));
         }
 
         [TestMethod]
         public void Validate_ShouldFail_WhenSourcePlantNotValid()
         {
-            _plantCacheMock.Setup(r => r.IsValidPlantForCurrentUserAsync(_sourcePlant)).Returns(Task.FromResult(false));
+            _plantCacheMock.Setup(r => r.HasCurrentUserAccessToPlantAsync(_sourcePlant)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Source plant is not valid!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Source plant is not valid or access missing!"));
         }
 
         [TestMethod]
         public void Validate_ShouldFail_WhenTargetPlantIsABasisPlant()
         {
             var targetPlant = "PCS$STATOIL_BASIS";
-            _plantCacheMock.Setup(r => r.IsValidPlantForCurrentUserAsync(targetPlant)).Returns(Task.FromResult(true));
+            _plantCacheMock.Setup(r => r.HasCurrentUserAccessToPlantAsync(targetPlant)).Returns(Task.FromResult(true));
             var command = new CloneCommand(_sourcePlant, targetPlant);
             var result = _dut.Validate(command);
 

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/MiscCommands/Clone/PlantProvider.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/MiscCommands/Clone/PlantProvider.cs
@@ -1,16 +1,13 @@
-﻿using System;
-using Equinor.Procosys.Preservation.Domain;
+﻿using Equinor.Procosys.Preservation.Domain;
 
 namespace Equinor.Procosys.Preservation.Command.Tests.MiscCommands.Clone
 {
     public class PlantProvider : IPlantProvider, IPlantSetter
     {
-        private string _plant;
+        public PlantProvider(string plant) => Plant = plant;
 
-        public PlantProvider(string plant) => _plant = plant;
+        public string Plant { get; private set; }
 
-        public string Plant => _plant ?? throw new Exception("Could not determine current plant");
-
-        public void SetPlant(string plant) => _plant = plant;
+        public void SetPlant(string plant) => Plant = plant;
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Area/MainApiAreaServiceTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Area/MainApiAreaServiceTests.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.MainApi.Area;
 using Equinor.Procosys.Preservation.MainApi.Client;
-using Equinor.Procosys.Preservation.MainApi.Plant;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -15,7 +13,6 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Area
         private const string _plant = "PCS$TESTPLANT";
         private Mock<IOptionsMonitor<MainApiOptions>> _mainApiOptions;
         private Mock<IBearerTokenApiClient> _mainApiClient;
-        private Mock<IPlantCache> _plantCache;
         private MainApiAreaService _dut;
         private ProcosysArea _procosysArea;
 
@@ -27,10 +24,6 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Area
                 .Setup(x => x.CurrentValue)
                 .Returns(new MainApiOptions { ApiVersion = "4.0", BaseAddress = "http://example.com" });
             _mainApiClient = new Mock<IBearerTokenApiClient>();
-            _plantCache = new Mock<IPlantCache>();
-            _plantCache
-                .Setup(x => x.IsValidPlantForCurrentUserAsync(_plant))
-                .Returns(Task.FromResult(true));
 
             _procosysArea = new ProcosysArea
             {
@@ -39,12 +32,8 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Area
                 Description = "Description1",
             };
            
-            _dut = new MainApiAreaService(_mainApiClient.Object, _plantCache.Object, _mainApiOptions.Object);
+            _dut = new MainApiAreaService(_mainApiClient.Object, _mainApiOptions.Object);
         }
-
-        [TestMethod]
-        public async Task TryGetAreaCode_ThrowsException_WhenPlantIsInvalid()
-            => await Assert.ThrowsExceptionAsync<ArgumentException>(async () => await _dut.TryGetAreaAsync("INVALIDPLANT", "C"));
 
         [TestMethod]
         public async Task TryGetAreaCode_ShouldReturnAreaCode()

--- a/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Discipline/MainApiDisciplineServiceTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Discipline/MainApiDisciplineServiceTests.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.MainApi.Client;
 using Equinor.Procosys.Preservation.MainApi.Discipline;
-using Equinor.Procosys.Preservation.MainApi.Plant;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -15,7 +13,6 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Discipline
         private const string _plant = "PCS$TESTPLANT";
         private Mock<IOptionsMonitor<MainApiOptions>> _mainApiOptions;
         private Mock<IBearerTokenApiClient> _mainApiClient;
-        private Mock<IPlantCache> _plantCache;
         private ProcosysDiscipline _procosysDiscipline;
         private MainApiDisciplineService _dut;
 
@@ -27,10 +24,6 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Discipline
                 .Setup(x => x.CurrentValue)
                 .Returns(new MainApiOptions { ApiVersion = "4.0", BaseAddress = "http://example.com" });
             _mainApiClient = new Mock<IBearerTokenApiClient>();
-            _plantCache = new Mock<IPlantCache>();
-            _plantCache
-                .Setup(x => x.IsValidPlantForCurrentUserAsync(_plant))
-                .Returns(Task.FromResult(true));
 
             _procosysDiscipline = new ProcosysDiscipline
             {
@@ -39,12 +32,8 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Discipline
                 Description = "Description1",
             };
            
-            _dut = new MainApiDisciplineService(_mainApiClient.Object, _plantCache.Object, _mainApiOptions.Object);
+            _dut = new MainApiDisciplineService(_mainApiClient.Object, _mainApiOptions.Object);
         }
-
-        [TestMethod]
-        public async Task TryGetDiscipline_ShouldThrowException_WhenPlantIsInvalid()
-            => await Assert.ThrowsExceptionAsync<ArgumentException>(async () => await _dut.TryGetDisciplineAsync("INVALIDPLANT", "C"));
 
         [TestMethod]
         public async Task TryGetDiscipline_ShouldReturnDiscipline()

--- a/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Plant/MainApiPlantServiceTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Plant/MainApiPlantServiceTests.cs
@@ -39,20 +39,20 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Plant
         }
 
         [TestMethod]
-        public async Task GetPlants_ShouldReturnCorrectNumberOfPlants()
+        public async Task GetAllPlants_ShouldReturnCorrectNumberOfPlants()
         {
             // Act
-            var result = await _dut.GetPlantsAsync();
+            var result = await _dut.GetAllPlantsAsync();
 
             // Assert
             Assert.AreEqual(4, result.Count());
         }
 
         [TestMethod]
-        public async Task GetPlants_ShouldSetsCorrectProperties()
+        public async Task GetAllPlants_ShouldSetsCorrectProperties()
         {
             // Act
-            var result = await _dut.GetPlantsAsync();
+            var result = await _dut.GetAllPlantsAsync();
 
             // Assert
             var plant = result.First();

--- a/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Project/MainApiProjectServiceTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Project/MainApiProjectServiceTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.MainApi.Project;
 using Equinor.Procosys.Preservation.MainApi.Client;
-using Equinor.Procosys.Preservation.MainApi.Plant;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -14,7 +13,6 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Project
         private const string _plant = "PCS$TESTPLANT";
         private Mock<IOptionsMonitor<MainApiOptions>> _mainApiOptions;
         private Mock<IBearerTokenApiClient> _mainApiClient;
-        private Mock<IPlantCache> _plantCache;
         private ProcosysProject _result;
         private string _name = "NameA";
         private string _description = "Description1";
@@ -28,13 +26,9 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Project
                 .Setup(x => x.CurrentValue)
                 .Returns(new MainApiOptions { ApiVersion = "4.0", BaseAddress = "http://example.com" });
             _mainApiClient = new Mock<IBearerTokenApiClient>();
-            _plantCache = new Mock<IPlantCache>();
-            _plantCache
-                .Setup(x => x.IsValidPlantForCurrentUserAsync(_plant))
-                .Returns(Task.FromResult(true));
 
             _result = new ProcosysProject {Id = 1, Name = _name, Description = _description};
-            _dut = new MainApiProjectService(_mainApiClient.Object, _plantCache.Object, _mainApiOptions.Object);
+            _dut = new MainApiProjectService(_mainApiClient.Object, _mainApiOptions.Object);
         }
 
         [TestMethod]

--- a/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Responsible/MainApiResponsibleServiceTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Responsible/MainApiResponsibleServiceTests.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.MainApi.Responsible;
 using Equinor.Procosys.Preservation.MainApi.Client;
-using Equinor.Procosys.Preservation.MainApi.Plant;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -15,7 +13,6 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Responsible
         private const string _plant = "PCS$TESTPLANT";
         private Mock<IOptionsMonitor<MainApiOptions>> _mainApiOptions;
         private Mock<IBearerTokenApiClient> _mainApiClient;
-        private Mock<IPlantCache> _plantCache;
         private MainApiResponsibleService _dut;
 
         [TestInitialize]
@@ -26,16 +23,9 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Responsible
                 .Setup(x => x.CurrentValue)
                 .Returns(new MainApiOptions { ApiVersion = "4.0", BaseAddress = "http://example.com" });
             _mainApiClient = new Mock<IBearerTokenApiClient>();
-            _plantCache = new Mock<IPlantCache>();
-            _plantCache
-                .Setup(x => x.IsValidPlantForCurrentUserAsync(_plant))
-                .Returns(Task.FromResult(true));
-            _dut = new MainApiResponsibleService(_mainApiClient.Object, _plantCache.Object, _mainApiOptions.Object);
-        }
 
-        [TestMethod]
-        public async Task TryGetResponsibleCode_ThrowsException_WhenPlantIsInvalid()
-            => await Assert.ThrowsExceptionAsync<ArgumentException>(async () => await _dut.TryGetResponsibleAsync("INVALIDPLANT", "C"));
+            _dut = new MainApiResponsibleService(_mainApiClient.Object, _mainApiOptions.Object);
+        }
 
         [TestMethod]
         public async Task TryGetResponsibleCode_ShouldReturnResponsibleCode()

--- a/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/TagFunction/MainApiTagFunctionServiceTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/TagFunction/MainApiTagFunctionServiceTests.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.MainApi.TagFunction;
 using Equinor.Procosys.Preservation.MainApi.Client;
-using Equinor.Procosys.Preservation.MainApi.Plant;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -15,7 +13,6 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.TagFunction
         private const string _plant = "PCS$TESTPLANT";
         private Mock<IOptionsMonitor<MainApiOptions>> _mainApiOptions;
         private Mock<IBearerTokenApiClient> _mainApiClient;
-        private Mock<IPlantCache> _plantCache;
         private ProcosysTagFunction _result;
         private readonly string TagFunctionCode = "CodeTF";
         private readonly string RegisterCode = "CodeR";
@@ -30,10 +27,6 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.TagFunction
                 .Setup(x => x.CurrentValue)
                 .Returns(new MainApiOptions { ApiVersion = "4.0", BaseAddress = "http://example.com" });
             _mainApiClient = new Mock<IBearerTokenApiClient>();
-            _plantCache = new Mock<IPlantCache>();
-            _plantCache
-                .Setup(x => x.IsValidPlantForCurrentUserAsync(_plant))
-                .Returns(Task.FromResult(true));
 
             _result = new ProcosysTagFunction
             {
@@ -43,7 +36,7 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.TagFunction
                 RegisterCode = RegisterCode
             };
 
-            _dut = new MainApiTagFunctionService(_mainApiClient.Object, _plantCache.Object, _mainApiOptions.Object);
+            _dut = new MainApiTagFunctionService(_mainApiClient.Object, _mainApiOptions.Object);
         }
 
         [TestMethod]
@@ -62,10 +55,5 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.TagFunction
             Assert.AreEqual(Description, result.Description);
             Assert.AreEqual(RegisterCode, result.RegisterCode);
         }
-
-        [TestMethod]
-        public async Task TryGetTagFunction_ThrowsException_WhenPlantIsInvalid()
-            => await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
-                await _dut.TryGetTagFunctionAsync("INVALIDPLANT", "", ""));
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Authorizations/ClaimsTransformationTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Authorizations/ClaimsTransformationTests.cs
@@ -38,8 +38,8 @@ namespace Equinor.Procosys.Preservation.WebApi.Tests.Authorizations
             _plantProviderMock.SetupGet(p => p.Plant).Returns(Plant1);
 
             _plantCacheMock = new Mock<IPlantCache>();
-            _plantCacheMock.Setup(p => p.IsValidPlantForUserAsync(Plant1, Oid)).Returns(Task.FromResult(true));
-            _plantCacheMock.Setup(p => p.IsValidPlantForUserAsync(Plant2, Oid)).Returns(Task.FromResult(true));
+            _plantCacheMock.Setup(p => p.HasUserAccessToPlantAsync(Plant1, Oid)).Returns(Task.FromResult(true));
+            _plantCacheMock.Setup(p => p.HasUserAccessToPlantAsync(Plant2, Oid)).Returns(Task.FromResult(true));
 
             var permissionCacheMock = new Mock<IPermissionCache>();
             permissionCacheMock.Setup(p => p.GetPermissionsForUserAsync(Plant1, Oid))


### PR DESCRIPTION
The goal for this change is to distinguish between accessing a invalid plant vs a plant where user don't have access.

* Refactor IPlantApiService ->GetAllPlantsAsync now get all plants, also those where user don't have access. New property ProcosysPlant.HasAccess tell if user has access
* CurrentPlantMiddleware Set plant if given in Headers. Not giving plant is allowed
* PlantProvider now allow that Plant is not set (no exception thrown)
* New PlantValidatorMiddleware checking if given plant (if any) is a valid plant. Must be authenticated to check this
* Services calling Main api do not need to check if it is a valid plant now, since it's done at request startup pipeline
