### PR TITLE
78680 Use new project features from main api

### DIFF
--- a/src/Equinor.Procosys.Preservation.Command/SyncCommands/SyncProjects/SyncProjectsCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/SyncCommands/SyncProjects/SyncProjectsCommandHandler.cs
@@ -58,7 +58,7 @@ namespace Equinor.Procosys.Preservation.Command.SyncCommands.SyncProjects
             var projects = await _projectRepository.GetAllProjectsOnlyAsync();
             var currentUserOid = _currentUserProvider.GetCurrentUserOid();
             
-            var projectsWhichUserCanAccess = await _permissionCache.GetProjectNamesForUserOidAsync(plant, currentUserOid);
+            var projectsWhichUserCanAccess = await _permissionCache.GetProjectsForUserAsync(plant, currentUserOid);
             
             foreach (var project in projects)
             {

--- a/src/Equinor.Procosys.Preservation.Domain/IPermissionCache.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/IPermissionCache.cs
@@ -8,6 +8,7 @@ namespace Equinor.Procosys.Preservation.Domain
     {
         Task<IList<string>> GetPermissionsForUserAsync(string plantId, Guid userOid);
         Task<IList<string>> GetProjectsForUserAsync(string plantId, Guid userOid);
+        Task<bool> IsAValidProjectAsync(string plantId, Guid userOid, string projectName);
         Task<IList<string>> GetContentRestrictionsForUserAsync(string plantId, Guid userOid);
         void ClearAll(string plantId, Guid userOid);
     }

--- a/src/Equinor.Procosys.Preservation.Domain/IPermissionCache.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/IPermissionCache.cs
@@ -7,8 +7,8 @@ namespace Equinor.Procosys.Preservation.Domain
     public interface IPermissionCache
     {
         Task<IList<string>> GetPermissionsForUserAsync(string plantId, Guid userOid);
-        Task<IList<string>> GetProjectNamesForUserOidAsync(string plantId, Guid userOid);
-        Task<IList<string>> GetContentRestrictionsForUserOidAsync(string plantId, Guid userOid);
+        Task<IList<string>> GetProjectsForUserAsync(string plantId, Guid userOid);
+        Task<IList<string>> GetContentRestrictionsForUserAsync(string plantId, Guid userOid);
         void ClearAll(string plantId, Guid userOid);
     }
 }

--- a/src/Equinor.Procosys.Preservation.MainApi/Permission/IPermissionApiService.cs
+++ b/src/Equinor.Procosys.Preservation.MainApi/Permission/IPermissionApiService.cs
@@ -6,7 +6,7 @@ namespace Equinor.Procosys.Preservation.MainApi.Permission
     public interface IPermissionApiService
     {
         Task<IList<string>> GetPermissionsAsync(string plantId);
-        Task<IList<string>> GetProjectsAsync(string plantId);
+        Task<IList<ProcosysProject>> GetAllProjectsAsync(string plantId);
         Task<IList<string>> GetContentRestrictionsAsync(string plantId);
     }
 }

--- a/src/Equinor.Procosys.Preservation.MainApi/Permission/MainApiPermissionService.cs
+++ b/src/Equinor.Procosys.Preservation.MainApi/Permission/MainApiPermissionService.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.MainApi.Client;
-using Equinor.Procosys.Preservation.MainApi.Project;
 using Microsoft.Extensions.Options;
 
 namespace Equinor.Procosys.Preservation.MainApi.Permission
@@ -22,15 +20,16 @@ namespace Equinor.Procosys.Preservation.MainApi.Permission
             _baseAddress = new Uri(options.CurrentValue.BaseAddress);
         }
         
-        public async Task<IList<string>> GetProjectsAsync(string plantId)
+        public async Task<IList<ProcosysProject>> GetAllProjectsAsync(string plantId)
         {
             var url = $"{_baseAddress}Projects" +
                       $"?plantId={plantId}" +
                       "&withCommPkgsOnly=false" +
+                      "&includeClosedProjects=true" +
+                      "&includeProjectsWithoutAccess=true" +
                       $"&api-version={_apiVersion}";
 
-            var projects = await _mainApiClient.QueryAndDeserializeAsync<List<ProcosysProject>>(url);
-            return projects != null ? projects.Select(p => p.Name).ToList() : new List<string>();
+            return await _mainApiClient.QueryAndDeserializeAsync<List<ProcosysProject>>(url);
         }
 
         public async Task<IList<string>> GetPermissionsAsync(string plantId)

--- a/src/Equinor.Procosys.Preservation.MainApi/Permission/ProcosysProject.cs
+++ b/src/Equinor.Procosys.Preservation.MainApi/Permission/ProcosysProject.cs
@@ -1,0 +1,9 @@
+﻿namespace Equinor.Procosys.Preservation.MainApi.Permission
+{
+    public class ProcosysProject
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public bool HasAccess { get; set; }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.WebApi/Authorizations/ClaimsTransformation.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Authorizations/ClaimsTransformation.cs
@@ -93,13 +93,13 @@ namespace Equinor.Procosys.Preservation.WebApi.Authorizations
 
         private async Task AddUserDataClaimForAllProjectsToIdentityAsync(ClaimsIdentity claimsIdentity, string plantId, Guid userOid)
         {
-            var projectNames = await _permissionCache.GetProjectNamesForUserOidAsync(plantId, userOid);
+            var projectNames = await _permissionCache.GetProjectsForUserAsync(plantId, userOid);
             projectNames?.ToList().ForEach(projectName => claimsIdentity.AddClaim(CreateClaim(ClaimTypes.UserData, GetProjectClaimValue(projectName))));
         }
 
         private async Task AddUserDataClaimForAllContentRestrictionsToIdentityAsync(ClaimsIdentity claimsIdentity, string plantId, Guid userOid)
         {
-            var contentRestrictions = await _permissionCache.GetContentRestrictionsForUserOidAsync(plantId, userOid);
+            var contentRestrictions = await _permissionCache.GetContentRestrictionsForUserAsync(plantId, userOid);
             contentRestrictions?.ToList().ForEach(
                 contentRestriction => claimsIdentity.AddClaim(CreateClaim(ClaimTypes.UserData, GetContentRestrictionClaimValue(contentRestriction))));
         }

--- a/src/Equinor.Procosys.Preservation.WebApi/Behaviors/CheckValidProjectBehavior.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Behaviors/CheckValidProjectBehavior.cs
@@ -1,0 +1,31 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.WebApi.Misc;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Equinor.Procosys.Preservation.WebApi.Behaviors
+{
+    public class CheckValidProjectBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> 
+    {
+        private readonly ILogger<CheckValidProjectBehavior<TRequest, TResponse>> _logger;
+        private readonly IProjectChecker _projectChecker;
+
+        public CheckValidProjectBehavior(ILogger<CheckValidProjectBehavior<TRequest, TResponse>> logger, IProjectChecker projectChecker)
+        {
+            _logger = logger;
+            _projectChecker = projectChecker;
+        }
+
+        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+        {
+            var typeName = request.GetGenericTypeName();
+
+            _logger.LogInformation($"----- Checking project for {typeName}");
+
+            await _projectChecker.EnsureValidProjectAsync(request as IBaseRequest);
+
+            return await next();
+        }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.WebApi/Caches/PermissionCache.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Caches/PermissionCache.cs
@@ -38,6 +38,12 @@ namespace Equinor.Procosys.Preservation.WebApi.Caches
             return allProjects?.Where(p => p.HasAccess).Select(p => p.Name).ToList();
         }
 
+        public async Task<bool> IsAValidProjectAsync(string plantId, Guid userOid, string projectName)
+        {
+            var allProjects = await GetAllProjectsForUserAsync(plantId, userOid);
+            return allProjects != null && allProjects.Any(p => p.Name == projectName);
+        }
+
         public async Task<IList<string>> GetContentRestrictionsForUserAsync(string plantId, Guid userOid)
             => await _cacheManager.GetOrCreate(
                 ContentRestrictionsCacheKey(plantId, userOid),

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Misc/CacheController.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Misc/CacheController.cs
@@ -71,7 +71,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Misc
             string plant)
         {
             var currentUserOid = _currentUserProvider.GetCurrentUserOid();
-            var projects = await _permissionCache.GetProjectNamesForUserOidAsync(plant, currentUserOid);
+            var projects = await _permissionCache.GetProjectsForUserAsync(plant, currentUserOid);
             return projects;
         }
 

--- a/src/Equinor.Procosys.Preservation.WebApi/DiModules/ApplicationModule.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/DiModules/ApplicationModule.cs
@@ -96,6 +96,7 @@ namespace Equinor.Procosys.Preservation.WebApi.DIModules
             services.AddScoped<IPlantProvider>(x => x.GetRequiredService<PlantProvider>());
             services.AddScoped<IPlantSetter>(x => x.GetRequiredService<PlantProvider>());
             services.AddScoped<IAccessValidator, AccessValidator>();
+            services.AddScoped<IProjectChecker, ProjectChecker>();
             services.AddScoped<IProjectAccessChecker, ProjectAccessChecker>();
             services.AddScoped<IContentRestrictionsChecker, ContentRestrictionsChecker>();
             services.AddScoped<ITagHelper, TagHelper>();

--- a/src/Equinor.Procosys.Preservation.WebApi/DiModules/MediatorModule.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/DiModules/MediatorModule.cs
@@ -17,8 +17,9 @@ namespace Equinor.Procosys.Preservation.WebApi.DIModules
                 typeof(IQueryMarker).GetTypeInfo().Assembly
             );
             services.AddTransient(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));
-            services.AddTransient(typeof(IPipelineBehavior<,>), typeof(CheckAccessBehavior<,>));
             services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidatorBehavior<,>));
+            services.AddTransient(typeof(IPipelineBehavior<,>), typeof(CheckValidProjectBehavior<,>));
+            services.AddTransient(typeof(IPipelineBehavior<,>), typeof(CheckAccessBehavior<,>));
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.WebApi/Middleware/CurrentPlantMiddleware.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Middleware/CurrentPlantMiddleware.cs
@@ -1,7 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Domain;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging;
 
 namespace Equinor.Procosys.Preservation.WebApi.Middleware
 {
@@ -16,18 +16,12 @@ namespace Equinor.Procosys.Preservation.WebApi.Middleware
         public async Task InvokeAsync(
             HttpContext context,
             IHttpContextAccessor httpContextAccessor,
-            IPlantSetter plantSetter,
-            ILogger<CurrentPlantMiddleware> logger)
+            IPlantSetter plantSetter)
         {
             var headers = httpContextAccessor?.HttpContext?.Request?.Headers;
             if (headers == null)
             {
-                var error = "Could not determine request headers";
-                logger.LogError(error);
-                context.Response.StatusCode = 400;
-                context.Response.ContentType = "application/text";
-                await context.Response.WriteAsync(error);
-                return;
+                throw new Exception("Could not determine request headers");
             }
 
             if (headers.Keys.Contains(PlantHeader))

--- a/src/Equinor.Procosys.Preservation.WebApi/Middleware/GlobalExceptionHandler.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Middleware/GlobalExceptionHandler.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Domain.Exceptions;
+using Equinor.Procosys.Preservation.WebApi.Misc;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -38,8 +39,6 @@ namespace Equinor.Procosys.Preservation.WebApi.Middleware
             }
             catch (FluentValidation.ValidationException ve)
             {
-                context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
-                context.Response.ContentType = "application/problem+json";
                 var errors = new Dictionary<string, string[]>();
                 foreach (var error in ve.Errors)
                 {
@@ -54,15 +53,13 @@ namespace Equinor.Procosys.Preservation.WebApi.Middleware
                         errors[error.PropertyName] = errorsForProperty.ToArray();
                     }
                 }
-                var problems = new ValidationProblemDetails(errors)
-                {
-                    Status = context.Response.StatusCode,
-                    Title = $"One or more business validation errors occurred. ({ve.Errors.Count()})"
-                };
-                var json = JsonSerializer.Serialize(problems);
-                _logger.LogInformation(json);
 
-                await context.Response.WriteAsync(json);
+                await context.WriteBadRequestAsync(errors, _logger);
+            }
+            catch (InValidProjectException ipe)
+            {
+                var errors = new Dictionary<string, string[]> {{"ProjectName", new[] {ipe.Message}}};
+                await context.WriteBadRequestAsync(errors, _logger);
             }
             catch (ConcurrencyException)
             {

--- a/src/Equinor.Procosys.Preservation.WebApi/Middleware/PlantValidatorMiddleware.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Middleware/PlantValidatorMiddleware.cs
@@ -10,8 +10,6 @@ namespace Equinor.Procosys.Preservation.WebApi.Middleware
 {
     public class PlantValidatorMiddleware
     {
-        public const string PlantHeader = "x-plant";
-
         private readonly RequestDelegate _next;
 
         public PlantValidatorMiddleware(RequestDelegate next) => _next = next;

--- a/src/Equinor.Procosys.Preservation.WebApi/Middleware/PlantValidatorMiddleware.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Middleware/PlantValidatorMiddleware.cs
@@ -1,6 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.Domain;
 using Equinor.Procosys.Preservation.MainApi.Plant;
+using Equinor.Procosys.Preservation.WebApi.Misc;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
@@ -25,11 +27,11 @@ namespace Equinor.Procosys.Preservation.WebApi.Middleware
             {
                 if (!await plantCache.IsAValidPlantAsync(plantId))
                 {
-                    var error = $"Plant '{plantId}' is not a valid plant";
-                    logger.LogError(error);
-                    context.Response.StatusCode = 400;
-                    context.Response.ContentType = "application/text";
-                    await context.Response.WriteAsync(error);
+                    var errors = new Dictionary<string, string[]>
+                    {
+                        {CurrentPlantMiddleware.PlantHeader, new[] {$"Plant '{plantId}' is not a valid plant"}}
+                    };
+                    await context.WriteBadRequestAsync(errors, logger);
                     return;
                 }
             }

--- a/src/Equinor.Procosys.Preservation.WebApi/Misc/HttpContextExtension.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Misc/HttpContextExtension.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using JsonSerializer = System.Text.Json.JsonSerializer;
+
+namespace Equinor.Procosys.Preservation.WebApi.Misc
+{
+    public static class HttpContextExtension
+    {
+        public static async Task WriteBadRequestAsync(
+            this HttpContext context,
+            Dictionary<string, string[]> errors,
+            ILogger _logger)
+        {
+            context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+            context.Response.ContentType = "application/problem+json";
+            var problems = new ValidationProblemDetails(errors)
+            {
+                Status = context.Response.StatusCode,
+                Title = "One or more business validation errors occurred"
+            };
+            var json = JsonSerializer.Serialize(problems);
+            _logger.LogInformation(json);
+
+            await context.Response.WriteAsync(json);
+        }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.WebApi/Misc/IProjectChecker.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Misc/IProjectChecker.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+using MediatR;
+
+namespace Equinor.Procosys.Preservation.WebApi.Misc
+{
+    public interface IProjectChecker
+    {
+        Task EnsureValidProjectAsync<TRequest>(TRequest request) where TRequest: IBaseRequest;
+    }
+}

--- a/src/Equinor.Procosys.Preservation.WebApi/Misc/InValidProjectException.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Misc/InValidProjectException.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Equinor.Procosys.Preservation.WebApi.Misc
+{
+    public class InValidProjectException : Exception
+    {
+        public InValidProjectException(string error) : base(error)
+        {
+        }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.WebApi/Misc/ProjectChecker.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Misc/ProjectChecker.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.Domain;
+using MediatR;
+
+namespace Equinor.Procosys.Preservation.WebApi.Misc
+{
+    public class ProjectChecker : IProjectChecker
+    {
+        private readonly IPlantProvider _plantProvider;
+        private readonly ICurrentUserProvider _currentUserProvider;
+        private readonly IPermissionCache _permissionCache;
+
+        public ProjectChecker(IPlantProvider plantProvider,
+            ICurrentUserProvider currentUserProvider,
+            IPermissionCache permissionCache)
+        {
+            _plantProvider = plantProvider;
+            _currentUserProvider = currentUserProvider;
+            _permissionCache = permissionCache;
+        }
+
+        public async Task EnsureValidProjectAsync<TRequest>(TRequest request) where TRequest : IBaseRequest
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            var plant = _plantProvider.Plant;
+            var userOid = _currentUserProvider.GetCurrentUserOid();
+
+            if (request is IProjectRequest projectRequest && !await _permissionCache.IsAValidProjectAsync(plant, userOid, projectRequest.ProjectName))
+            {
+                throw new InValidProjectException($"Project '{projectRequest.ProjectName}' is not a valid project in '{plant}'");
+            }
+        }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/SyncCommands/SyncProjects/SyncProjectsCommandHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/SyncCommands/SyncProjects/SyncProjectsCommandHandlerTests.cs
@@ -159,7 +159,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.SyncCommands.SyncProjects
             
             // Assert other interfaces and device in test (dut)
             _permissionCacheMock = new Mock<IPermissionCache>();
-            _permissionCacheMock.Setup(p => p.GetProjectNamesForUserOidAsync(TestPlant, CurrentUserOid))
+            _permissionCacheMock.Setup(p => p.GetProjectsForUserAsync(TestPlant, CurrentUserOid))
                 .Returns(Task.FromResult<IList<string>>(new List<string> {ProjectName1, ProjectName2}));
 
             _command = new SyncProjectsCommand();

--- a/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Plant/MainApiPlantServiceTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Plant/MainApiPlantServiceTests.cs
@@ -45,7 +45,7 @@ namespace Equinor.Procosys.Preservation.MainApi.Tests.Plant
             var result = await _dut.GetAllPlantsAsync();
 
             // Assert
-            Assert.AreEqual(4, result.Count());
+            Assert.AreEqual(4, result.Count);
         }
 
         [TestMethod]

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Authorizations/ClaimsTransformationTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Authorizations/ClaimsTransformationTests.cs
@@ -44,16 +44,16 @@ namespace Equinor.Procosys.Preservation.WebApi.Tests.Authorizations
             var permissionCacheMock = new Mock<IPermissionCache>();
             permissionCacheMock.Setup(p => p.GetPermissionsForUserAsync(Plant1, Oid))
                 .Returns(Task.FromResult<IList<string>>(new List<string> {Permission1_Plant1, Permission2_Plant1}));
-            permissionCacheMock.Setup(p => p.GetProjectNamesForUserOidAsync(Plant1, Oid))
+            permissionCacheMock.Setup(p => p.GetProjectsForUserAsync(Plant1, Oid))
                 .Returns(Task.FromResult<IList<string>>(new List<string> {Project1_Plant1, Project2_Plant1}));
-            permissionCacheMock.Setup(p => p.GetContentRestrictionsForUserOidAsync(Plant1, Oid))
+            permissionCacheMock.Setup(p => p.GetContentRestrictionsForUserAsync(Plant1, Oid))
                 .Returns(Task.FromResult<IList<string>>(new List<string> {Restriction1_Plant1, Restriction2_Plant1}));
 
             permissionCacheMock.Setup(p => p.GetPermissionsForUserAsync(Plant2, Oid))
                 .Returns(Task.FromResult<IList<string>>(new List<string> {Permission1_Plant2}));
-            permissionCacheMock.Setup(p => p.GetProjectNamesForUserOidAsync(Plant2, Oid))
+            permissionCacheMock.Setup(p => p.GetProjectsForUserAsync(Plant2, Oid))
                 .Returns(Task.FromResult<IList<string>>(new List<string> {Project1_Plant2}));
-            permissionCacheMock.Setup(p => p.GetContentRestrictionsForUserOidAsync(Plant2, Oid))
+            permissionCacheMock.Setup(p => p.GetContentRestrictionsForUserAsync(Plant2, Oid))
                 .Returns(Task.FromResult<IList<string>>(new List<string> {Restriction1_Plant2}));
 
             _principalWithOid = new ClaimsPrincipal();

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Caches/PermissionCacheTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Caches/PermissionCacheTests.cs
@@ -22,8 +22,9 @@ namespace Equinor.Procosys.Preservation.WebApi.Tests.Caches
         private readonly string TestPlant = "TestPlant";
         private readonly string Permission1 = "A";
         private readonly string Permission2 = "B";
-        private readonly string Project1 = "P1";
-        private readonly string Project2 = "P2";
+        private readonly string Project1WithAccess = "P1";
+        private readonly string Project2WithAccess = "P2";
+        private readonly string ProjectWithoutAccess = "P3";
         private readonly string Restriction1 = "R1";
         private readonly string Restriction2 = "R2";
 
@@ -33,8 +34,13 @@ namespace Equinor.Procosys.Preservation.WebApi.Tests.Caches
             TimeService.SetProvider(new ManualTimeProvider(new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc)));
 
             _permissionApiServiceMock = new Mock<IPermissionApiService>();
-            _permissionApiServiceMock.Setup(p => p.GetProjectsAsync(TestPlant))
-                .Returns(Task.FromResult<IList<string>>(new List<string> {Project1, Project2}));
+            _permissionApiServiceMock.Setup(p => p.GetAllProjectsAsync(TestPlant))
+                .Returns(Task.FromResult<IList<ProcosysProject>>(new List<ProcosysProject>
+                {
+                    new ProcosysProject {Name = Project1WithAccess, HasAccess = true},
+                    new ProcosysProject {Name = Project2WithAccess, HasAccess = true},
+                    new ProcosysProject {Name = ProjectWithoutAccess}
+                }));
             _permissionApiServiceMock.Setup(p => p.GetPermissionsAsync(TestPlant))
                 .Returns(Task.FromResult<IList<string>>(new List<string> {Permission1, Permission2}));
             _permissionApiServiceMock.Setup(p => p.GetContentRestrictionsAsync(TestPlant))
@@ -49,7 +55,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Tests.Caches
         }
 
         [TestMethod]
-        public async Task GetPermissionsForUserOid_ShouldReturnPermissionsFromPermissionApiServiceFirstTime()
+        public async Task GetPermissionsForUser_ShouldReturnPermissionsFromPermissionApiServiceFirstTime()
         {
             // Act
             var result = await _dut.GetPermissionsForUserAsync(TestPlant, Oid);
@@ -60,7 +66,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Tests.Caches
         }
 
         [TestMethod]
-        public async Task GetPermissionsForUserOid_ShouldReturnPermissionsFromCacheSecondTime()
+        public async Task GetPermissionsForUser_ShouldReturnPermissionsFromCacheSecondTime()
         {
             await _dut.GetPermissionsForUserAsync(TestPlant, Oid);
             // Act
@@ -68,39 +74,39 @@ namespace Equinor.Procosys.Preservation.WebApi.Tests.Caches
 
             // Assert
             AssertPermissions(result);
-            // since GetPermissionsForUserOidAsync has been called twice, but GetPermissionsAsync has been called once, the second Get uses cache
+            // since GetPermissionsForUserAsync has been called twice, but GetPermissionsAsync has been called once, the second Get uses cache
             _permissionApiServiceMock.Verify(p => p.GetPermissionsAsync(TestPlant), Times.Once);
         }
 
         [TestMethod]
-        public async Task GetProjectsForUserOid_ShouldReturnProjectsFromPermissionApiServiceFirstTime()
+        public async Task GetProjectsForUser_ShouldReturnProjectsFromPermissionApiServiceFirstTime()
         {
             // Act
-            var result = await _dut.GetProjectNamesForUserOidAsync(TestPlant, Oid);
+            var result = await _dut.GetProjectsForUserAsync(TestPlant, Oid);
 
             // Assert
             AssertProjects(result);
-            _permissionApiServiceMock.Verify(p => p.GetProjectsAsync(TestPlant), Times.Once);
+            _permissionApiServiceMock.Verify(p => p.GetAllProjectsAsync(TestPlant), Times.Once);
         }
 
         [TestMethod]
-        public async Task GetProjectsForUserOid_ShouldReturnProjectsFromCacheSecondTime()
+        public async Task GetProjectsForUser_ShouldReturnProjectsFromCacheSecondTime()
         {
-            await _dut.GetProjectNamesForUserOidAsync(TestPlant, Oid);
+            await _dut.GetProjectsForUserAsync(TestPlant, Oid);
             // Act
-            var result = await _dut.GetProjectNamesForUserOidAsync(TestPlant, Oid);
+            var result = await _dut.GetProjectsForUserAsync(TestPlant, Oid);
 
             // Assert
             AssertProjects(result);
-            // since GetProjectsForUserOidAsync has been called twice, but GetProjectsAsync has been called once, the second Get uses cache
-            _permissionApiServiceMock.Verify(p => p.GetProjectsAsync(TestPlant), Times.Once);
+            // since GetProjectsForUserAsync has been called twice, but GetAllProjectsAsync has been called once, the second Get uses cache
+            _permissionApiServiceMock.Verify(p => p.GetAllProjectsAsync(TestPlant), Times.Once);
         }
 
         [TestMethod]
-        public async Task GetContentRestrictionsForUserOid_ShouldReturnPermissionsFromPermissionApiServiceFirstTime()
+        public async Task GetContentRestrictionsForUser_ShouldReturnPermissionsFromPermissionApiServiceFirstTime()
         {
             // Act
-            var result = await _dut.GetContentRestrictionsForUserOidAsync(TestPlant, Oid);
+            var result = await _dut.GetContentRestrictionsForUserAsync(TestPlant, Oid);
 
             // Assert
             AssertRestrictions(result);
@@ -108,29 +114,29 @@ namespace Equinor.Procosys.Preservation.WebApi.Tests.Caches
         }
 
         [TestMethod]
-        public async Task GetContentRestrictionsForUserOid_ShouldReturnPermissionsFromCacheSecondTime()
+        public async Task GetContentRestrictionsForUser_ShouldReturnPermissionsFromCacheSecondTime()
         {
-            await _dut.GetContentRestrictionsForUserOidAsync(TestPlant, Oid);
+            await _dut.GetContentRestrictionsForUserAsync(TestPlant, Oid);
             // Act
-            var result = await _dut.GetContentRestrictionsForUserOidAsync(TestPlant, Oid);
+            var result = await _dut.GetContentRestrictionsForUserAsync(TestPlant, Oid);
 
             // Assert
             AssertRestrictions(result);
-            // since GetContentRestrictionsForUserOidAsync has been called twice, but GetContentRestrictionsAsync has been called once, the second Get uses cache
+            // since GetContentRestrictionsForUserAsync has been called twice, but GetContentRestrictionsAsync has been called once, the second Get uses cache
             _permissionApiServiceMock.Verify(p => p.GetContentRestrictionsAsync(TestPlant), Times.Once);
         }
 
         [TestMethod]
-        public async Task GetPermissionsForUserOid_ShouldThrowExceptionWhenOidIsEmty()
+        public async Task GetPermissionsForUser_ShouldThrowExceptionWhenOidIsEmty()
             => await Assert.ThrowsExceptionAsync<Exception>(() => _dut.GetPermissionsForUserAsync(TestPlant, Guid.Empty));
 
         [TestMethod]
         public async Task GetProjectNamesForUserOid_ShouldThrowExceptionWhenOidIsEmty()
-            => await Assert.ThrowsExceptionAsync<Exception>(() => _dut.GetProjectNamesForUserOidAsync(TestPlant, Guid.Empty));
+            => await Assert.ThrowsExceptionAsync<Exception>(() => _dut.GetProjectsForUserAsync(TestPlant, Guid.Empty));
 
         [TestMethod]
-        public async Task GetContentRestrictionsForUserOid_ShouldThrowExceptionWhenOidIsEmty()
-            => await Assert.ThrowsExceptionAsync<Exception>(() => _dut.GetContentRestrictionsForUserOidAsync(TestPlant, Guid.Empty));
+        public async Task GetContentRestrictionsForUser_ShouldThrowExceptionWhenOidIsEmty()
+            => await Assert.ThrowsExceptionAsync<Exception>(() => _dut.GetContentRestrictionsForUserAsync(TestPlant, Guid.Empty));
 
         [TestMethod]
         public void ClearAll_ShouldClearAllPermissionCaches()
@@ -158,8 +164,8 @@ namespace Equinor.Procosys.Preservation.WebApi.Tests.Caches
         private void AssertProjects(IList<string> result)
         {
             Assert.AreEqual(2, result.Count);
-            Assert.AreEqual(Project1, result.First());
-            Assert.AreEqual(Project2, result.Last());
+            Assert.AreEqual(Project1WithAccess, result.First());
+            Assert.AreEqual(Project2WithAccess, result.Last());
         }
 
         private void AssertRestrictions(IList<string> result)

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Caches/PlantCacheTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Caches/PlantCacheTests.cs
@@ -63,7 +63,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Tests.Caches
         }
 
         [TestMethod]
-        public async Task GetAllPlantsForUserOid_ShouldReturnPlantsFromCacheSecondTime()
+        public async Task GetPlantWithAccessForUserAsync_ShouldReturnPlantsFromCacheSecondTime()
         {
             await _dut.GetPlantWithAccessForUserAsync(_currentUserOid);
 


### PR DESCRIPTION
Part 2 of #425
The goal for this change is to distinguish between accessing a invalid project vs a project where user don't have access.

* Refactor IPermissionApiService -> GetAllProjectsAsync now get all projects, also those where user don't have access. New property ProcosysProject.HasAccess tell if user has access
* Refactored CurrentPlantMiddleware. Throw exception, not return BadRequest, if headers can't be found. This **IS** unexcepted. 
* New behavior in MediatR pipeline: If request is requesting data froma project, check if that project is a valid one. Return BadRequest if not valid. 
* HttpContextExtension which write a correct BadRequest json back to client. Also used in PlantValidatorMiddleware made in prev PR
* NB! Sequence of behaviors changed. Validate query/command before checking access and if project is valid. This because we want a BadRequest before Forbidden