### PR TITLE
77899 how validator check when children exists vol3

### DIFF
--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/CreateStep/CreateStepCommand.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/CreateStep/CreateStepCommand.cs
@@ -4,7 +4,7 @@ using ServiceResult;
 
 namespace Equinor.Procosys.Preservation.Command.JourneyCommands.CreateStep
 {
-    public class CreateStepCommand : IRequest<Result<Unit>>
+    public class CreateStepCommand : IRequest<Result<int>>
     {
         public CreateStepCommand(
             int journeyId,

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/CreateStep/CreateStepCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/CreateStep/CreateStepCommandHandler.cs
@@ -10,7 +10,7 @@ using ServiceResult;
 
 namespace Equinor.Procosys.Preservation.Command.JourneyCommands.CreateStep
 {
-    public class CreateStepCommandHandler : IRequestHandler<CreateStepCommand, Result<Unit>>
+    public class CreateStepCommandHandler : IRequestHandler<CreateStepCommand, Result<int>>
     {
         private readonly IJourneyRepository _journeyRepository;
         private readonly IModeRepository _modeRepository;
@@ -35,7 +35,7 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.CreateStep
             _responsibleApiService = responsibleApiService;
         }
 
-        public async Task<Result<Unit>> Handle(CreateStepCommand request, CancellationToken cancellationToken)
+        public async Task<Result<int>> Handle(CreateStepCommand request, CancellationToken cancellationToken)
         {
             var journey = await _journeyRepository.GetByIdAsync(request.JourneyId);
             var mode = await _modeRepository.GetByIdAsync(request.ModeId);
@@ -47,7 +47,7 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.CreateStep
                 responsible = await CreateResponsibleAsync(request.ResponsibleCode);
                 if (responsible == null)
                 {
-                    return new NotFoundResult<Unit>($"Responsible with code {request.ResponsibleCode} not found");
+                    return new NotFoundResult<int>($"Responsible with code {request.ResponsibleCode} not found");
                 }
                 // must save new Responsible to get id of it
                 await _unitOfWork.SaveChangesAsync(cancellationToken);
@@ -61,7 +61,7 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.CreateStep
             journey.AddStep(step);
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 
-            return new SuccessResult<Unit>(Unit.Value);
+            return new SuccessResult<int>(step.Id);
         }
 
         private async Task<Responsible> CreateResponsibleAsync(string responsibleCode)

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/DeleteStep/DeleteStepCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/DeleteStep/DeleteStepCommandValidator.cs
@@ -17,22 +17,17 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.DeleteStep
             CascadeMode = CascadeMode.Stop;
             
             RuleFor(command => command)
-                .MustAsync((command, token) => BeAnExistingJourneyAsync(command.JourneyId, token))
-                .WithMessage(command => $"Journey doesn't exist! Journey={command.JourneyId}")
-                .MustAsync((command, token) => BeAnExistingStepInJourneyAsync(command.JourneyId, command.StepId, token))
-                .WithMessage(command => $"Step doesn't exist within given journey! Step={command.StepId}")
+                .MustAsync((command, token) => BeAnExistingStepAsync(command.JourneyId, command.StepId, token))
+                .WithMessage(command => "Journey and/or step doesn't exist!")
                 .MustAsync((command, token) => BeAVoidedStepAsync(command.StepId, token))
                 .WithMessage(command => $"Step is not voided! Step={command.StepId}")
                 .MustAsync((command, token) => JourneyForStepNotBeUsedAsync(command.JourneyId, token))
                 .WithMessage(command => $"No steps can be deleted from journey when preservation tags exists in journey! Journey={command.JourneyId}")
                 .Must(command => HaveAValidRowVersion(command.RowVersion))
                 .WithMessage(command => $"Not a valid row version! Row version={command.RowVersion}");
-
-            async Task<bool> BeAnExistingJourneyAsync(int journeyId, CancellationToken token)
-                => await journeyValidator.ExistsAsync(journeyId, token);
             
-            async Task<bool> BeAnExistingStepInJourneyAsync(int journeyId, int stepId, CancellationToken token)
-                => await journeyValidator.HasStepAsync(journeyId, stepId, token);
+            async Task<bool> BeAnExistingStepAsync(int journeyId, int stepId, CancellationToken token)
+                => await journeyValidator.ExistsStepAsync(journeyId, stepId, token);
             
             async Task<bool> BeAVoidedStepAsync(int stepId, CancellationToken token)
                 => await stepValidator.IsVoidedAsync(stepId, token);

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/SwapSteps/SwapStepsCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/SwapSteps/SwapStepsCommandValidator.cs
@@ -17,12 +17,10 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.SwapSteps
             CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
-                .MustAsync((command, token) => BeAnExistingJourneyAsync(command.JourneyId, token))
-                .WithMessage(command => $"Journey doesn't exist! Journey={command.JourneyId}")
-                .MustAsync((command, token) => BeAnExistingStepInJourneyAsync(command.JourneyId, command.StepAId, token))
-                .WithMessage(command => $"Step doesn't exist within given journey! Step={command.StepAId}")
-                .MustAsync((command, token) => BeAnExistingStepInJourneyAsync(command.JourneyId, command.StepBId, token))
-                .WithMessage(command => $"Step doesn't exist within given journey! Step={command.StepBId}")
+                .MustAsync((command, token) => BeAnExistingStepAsync(command.JourneyId, command.StepAId, token))
+                .WithMessage(command => "Journey and/or step doesn't exist!")
+                .MustAsync((command, token) => BeAnExistingStepAsync(command.JourneyId, command.StepBId, token))
+                .WithMessage(command => "Journey and/or step doesn't exist!")
                 .MustAsync((command, token) => BeAdjacentStepsInAJourneyAsync(command.JourneyId, command.StepAId, command.StepBId, token))
                 .WithMessage(command => $"Steps are not adjacent! Steps={command.StepAId} and {command.StepBId}")
                 .MustAsync((command, token) => NotIncludeAnySupplierStep(command.StepAId, command.StepBId, token))
@@ -31,12 +29,9 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.SwapSteps
                 .WithMessage(command => $"Not a valid row version! Row version{command.StepARowVersion}")
                 .Must(command => HaveAValidRowVersion(command.StepBRowVersion))
                 .WithMessage(command => $"Not a valid row version! Row version={command.StepBRowVersion}");
-
-            async Task<bool> BeAnExistingJourneyAsync(int journeyId, CancellationToken token)
-                => await journeyValidator.ExistsAsync(journeyId, token);
             
-            async Task<bool> BeAnExistingStepInJourneyAsync(int journeyId, int stepId, CancellationToken token)
-                => await journeyValidator.HasStepAsync(journeyId, stepId, token);
+            async Task<bool> BeAnExistingStepAsync(int journeyId, int stepId, CancellationToken token)
+                => await journeyValidator.ExistsStepAsync(journeyId, stepId, token);
             
             async Task<bool> BeAdjacentStepsInAJourneyAsync(int journeyId, int stepAId, int stepBId, CancellationToken token)
                 => await journeyValidator.AreAdjacentStepsInAJourneyAsync(journeyId, stepAId, stepBId, token);

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UnvoidStep/UnvoidStepCommand.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UnvoidStep/UnvoidStepCommand.cs
@@ -3,7 +3,7 @@ using ServiceResult;
 
 namespace Equinor.Procosys.Preservation.Command.JourneyCommands.UnvoidStep
 {
-    public class UnvoidStepCommand : IRequest<Result<Unit>>
+    public class UnvoidStepCommand : IRequest<Result<string>>
     {
         public UnvoidStepCommand(int journeyId, int stepId, string rowVersion)
         {

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UnvoidStep/UnvoidStepCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UnvoidStep/UnvoidStepCommandHandler.cs
@@ -7,7 +7,7 @@ using ServiceResult;
 
 namespace Equinor.Procosys.Preservation.Command.JourneyCommands.UnvoidStep
 {
-    public class UnvoidStepCommandHandler : IRequestHandler<UnvoidStepCommand, Result<Unit>>
+    public class UnvoidStepCommandHandler : IRequestHandler<UnvoidStepCommand, Result<string>>
     {
         private readonly IJourneyRepository _journeyRepository;
         private readonly IUnitOfWork _unitOfWork;
@@ -18,14 +18,14 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.UnvoidStep
             _unitOfWork = unitOfWork;
         }
 
-        public async Task<Result<Unit>> Handle(UnvoidStepCommand request, CancellationToken cancellationToken)
+        public async Task<Result<string>> Handle(UnvoidStepCommand request, CancellationToken cancellationToken)
         {
             var journey = await _journeyRepository.GetByIdAsync(request.JourneyId);
 
-            journey.UnvoidStep(request.StepId, request.RowVersion);
+            var step = journey.UnvoidStep(request.StepId, request.RowVersion);
 
             await _unitOfWork.SaveChangesAsync(cancellationToken);
-            return new SuccessResult<Unit>(Unit.Value);
+            return new SuccessResult<string>(step.RowVersion.ConvertToString());
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UnvoidStep/UnvoidStepCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UnvoidStep/UnvoidStepCommandValidator.cs
@@ -17,15 +17,15 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.UnvoidStep
             CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
-                .MustAsync((command, token) => BeAnExistingStepInJourneyAsync(command.JourneyId, command.StepId, token))
-                .WithMessage(command => $"Step doesn't exist within given journey! Step={command.StepId}")
+                .MustAsync((command, token) => BeAnExistingStepAsync(command.JourneyId, command.StepId, token))
+                .WithMessage(command => "Journey and/or step doesn't exist!")
                 .MustAsync((command, token) => BeAVoidedStepAsync(command.StepId, token))
                 .WithMessage(command => $"Step is not voided! Step={command.StepId}")
                 .Must(command => HaveAValidRowVersion(command.RowVersion))
                 .WithMessage(command => $"Not a valid row version! Row version={command.RowVersion}");
 
-            async Task<bool> BeAnExistingStepInJourneyAsync(int journeyId, int stepId, CancellationToken token)
-                => await journeyValidator.HasStepAsync(journeyId, stepId, token);
+            async Task<bool> BeAnExistingStepAsync(int journeyId, int stepId, CancellationToken token)
+                => await journeyValidator.ExistsStepAsync(journeyId, stepId, token);
             async Task<bool> BeAVoidedStepAsync(int stepId, CancellationToken token)
                 => await stepValidator.IsVoidedAsync(stepId, token);
             bool HaveAValidRowVersion(string rowVersion)

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UpdateStep/UpdateStepCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/UpdateStep/UpdateStepCommandValidator.cs
@@ -22,14 +22,8 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.UpdateStep
             CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
-                .MustAsync((command, token) => BeAnExistingJourneyAsync(command.JourneyId, token))
-                .WithMessage(command => $"Journey doesn't exist! Journey={command.JourneyId}")
-                .MustAsync((command, token) => BeAnExistingStepAsync(command.StepId, token))
-                .WithMessage(command => $"Step doesn't exist! Step={command.StepId}")
-                .MustAsync((command, token) => StepHasJourneyAsParentAsync(command.JourneyId, command.StepId, token))
-                // this check must come after checking if both journey and step exists.
-                // If both exists, but step has another journey as parent, this is a change of parent, i.e a "move"
-                .WithMessage(command => $"Can not move a step to another journey! Step={command.StepId}")
+                .MustAsync((command, token) => BeAnExistingStepAsync(command.JourneyId, command.StepId, token))
+                .WithMessage(command => "Journey and/or step doesn't exist!")
                 .MustAsync((command, token) => HaveUniqueStepTitleInJourneyAsync(command.JourneyId, command.StepId, command.Title, token))
                 .WithMessage(command => $"Another step with title already exists in a journey! Step={command.Title}")
                 .MustAsync((command, token) => NotBeAVoidedStepAsync(command.StepId, token))
@@ -46,15 +40,9 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.UpdateStep
                 .WithMessage(command => $"Same auto transfer method can not be set on multiple steps in a journey! Method={command.AutoTransferMethod}")
                 .Must(command => HaveAValidRowVersion(command.RowVersion))
                 .WithMessage(command => $"Not a valid row version! Row version={command.RowVersion}");
-
-            async Task<bool> BeAnExistingJourneyAsync(int journeyId, CancellationToken token)
-                => await journeyValidator.ExistsAsync(journeyId, token);
             
-            async Task<bool> BeAnExistingStepAsync(int stepId, CancellationToken token)
-                => await stepValidator.ExistsAsync(stepId, token);
-            
-            async Task<bool> StepHasJourneyAsParentAsync(int journeyId, int stepId, CancellationToken token)
-                => await stepValidator.StepHasJourneyAsParentAsync(journeyId, stepId, token);
+            async Task<bool> BeAnExistingStepAsync(int journeyId, int stepId, CancellationToken token)
+                => await journeyValidator.ExistsStepAsync(journeyId, stepId, token);
             
             async Task<bool> HaveUniqueStepTitleInJourneyAsync(int journeyId, int stepId, string stepTitle, CancellationToken token) =>
                 !await journeyValidator.OtherStepExistsWithSameTitleAsync(journeyId, stepId, stepTitle, token);

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/VoidStep/VoidStepCommand.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/VoidStep/VoidStepCommand.cs
@@ -3,7 +3,7 @@ using ServiceResult;
 
 namespace Equinor.Procosys.Preservation.Command.JourneyCommands.VoidStep
 {
-    public class VoidStepCommand : IRequest<Result<Unit>>
+    public class VoidStepCommand : IRequest<Result<string>>
     {
         public VoidStepCommand(int journeyId, int stepId, string rowVersion)
         {

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/VoidStep/VoidStepCommandHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/VoidStep/VoidStepCommandHandler.cs
@@ -7,7 +7,7 @@ using ServiceResult;
 
 namespace Equinor.Procosys.Preservation.Command.JourneyCommands.VoidStep
 {
-    public class VoidStepCommandHandler : IRequestHandler<VoidStepCommand, Result<Unit>>
+    public class VoidStepCommandHandler : IRequestHandler<VoidStepCommand, Result<string>>
     {
         private readonly IJourneyRepository _journeyRepository;
         private readonly IUnitOfWork _unitOfWork;
@@ -18,14 +18,14 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.VoidStep
             _unitOfWork = unitOfWork;
         }
 
-        public async Task<Result<Unit>> Handle(VoidStepCommand request, CancellationToken cancellationToken)
+        public async Task<Result<string>> Handle(VoidStepCommand request, CancellationToken cancellationToken)
         {
             var journey = await _journeyRepository.GetByIdAsync(request.JourneyId);
 
-            journey.VoidStep(request.StepId, request.RowVersion);
+            var step = journey.VoidStep(request.StepId, request.RowVersion);
 
             await _unitOfWork.SaveChangesAsync(cancellationToken);
-            return new SuccessResult<Unit>(Unit.Value);
+            return new SuccessResult<string>(step.RowVersion.ConvertToString());
         }
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/JourneyCommands/VoidStep/VoidStepCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/JourneyCommands/VoidStep/VoidStepCommandValidator.cs
@@ -17,15 +17,15 @@ namespace Equinor.Procosys.Preservation.Command.JourneyCommands.VoidStep
             CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
-                .MustAsync((command, token) => BeAnExistingStepInJourneyAsync(command.JourneyId, command.StepId, token))
-                .WithMessage(command => $"Step doesn't exist within given journey! Step={command.StepId}")
+                .MustAsync((command, token) => BeAnExistingStepAsync(command.JourneyId, command.StepId, token))
+                .WithMessage(command => "Journey and/or step doesn't exist!")
                 .MustAsync((command, token) => NotBeAVoidedStepAsync(command.StepId, token))
                 .WithMessage(command => $"Step is already voided! Step={command.StepId}")
                 .Must(command => HaveAValidRowVersion(command.RowVersion))
                 .WithMessage(command => $"Not a valid row version! Row version={command.RowVersion}");
 
-            async Task<bool> BeAnExistingStepInJourneyAsync(int journeyId, int stepId, CancellationToken token)
-                => await journeyValidator.HasStepAsync(journeyId, stepId, token);
+            async Task<bool> BeAnExistingStepAsync(int journeyId, int stepId, CancellationToken token)
+                => await journeyValidator.ExistsStepAsync(journeyId, stepId, token);
             async Task<bool> NotBeAVoidedStepAsync(int stepId, CancellationToken token)
                 => !await stepValidator.IsVoidedAsync(stepId, token);
             bool HaveAValidRowVersion(string rowVersion)

--- a/src/Equinor.Procosys.Preservation.Command/Validators/JourneyValidators/IJourneyValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/JourneyValidators/IJourneyValidator.cs
@@ -7,7 +7,7 @@ namespace Equinor.Procosys.Preservation.Command.Validators.JourneyValidators
     public interface IJourneyValidator
     {
         Task<bool> ExistsAsync(int journeyId, CancellationToken token);
-        Task<bool> HasStepAsync(int journeyId, int stepId, CancellationToken token);
+        Task<bool> ExistsStepAsync(int journeyId, int stepId, CancellationToken token);
         Task<bool> ExistsWithSameTitleAsync(string journeyTitle, CancellationToken token);
         Task<bool> ExistsWithSameTitleInAnotherJourneyAsync(int journeyId, string journeyTitle, CancellationToken token);
         Task<bool> AnyStepExistsWithSameTitleAsync(int journeyId, string stepTitle, CancellationToken token);

--- a/src/Equinor.Procosys.Preservation.Command/Validators/JourneyValidators/JourneyValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/JourneyValidators/JourneyValidator.cs
@@ -19,7 +19,7 @@ namespace Equinor.Procosys.Preservation.Command.Validators.JourneyValidators
                 where j.Id == journeyId
                 select j).AnyAsync(token);
         
-        public async Task<bool> HasStepAsync(int journeyId, int stepId, CancellationToken token)
+        public async Task<bool> ExistsStepAsync(int journeyId, int stepId, CancellationToken token)
         {
             var journey = await GetJourneyWithStepsAsync(journeyId, token);
 

--- a/src/Equinor.Procosys.Preservation.Command/Validators/StepValidators/IStepValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/StepValidators/IStepValidator.cs
@@ -11,6 +11,5 @@ namespace Equinor.Procosys.Preservation.Command.Validators.StepValidators
         Task<bool> IsFirstStepOrModeIsNotForSupplierAsync(int journeyId, int modeId, int stepId, CancellationToken token);
         Task<bool> IsForSupplierAsync(int stepId, CancellationToken token);
         Task<bool> HasModeAsync(int modeId, int stepId, CancellationToken token);
-        Task<bool> StepHasJourneyAsParentAsync(int journeyId, int stepId, CancellationToken token);
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/Validators/StepValidators/StepValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/StepValidators/StepValidator.cs
@@ -66,10 +66,5 @@ namespace Equinor.Procosys.Preservation.Command.Validators.StepValidators
                 select s).SingleOrDefaultAsync(token);
             return step != null && step.ModeId == modeId;
         }
-
-        public async Task<bool> StepHasJourneyAsParentAsync(int journeyId, int stepId, CancellationToken token)
-            => await (from s in _context.QuerySet<Step>()
-                where s.Id == stepId && EF.Property<int>(s, "JourneyId") == journeyId
-                select s).AnyAsync(token);
     }
 }

--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/JourneyAggregate/Journey.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/JourneyAggregate/Journey.cs
@@ -92,7 +92,7 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate
             step2.SortKey = tmp;
         }
 
-        public void VoidStep(int stepId, string stepRowVersion)
+        public Step VoidStep(int stepId, string stepRowVersion)
         {
             var step = Steps.Single(s => s.Id == stepId);
 
@@ -108,9 +108,10 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate
 
             step.IsVoided = true;
             step.SetRowVersion(stepRowVersion);
+            return step;
         }
 
-        public void UnvoidStep(int stepId, string stepRowVersion)
+        public Step UnvoidStep(int stepId, string stepRowVersion)
         {
             var step = Steps.Single(s => s.Id == stepId);
 
@@ -126,6 +127,7 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate
 
             step.IsVoided = false;
             step.SetRowVersion(stepRowVersion);
+            return step;
         }
 
         public bool AreAdjacentSteps(int stepId1, int stepId2)

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Journeys/JourneysController.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Journeys/JourneysController.cs
@@ -72,7 +72,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Journeys
 
         [Authorize(Roles = Permissions.LIBRARY_PRESERVATION_WRITE)]
         [HttpPut("{id}")]
-        public async Task<IActionResult> UpdateJourney(
+        public async Task<ActionResult<string>> UpdateJourney(
             [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
             [Required]
             string plant,
@@ -97,7 +97,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Journeys
         
         [Authorize(Roles = Permissions.LIBRARY_PRESERVATION_VOIDUNVOID)]
         [HttpPut("{id}/Void")]
-        public async Task<IActionResult> VoidJourney(
+        public async Task<ActionResult<string>> VoidJourney(
             [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
             [Required]
             string plant,
@@ -111,7 +111,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Journeys
 
         [Authorize(Roles = Permissions.LIBRARY_PRESERVATION_VOIDUNVOID)]
         [HttpPut("{id}/Unvoid")]
-        public async Task<IActionResult> UnvoidJourney(
+        public async Task<ActionResult<string>> UnvoidJourney(
             [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
             [Required]
             string plant,
@@ -138,7 +138,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Journeys
 
         [Authorize(Roles = Permissions.LIBRARY_PRESERVATION_CREATE)]
         [HttpPost("{id}/AddStep")]
-        public async Task<ActionResult> AddStep(
+        public async Task<ActionResult<int>> AddStep(
             [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
             [Required]
             [StringLength(PlantEntityBase.PlantLengthMax, MinimumLength = PlantEntityBase.PlantLengthMin)]
@@ -157,7 +157,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Journeys
 
         [Authorize(Roles = Permissions.LIBRARY_PRESERVATION_WRITE)]
         [HttpPut("{id}/Steps/{stepId}")]
-        public async Task<ActionResult> UpdateStep(
+        public async Task<ActionResult<string>> UpdateStep(
             [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
             [Required]
             string plant,
@@ -193,7 +193,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Journeys
 
         [Authorize(Roles = Permissions.LIBRARY_PRESERVATION_VOIDUNVOID)]
         [HttpPut("{id}/Steps/{stepId}/Void")]
-        public async Task<ActionResult> VoidStep(
+        public async Task<ActionResult<string>> VoidStep(
             [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
             [Required]
             [StringLength(PlantEntityBase.PlantLengthMax, MinimumLength = PlantEntityBase.PlantLengthMin)]
@@ -208,7 +208,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Journeys
 
         [Authorize(Roles = Permissions.LIBRARY_PRESERVATION_VOIDUNVOID)]
         [HttpPut("{id}/Steps/{stepId}/Unvoid")]
-        public async Task<ActionResult> UnvoidStep(
+        public async Task<ActionResult<string>> UnvoidStep(
             [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
             [Required]
             [StringLength(PlantEntityBase.PlantLengthMax, MinimumLength = PlantEntityBase.PlantLengthMin)]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/DeleteStep/DeleteStepCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/DeleteStep/DeleteStepCommandValidatorTests.cs
@@ -25,8 +25,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.DeleteStep
         public void Setup_OkState()
         {
             _journeyValidatorMock = new Mock<IJourneyValidator>();
-            _journeyValidatorMock.Setup(r => r.ExistsAsync(_journeyId, default)).Returns(Task.FromResult(true));
-            _journeyValidatorMock.Setup(r => r.HasStepAsync(_journeyId, _stepId, default)).Returns(Task.FromResult(true));
+            _journeyValidatorMock.Setup(r => r.ExistsStepAsync(_journeyId, _stepId, default)).Returns(Task.FromResult(true));
             _stepValidatorMock = new Mock<IStepValidator>();
             _stepValidatorMock.Setup(r => r.IsVoidedAsync(_stepId, default)).Returns(Task.FromResult(true));
             _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
@@ -49,27 +48,15 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.DeleteStep
         }
 
         [TestMethod]
-        public void Validate_ShouldFail_WhenJourneyNotExists()
+        public void Validate_ShouldFail_WhenStepNotExists()
         {
-            _journeyValidatorMock.Setup(r => r.ExistsAsync(_journeyId, default)).Returns(Task.FromResult(false));
+            _journeyValidatorMock.Setup(r => r.ExistsStepAsync(_journeyId, _stepId, default)).Returns(Task.FromResult(false));
             
             var result = _dut.Validate(_command);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Journey doesn't exist!"));
-        }
-
-        [TestMethod]
-        public void Validate_ShouldFail_WhenJourneyDontHaveTheStep()
-        {
-            _journeyValidatorMock.Setup(r => r.HasStepAsync(_journeyId, _stepId, default)).Returns(Task.FromResult(false));
-            
-            var result = _dut.Validate(_command);
-
-            Assert.IsFalse(result.IsValid);
-            Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Step doesn't exist within given journey!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Journey and/or step doesn't exist!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/SwapSteps/SwapStepsCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/SwapSteps/SwapStepsCommandValidatorTests.cs
@@ -28,11 +28,10 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.SwapSteps
         public void Setup_OkState()
         {
             _journeyValidatorMock = new Mock<IJourneyValidator>();
-            _journeyValidatorMock.Setup(r => r.ExistsAsync(_journeyId, default)).Returns(Task.FromResult(true));
             _journeyValidatorMock.Setup(r => r.AreAdjacentStepsInAJourneyAsync(_journeyId, _stepAId, _stepBId, default))
                 .Returns(Task.FromResult(true));
-            _journeyValidatorMock.Setup(r => r.HasStepAsync(_journeyId, _stepAId, default)).Returns(Task.FromResult(true));
-            _journeyValidatorMock.Setup(r => r.HasStepAsync(_journeyId, _stepBId, default)).Returns(Task.FromResult(true));
+            _journeyValidatorMock.Setup(r => r.ExistsStepAsync(_journeyId, _stepAId, default)).Returns(Task.FromResult(true));
+            _journeyValidatorMock.Setup(r => r.ExistsStepAsync(_journeyId, _stepBId, default)).Returns(Task.FromResult(true));
 
             _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
             _rowVersionValidatorMock.Setup(r => r.IsValid(_stepARowVersion)).Returns(true);
@@ -54,39 +53,27 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.SwapSteps
         }
 
         [TestMethod]
-        public void Validate_ShouldFail_WhenJourneyNotExists()
+        public void Validate_ShouldFail_WhenStepANotExists()
         {
-            _journeyValidatorMock.Setup(r => r.ExistsAsync(_journeyId, default)).Returns(Task.FromResult(false));
-
-            var result = _dut.Validate(_command);
-
-            Assert.IsFalse(result.IsValid);
-            Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Journey doesn't exist!"));
-        }
-
-        [TestMethod]
-        public void Validate_ShouldFail_WhenJourneyDoesNotHaveStepA()
-        {
-            _journeyValidatorMock.Setup(r => r.HasStepAsync(_journeyId, _stepAId, default)).Returns(Task.FromResult(false));
+            _journeyValidatorMock.Setup(r => r.ExistsStepAsync(_journeyId, _stepAId, default)).Returns(Task.FromResult(false));
             
             var result = _dut.Validate(_command);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Step doesn't exist within given journey!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Journey and/or step doesn't exist!"));
         }
 
         [TestMethod]
-        public void Validate_ShouldFail_WhenJourneyDoesNotHaveStepB()
+        public void Validate_ShouldFail_WhenStepBNotExists()
         {
-            _journeyValidatorMock.Setup(r => r.HasStepAsync(_journeyId, _stepBId, default)).Returns(Task.FromResult(false));
+            _journeyValidatorMock.Setup(r => r.ExistsStepAsync(_journeyId, _stepBId, default)).Returns(Task.FromResult(false));
             
             var result = _dut.Validate(_command);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Step doesn't exist within given journey!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Journey and/or step doesn't exist!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UnvoidStep/UnvoidStepCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UnvoidStep/UnvoidStepCommandValidatorTests.cs
@@ -25,7 +25,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UnvoidStep
         public void Setup_OkState()
         {
             _journeyValidatorMock = new Mock<IJourneyValidator>();
-            _journeyValidatorMock.Setup(r => r.HasStepAsync(_journeyId, _stepId, default)).Returns(Task.FromResult(true));
+            _journeyValidatorMock.Setup(r => r.ExistsStepAsync(_journeyId, _stepId, default)).Returns(Task.FromResult(true));
             _stepValidatorMock = new Mock<IStepValidator>();
             _stepValidatorMock.Setup(r => r.IsVoidedAsync(_stepId, default)).Returns(Task.FromResult(true));
 
@@ -45,15 +45,15 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UnvoidStep
         }
 
         [TestMethod]
-        public void Validate_ShouldFail_WhenJourneyDoesNotHaveStep()
+        public void Validate_ShouldFail_WhenStepNotExists()
         {
-            _journeyValidatorMock.Setup(r => r.HasStepAsync(_journeyId, _stepId, default)).Returns(Task.FromResult(false));
+            _journeyValidatorMock.Setup(r => r.ExistsStepAsync(_journeyId, _stepId, default)).Returns(Task.FromResult(false));
             
             var result = _dut.Validate(_command);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Step doesn't exist within given journey!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Journey and/or step doesn't exist!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateStep/UpdateStepCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/UpdateStep/UpdateStepCommandValidatorTests.cs
@@ -34,11 +34,9 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UpdateStep
         public void Setup_OkState()
         {
             _journeyValidatorMock = new Mock<IJourneyValidator>();
-            _journeyValidatorMock.Setup(r => r.ExistsAsync(_journeyId, default)).Returns(Task.FromResult(true));
+            _journeyValidatorMock.Setup(r => r.ExistsStepAsync(_journeyId, _stepId, default)).Returns(Task.FromResult(true));
 
             _stepValidatorMock = new Mock<IStepValidator>();
-            _stepValidatorMock.Setup(r => r.ExistsAsync(_stepId, default)).Returns(Task.FromResult(true));
-            _stepValidatorMock.Setup(r => r.StepHasJourneyAsParentAsync(_journeyId, _stepId, default)).Returns(Task.FromResult(true));
             _stepValidatorMock.Setup(r => r.IsFirstStepOrModeIsNotForSupplierAsync(_journeyId, _modeId, _stepId, default)).Returns(Task.FromResult(true));
             _stepValidatorMock.Setup(r => r.HasModeAsync(_modeId, _stepId, default)).Returns(Task.FromResult(true));
 
@@ -69,39 +67,15 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.UpdateStep
         }
 
         [TestMethod]
-        public void Validate_ShouldFail_WhenJourneyNotExists()
-        {
-            _journeyValidatorMock.Setup(r => r.ExistsAsync(_journeyId, default)).Returns(Task.FromResult(false));
-
-            var result = _dut.Validate(_command);
-
-            Assert.IsFalse(result.IsValid);
-            Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Journey doesn't exist!"));
-        }
-
-        [TestMethod]
         public void Validate_ShouldFail_WhenStepNotExists()
         {
-            _stepValidatorMock.Setup(r => r.ExistsAsync(_stepId, default)).Returns(Task.FromResult(false));
+            _journeyValidatorMock.Setup(r => r.ExistsStepAsync(_journeyId, _stepId, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Step doesn't exist!"));
-        }
-
-        [TestMethod]
-        public void Validate_ShouldFail_WhenBothJourneyAndStepExists_ButStepHasOtherParent()
-        {
-            _stepValidatorMock.Setup(r => r.StepHasJourneyAsParentAsync(_journeyId, _stepId, default)).Returns(Task.FromResult(false));
-
-            var result = _dut.Validate(_command);
-
-            Assert.IsFalse(result.IsValid);
-            Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Can not move a step to another journey!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Journey and/or step doesn't exist!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/VoidStep/VoidStepCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/JourneyCommands/VoidStep/VoidStepCommandValidatorTests.cs
@@ -25,7 +25,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.VoidStep
         public void Setup_OkState()
         {
             _journeyValidatorMock = new Mock<IJourneyValidator>();
-            _journeyValidatorMock.Setup(r => r.HasStepAsync(_journeyId, _stepId, default)).Returns(Task.FromResult(true));
+            _journeyValidatorMock.Setup(r => r.ExistsStepAsync(_journeyId, _stepId, default)).Returns(Task.FromResult(true));
 
             _stepValidatorMock = new Mock<IStepValidator>();
 
@@ -43,17 +43,17 @@ namespace Equinor.Procosys.Preservation.Command.Tests.JourneyCommands.VoidStep
 
             Assert.IsTrue(result.IsValid);
         }
-
+        
         [TestMethod]
-        public void Validate_ShouldFail_WhenJourneyDoesNotHaveStep()
+        public void Validate_ShouldFail_WhenStepNotExists()
         {
-            _journeyValidatorMock.Setup(r => r.HasStepAsync(_journeyId, _stepId, default)).Returns(Task.FromResult(false));
+            _journeyValidatorMock.Setup(r => r.ExistsStepAsync(_journeyId, _stepId, default)).Returns(Task.FromResult(false));
             
             var result = _dut.Validate(_command);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Step doesn't exist within given journey!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Journey and/or step doesn't exist!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/JourneyValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/JourneyValidatorTests.cs
@@ -74,34 +74,34 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
-        public async Task HasStepAsync_KnownIds_ShouldReturnTrue()
+        public async Task ExistsStepAsync_KnownIds_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new JourneyValidator(context);
-                var result = await dut.HasStepAsync(_journey1WithStepId, _step1InJourney1.Id, default);
+                var result = await dut.ExistsStepAsync(_journey1WithStepId, _step1InJourney1.Id, default);
                 Assert.IsTrue(result);
             }
         }
 
         [TestMethod]
-        public async Task HasStepAsync_UnknownJourneyId_ShouldReturnFalse()
+        public async Task ExistsStepAsync_UnknownJourneyId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new JourneyValidator(context);
-                var result = await dut.HasStepAsync(126234, _step1InJourney1.Id, default);
+                var result = await dut.ExistsStepAsync(126234, _step1InJourney1.Id, default);
                 Assert.IsFalse(result);
             }
         }
 
         [TestMethod]
-        public async Task HasStepAsync_UnknownStepId_ShouldReturnFalse()
+        public async Task ExistsStepAsync_UnknownStepId_ShouldReturnFalse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {
                 var dut = new JourneyValidator(context);
-                var result = await dut.HasStepAsync(_journey1WithStepId, 126234, default);
+                var result = await dut.ExistsStepAsync(_journey1WithStepId, 126234, default);
                 Assert.IsFalse(result);
             }
         }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/StepValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/StepValidatorTests.cs
@@ -210,38 +210,5 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
                 Assert.IsTrue(result);
             }
         }
-
-        [TestMethod]
-        public async Task StepHasJourneyAsParentAsync_UnknownStepId_ShouldReturnFalse()
-        {
-            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
-            {
-                var dut = new StepValidator(context);
-                var result = await dut.StepHasJourneyAsParentAsync(_journey1.Id, 126234, default);
-                Assert.IsFalse(result);
-            }
-        }
-
-        [TestMethod]
-        public async Task StepHasJourneyAsParentAsync_UnknownJourneyId_ShouldReturnFalse()
-        {
-            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
-            {
-                var dut = new StepValidator(context);
-                var result = await dut.StepHasJourneyAsParentAsync(126234, _step1InJourney1ForSupplier.Id, default);
-                Assert.IsFalse(result);
-            }
-        }
-
-        [TestMethod]
-        public async Task StepHasJourneyAsParentAsync_KnownIds_ShouldReturnTrue()
-        {
-            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
-            {
-                var dut = new StepValidator(context);
-                var result = await dut.StepHasJourneyAsParentAsync(_journey1.Id, _step1InJourney1ForSupplier.Id, default);
-                Assert.IsTrue(result);
-            }
-        }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Domain.Tests/AggregateModels/JourneyAggregate/JourneyTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Domain.Tests/AggregateModels/JourneyAggregate/JourneyTests.cs
@@ -199,11 +199,21 @@ namespace Equinor.Procosys.Preservation.Domain.Tests.AggregateModels.JourneyAggr
         public void VoidStep_ShouldVoidStep()
         {
             var stepToVoid = _dutWith3Steps.Steps.First();
-            Assert.IsTrue(stepToVoid.IsVoided == false);
+            Assert.IsFalse(stepToVoid.IsVoided);
 
             _dutWith3Steps.VoidStep(stepToVoid.Id, "AAAAAAAAABA=");
 
             Assert.IsTrue(stepToVoid.IsVoided);
+        }
+
+        [TestMethod]
+        public void VoidStep_ShouldReturnVoidedStep()
+        {
+            var stepToVoid = _dutWith3Steps.Steps.First();
+
+            var step = _dutWith3Steps.VoidStep(stepToVoid.Id, "AAAAAAAAABA=");
+
+            Assert.AreEqual(step, stepToVoid);
         }
 
         [TestMethod]
@@ -217,6 +227,17 @@ namespace Equinor.Procosys.Preservation.Domain.Tests.AggregateModels.JourneyAggr
             _dutWith3Steps.UnvoidStep(stepToUnvoid.Id, "AAAAAAAAABA=");
 
             Assert.IsFalse(stepToUnvoid.IsVoided);
+        }
+
+        [TestMethod]
+        public void UnvoidStep_ShouldReturnUnvoidedStep()
+        {
+            var stepToUnvoid = _dutWith3Steps.Steps.First();
+            stepToUnvoid.IsVoided = true;
+
+            var step = _dutWith3Steps.UnvoidStep(stepToUnvoid.Id, "AAAAAAAAABA=");
+
+            Assert.AreEqual(step, stepToUnvoid);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneyDetailsDto.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneyDetailsDto.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
+{
+    public class JourneyDetailsDto
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public bool IsVoided { get; set; }
+        public bool IsInUse { get; set; }
+        public IEnumerable<StepDetailsDto> Steps { get; set; }
+        public string RowVersion { get; set; }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneyDto.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneyDto.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
+{
+    public class JourneyDto
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public bool IsVoided { get; set; }
+        public IEnumerable<StepDto> Steps { get; set; }
+        public string RowVersion { get; set; }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerNegativeTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerNegativeTests.cs
@@ -60,6 +60,80 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
                 HttpStatusCode.Forbidden);
         #endregion
 
+        #region CreateStep
+        [TestMethod]
+        public async Task CreateStep_AsAnonymous_ShouldReturnUnauthorized()
+            => await JourneysControllerTestsHelper.CreateStepAsync(
+                AnonymousClient(TestFactory.UnknownPlant),
+                9999,
+                "Step1",
+                7777,
+                "RC",
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task CreateStep_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await JourneysControllerTestsHelper.CreateStepAsync(
+                AuthenticatedHackerClient(TestFactory.UnknownPlant),
+                9999,
+                "Step1",
+                7777,
+                "RC",
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task CreateStep_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await JourneysControllerTestsHelper.CreateStepAsync(
+                LibraryAdminClient(TestFactory.UnknownPlant),
+                9999,
+                "Step1",
+                7777,
+                "RC",
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task CreateStep_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await JourneysControllerTestsHelper.CreateStepAsync(
+                AuthenticatedHackerClient(TestFactory.PlantWithoutAccess),
+                9999,
+                "Step1",
+                7777,
+                "RC",
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task CreateStep_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await JourneysControllerTestsHelper.CreateStepAsync(
+                LibraryAdminClient(TestFactory.PlantWithoutAccess),
+                9999,
+                "Step1",
+                7777,
+                "RC",
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task CreateStep_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await JourneysControllerTestsHelper.CreateStepAsync(
+                PlannerClient(TestFactory.PlantWithAccess),
+                9999,
+                "Step1",
+                7777,
+                "RC",
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task CreateStep_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await JourneysControllerTestsHelper.CreateStepAsync(
+                PreserverClient(TestFactory.PlantWithAccess),
+                9999,
+                "Step1",
+                7777,
+                "RC",
+                HttpStatusCode.Forbidden);
+        #endregion
+
         #region UpdateStep
         [TestMethod]
         public async Task UpdateStep_AsAnonymous_ShouldReturnUnauthorized()
@@ -144,6 +218,140 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
                 "Step1",
                 7777,
                 "RC",
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+        #endregion
+
+        #region VoidStep
+        [TestMethod]
+        public async Task VoidStep_AsAnonymous_ShouldReturnUnauthorized()
+            => await JourneysControllerTestsHelper.VoidStepAsync(
+                AnonymousClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task VoidStep_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await JourneysControllerTestsHelper.VoidStepAsync(
+                AuthenticatedHackerClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task VoidStep_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await JourneysControllerTestsHelper.VoidStepAsync(
+                LibraryAdminClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task VoidStep_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await JourneysControllerTestsHelper.VoidStepAsync(
+                AuthenticatedHackerClient(TestFactory.PlantWithoutAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidStep_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await JourneysControllerTestsHelper.VoidStepAsync(
+                LibraryAdminClient(TestFactory.PlantWithoutAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidStep_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await JourneysControllerTestsHelper.VoidStepAsync(
+                PlannerClient(TestFactory.PlantWithAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidStep_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await JourneysControllerTestsHelper.VoidStepAsync(
+                PreserverClient(TestFactory.PlantWithAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+        #endregion
+
+        #region UnvoidStep
+        [TestMethod]
+        public async Task UnvoidStep_AsAnonymous_ShouldReturnUnauthorized()
+            => await JourneysControllerTestsHelper.UnvoidStepAsync(
+                AnonymousClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task UnvoidStep_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await JourneysControllerTestsHelper.UnvoidStepAsync(
+                AuthenticatedHackerClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task UnvoidStep_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await JourneysControllerTestsHelper.UnvoidStepAsync(
+                LibraryAdminClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task UnvoidStep_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await JourneysControllerTestsHelper.UnvoidStepAsync(
+                AuthenticatedHackerClient(TestFactory.PlantWithoutAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidStep_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await JourneysControllerTestsHelper.UnvoidStepAsync(
+                LibraryAdminClient(TestFactory.PlantWithoutAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidStep_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await JourneysControllerTestsHelper.UnvoidStepAsync(
+                PlannerClient(TestFactory.PlantWithAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidStep_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await JourneysControllerTestsHelper.UnvoidStepAsync(
+                PreserverClient(TestFactory.PlantWithAccess),
+                9999,
+                8888,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
         #endregion

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerNegativeTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerNegativeTests.cs
@@ -1,0 +1,144 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
+{
+    [TestClass]
+    public class JourneysControllerNegativeTests : JourneysControllerTestsBase
+    {
+        #region GetStep
+        [TestMethod]
+        public async Task GetStep_AsAnonymous_ShouldReturnUnauthorized()
+            => await JourneysControllerTestsHelper.GetStepAsync(
+                AnonymousClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task GetStep_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await JourneysControllerTestsHelper.GetStepAsync(
+                AuthenticatedHackerClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task GetStep_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await JourneysControllerTestsHelper.GetStepAsync(
+                LibraryAdminClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task GetStep_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await JourneysControllerTestsHelper.GetStepAsync(
+                AuthenticatedHackerClient(TestFactory.PlantWithoutAccess),
+                9999,
+                8888,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task GetStep_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await JourneysControllerTestsHelper.GetStepAsync(
+                LibraryAdminClient(TestFactory.PlantWithoutAccess),
+                9999,
+                8888,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task GetStep_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await JourneysControllerTestsHelper.GetStepAsync(
+                PlannerClient(TestFactory.PlantWithAccess),
+                9999,
+                8888,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task GetStep_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await JourneysControllerTestsHelper.GetStepAsync(
+                PreserverClient(TestFactory.PlantWithAccess),
+                9999,
+                8888,
+                HttpStatusCode.Forbidden);
+        #endregion
+
+        #region UpdateStep
+        [TestMethod]
+        public async Task UpdateStep_AsAnonymous_ShouldReturnUnauthorized()
+            => await JourneysControllerTestsHelper.UpdateStepAsync(
+                AnonymousClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                "Step1",
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task UpdateStep_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await JourneysControllerTestsHelper.UpdateStepAsync(
+                AuthenticatedHackerClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                "Step1",
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task UpdateStep_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await JourneysControllerTestsHelper.UpdateStepAsync(
+                LibraryAdminClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                "Step1",
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task UpdateStep_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await JourneysControllerTestsHelper.UpdateStepAsync(
+                AuthenticatedHackerClient(TestFactory.PlantWithoutAccess),
+                9999,
+                8888,
+                "Step1",
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateStep_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await JourneysControllerTestsHelper.UpdateStepAsync(
+                LibraryAdminClient(TestFactory.PlantWithoutAccess),
+                9999,
+                8888,
+                "Step1",
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateStep_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await JourneysControllerTestsHelper.UpdateStepAsync(
+                PlannerClient(TestFactory.PlantWithAccess),
+                9999,
+                8888,
+                "Step1",
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateStep_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await JourneysControllerTestsHelper.UpdateStepAsync(
+                PreserverClient(TestFactory.PlantWithAccess),
+                9999,
+                8888,
+                "Step1",
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+        #endregion
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerNegativeTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerNegativeTests.cs
@@ -7,63 +7,56 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
     [TestClass]
     public class JourneysControllerNegativeTests : JourneysControllerTestsBase
     {
-        #region GetStep
+        #region GetJourney
         [TestMethod]
-        public async Task GetStep_AsAnonymous_ShouldReturnUnauthorized()
-            => await JourneysControllerTestsHelper.GetStepAsync(
+        public async Task GetJourney_AsAnonymous_ShouldReturnUnauthorized()
+            => await JourneysControllerTestsHelper.GetJourneyAsync(
                 AnonymousClient(TestFactory.UnknownPlant),
                 9999,
-                8888,
                 HttpStatusCode.Unauthorized);
 
         [TestMethod]
-        public async Task GetStep_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
-            => await JourneysControllerTestsHelper.GetStepAsync(
+        public async Task GetJourney_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await JourneysControllerTestsHelper.GetJourneyAsync(
                 AuthenticatedHackerClient(TestFactory.UnknownPlant),
                 9999,
-                8888,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
 
         [TestMethod]
-        public async Task GetStep_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
-            => await JourneysControllerTestsHelper.GetStepAsync(
+        public async Task GetJourney_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await JourneysControllerTestsHelper.GetJourneyAsync(
                 LibraryAdminClient(TestFactory.UnknownPlant),
                 9999,
-                8888,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
 
         [TestMethod]
-        public async Task GetStep_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
-            => await JourneysControllerTestsHelper.GetStepAsync(
+        public async Task GetJourney_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await JourneysControllerTestsHelper.GetJourneyAsync(
                 AuthenticatedHackerClient(TestFactory.PlantWithoutAccess),
                 9999,
-                8888,
                 HttpStatusCode.Forbidden);
 
         [TestMethod]
-        public async Task GetStep_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
-            => await JourneysControllerTestsHelper.GetStepAsync(
+        public async Task GetJourney_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await JourneysControllerTestsHelper.GetJourneyAsync(
                 LibraryAdminClient(TestFactory.PlantWithoutAccess),
                 9999,
-                8888,
                 HttpStatusCode.Forbidden);
 
         [TestMethod]
-        public async Task GetStep_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
-            => await JourneysControllerTestsHelper.GetStepAsync(
+        public async Task GetJourney_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await JourneysControllerTestsHelper.GetJourneyAsync(
                 PlannerClient(TestFactory.PlantWithAccess),
                 9999,
-                8888,
                 HttpStatusCode.Forbidden);
 
         [TestMethod]
-        public async Task GetStep_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
-            => await JourneysControllerTestsHelper.GetStepAsync(
+        public async Task GetJourney_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await JourneysControllerTestsHelper.GetJourneyAsync(
                 PreserverClient(TestFactory.PlantWithAccess),
                 9999,
-                8888,
                 HttpStatusCode.Forbidden);
         #endregion
 
@@ -75,6 +68,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
                 9999,
                 8888,
                 "Step1",
+                7777,
+                "RC",
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Unauthorized);
 
@@ -85,6 +80,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
                 9999,
                 8888,
                 "Step1",
+                7777,
+                "RC",
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
@@ -96,6 +93,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
                 9999,
                 8888,
                 "Step1",
+                7777,
+                "RC",
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
@@ -107,6 +106,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
                 9999,
                 8888,
                 "Step1",
+                7777,
+                "RC",
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -117,6 +118,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
                 9999,
                 8888,
                 "Step1",
+                7777,
+                "RC",
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -127,6 +130,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
                 9999,
                 8888,
                 "Step1",
+                7777,
+                "RC",
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -137,6 +142,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
                 9999,
                 8888,
                 "Step1",
+                7777,
+                "RC",
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
         #endregion

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerNegativeTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerNegativeTests.cs
@@ -272,8 +272,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task UpdateStep_AsAdmin_ShouldReturnBadRequest_WhenUnknownJourneyOrStepId()
             => await JourneysControllerTestsHelper.UpdateStepAsync(
                 LibraryAdminClient(TestFactory.PlantWithAccess),
-                JourneyBIdUnderTest,
-                StepInJourneyAIdUnderTest, // step in other Journey
+                JourneyNotInUseIdUnderTest,
+                StepInJourneyWithTagsIdUnderTest, // step in other Journey
                 Guid.NewGuid().ToString(),
                 ModeIdUnderTest,
                 KnownTestData.ResponsibleCode,
@@ -353,8 +353,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task VoidStep_AsAdmin_ShouldReturnBadRequest_WhenUnknownJourneyOrStepId()
             => await JourneysControllerTestsHelper.VoidStepAsync(
                 LibraryAdminClient(TestFactory.PlantWithAccess),
-                JourneyBIdUnderTest,
-                StepInJourneyAIdUnderTest, // step in other Journey
+                JourneyNotInUseIdUnderTest,
+                StepInJourneyWithTagsIdUnderTest, // step in other Journey
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "Journey and/or step doesn't exist!");
@@ -430,11 +430,89 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task UnvoidStep_AsAdmin_ShouldReturnBadRequest_WhenUnknownJourneyOrStepId()
             => await JourneysControllerTestsHelper.UnvoidStepAsync(
                 LibraryAdminClient(TestFactory.PlantWithAccess),
-                JourneyBIdUnderTest,
-                StepInJourneyAIdUnderTest, // step in other Journey
+                JourneyNotInUseIdUnderTest,
+                StepInJourneyWithTagsIdUnderTest, // step in other Journey
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "Journey and/or step doesn't exist!");
+        #endregion
+
+        #region DeleteStep
+        [TestMethod]
+        public async Task DeleteStep_AsAnonymous_ShouldReturnUnauthorized()
+            => await JourneysControllerTestsHelper.DeleteStepAsync(
+                AnonymousClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task DeleteStep_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await JourneysControllerTestsHelper.DeleteStepAsync(
+                AuthenticatedHackerClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task DeleteStep_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await JourneysControllerTestsHelper.DeleteStepAsync(
+                LibraryAdminClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task DeleteStep_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await JourneysControllerTestsHelper.DeleteStepAsync(
+                AuthenticatedHackerClient(TestFactory.PlantWithoutAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task DeleteStep_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await JourneysControllerTestsHelper.DeleteStepAsync(
+                LibraryAdminClient(TestFactory.PlantWithoutAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task DeleteStep_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await JourneysControllerTestsHelper.DeleteStepAsync(
+                PlannerClient(TestFactory.PlantWithAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task DeleteStep_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await JourneysControllerTestsHelper.DeleteStepAsync(
+                PreserverClient(TestFactory.PlantWithAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task DeleteStep_AsAdmin_ShouldReturnBadRequest_WhenUnknownJourneyOrStepId()
+            => await JourneysControllerTestsHelper.DeleteStepAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                JourneyNotInUseIdUnderTest,
+                StepInJourneyWithTagsIdUnderTest, // step in other Journey
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "Journey and/or step doesn't exist!");
+
         #endregion
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTests.cs
@@ -9,18 +9,32 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
     public class JourneysControllerTests : JourneysControllerTestsBase
     {
         [TestMethod]
+        public async Task GetJourneys_AsAdmin_ShouldGetJourneysWithSteps()
+        {
+            // Act
+            var journeys = await JourneysControllerTestsHelper.GetJourneysAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess));
+
+            // Assert
+            Assert.IsNotNull(journeys);
+            Assert.AreNotEqual(0, journeys.Count);
+            var step = journeys.First().Steps.FirstOrDefault();
+            Assert.IsNotNull(step);
+        }
+
+        [TestMethod]
         public async Task GetJourney_AsAdmin_ShouldGetJourneyWithStep()
         {
             // Act
             var journey = await JourneysControllerTestsHelper.GetJourneyAsync(
                 LibraryAdminClient(TestFactory.PlantWithAccess),
-                JourneyIdUnderTest);
+                JourneyAIdUnderTest);
 
             // Assert
             Assert.IsNotNull(journey);
             Assert.IsNotNull(journey.Steps);
             Assert.AreNotEqual(0, journey.Steps.Count());
-            var step = journey.Steps.SingleOrDefault(s => s.Id == StepIdUnderTest);
+            var step = journey.Steps.SingleOrDefault(s => s.Id == StepInJourneyAIdUnderTest);
             Assert.IsNotNull(step);
         }
 
@@ -33,7 +47,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
             // Act
             var stepId = await JourneysControllerTestsHelper.CreateStepAsync(
                 LibraryAdminClient(TestFactory.PlantWithAccess),
-                JourneyIdUnderTest,
+                JourneyAIdUnderTest,
                 title,
                 ModeIdUnderTest,
                 KnownTestData.ResponsibleCode);
@@ -47,14 +61,14 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task UpdateStep_AsAdmin_ShouldUpdateStepAndRowVersion()
         {
             // Arrange
-            var step = await GetStepDetails(StepIdUnderTest);
+            var step = await GetStepDetails(StepInJourneyAIdUnderTest);
             var currentRowVersion = step.RowVersion;
             var newTitle = Guid.NewGuid().ToString();
 
             // Act
             var newRowVersion = await JourneysControllerTestsHelper.UpdateStepAsync(
                 LibraryAdminClient(TestFactory.PlantWithAccess),
-                JourneyIdUnderTest,
+                JourneyAIdUnderTest,
                 step.Id,
                 newTitle,
                 ModeIdUnderTest,
@@ -63,7 +77,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
 
             // Assert
             AssertRowVersionChange(currentRowVersion, newRowVersion);
-            step = await GetStepDetails(StepIdUnderTest);
+            step = await GetStepDetails(StepInJourneyAIdUnderTest);
             Assert.AreEqual(newTitle, step.Title);
         }
 
@@ -73,7 +87,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
             // Arrange
             var stepId = await JourneysControllerTestsHelper.CreateStepAsync(
                 LibraryAdminClient(TestFactory.PlantWithAccess),
-                JourneyIdUnderTest,
+                JourneyAIdUnderTest,
                 Guid.NewGuid().ToString(),
                 ModeIdUnderTest,
                 KnownTestData.ResponsibleCode);
@@ -84,7 +98,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
             // Act
             var newRowVersion = await JourneysControllerTestsHelper.VoidStepAsync(
                 LibraryAdminClient(TestFactory.PlantWithAccess),
-                JourneyIdUnderTest,
+                JourneyAIdUnderTest,
                 stepId,
                 currentRowVersion);
 
@@ -100,21 +114,21 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
             // Arrange
             var stepId = await JourneysControllerTestsHelper.CreateStepAsync(
                 LibraryAdminClient(TestFactory.PlantWithAccess),
-                JourneyIdUnderTest,
+                JourneyAIdUnderTest,
                 Guid.NewGuid().ToString(),
                 ModeIdUnderTest,
                 KnownTestData.ResponsibleCode);
             var step = await GetStepDetails(stepId);
             var currentRowVersion = await JourneysControllerTestsHelper.VoidStepAsync(
                 LibraryAdminClient(TestFactory.PlantWithAccess),
-                JourneyIdUnderTest,
+                JourneyAIdUnderTest,
                 stepId,
                 step.RowVersion);
 
             // Act
             var newRowVersion = await JourneysControllerTestsHelper.UnvoidStepAsync(
                 LibraryAdminClient(TestFactory.PlantWithAccess),
-                JourneyIdUnderTest,
+                JourneyAIdUnderTest,
                 stepId,
                 currentRowVersion);
 
@@ -128,7 +142,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
         {
             var journey = await JourneysControllerTestsHelper.GetJourneyAsync(
                 LibraryAdminClient(TestFactory.PlantWithAccess),
-                JourneyIdUnderTest);
+                JourneyAIdUnderTest);
             return journey.Steps.SingleOrDefault(s => s.Id == stepId);
         }
     }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTests.cs
@@ -133,7 +133,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
             // Act
             var newRowVersion = await JourneysControllerTestsHelper.UnvoidStepAsync(
                 LibraryAdminClient(TestFactory.PlantWithAccess),
-                JourneyWithTagsIdUnderTest,
+                journeyIdUnderTest,
                 stepId,
                 currentRowVersion);
 

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTests.cs
@@ -85,7 +85,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
         }
 
         [TestMethod]
-        public async Task VoidStep_AsAdmin_ShouldVoidStep()
+        public async Task VoidStep_AsAdmin_ShouldVoidStep_AndUpdateAndRowVersion()
         {
             // Arrange
             var journeyIdUnderTest = JourneyWithTagsIdUnderTest;
@@ -113,7 +113,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
         }
 
         [TestMethod]
-        public async Task UnvoidStep_AsAdmin_ShouldUnvoidStep()
+        public async Task UnvoidStep_AsAdmin_ShouldUnvoidStep_AndUpdateAndRowVersion()
         {
             // Arrange
             var journeyIdUnderTest = JourneyWithTagsIdUnderTest;

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTests.cs
@@ -9,32 +9,71 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
     public class JourneysControllerTests : JourneysControllerTestsBase
     {
         [TestMethod]
+        public async Task GetJourney_AsAdmin_ShouldGetJourneyWithStep()
+        {
+            // Act
+            var journey = await JourneysControllerTestsHelper.GetJourneyAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                JourneyIdUnderTest);
+
+            // Assert
+            Assert.IsNotNull(journey);
+            Assert.IsNotNull(journey.Steps);
+            Assert.AreNotEqual(0, journey.Steps.Count());
+            var step = journey.Steps.SingleOrDefault(s => s.Id == StepIdUnderTest);
+            Assert.IsNotNull(step);
+        }
+
+        [TestMethod]
+        public async Task CreateStep_AsAdmin_ShouldCreateStep()
+        {
+            // Arrange
+            var title = Guid.NewGuid().ToString();
+
+            // Act
+            var stepId = await JourneysControllerTestsHelper.CreateStepAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                JourneyIdUnderTest,
+                title,
+                ModeIdUnderTest,
+                KnownTestData.ResponsibleCode);
+
+            // Assert
+            var journey = await JourneysControllerTestsHelper.GetJourneyAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                JourneyIdUnderTest);
+            var step = journey.Steps.SingleOrDefault(s => s.Id == stepId);
+            Assert.IsNotNull(step);
+        }
+
+        [TestMethod]
         public async Task UpdateStep_AsAdmin_ShouldUpdateStepAndRowVersion()
         {
-            // Assert
-            var journeyIdUnderTest = TestFactory.KnownTestData.JourneyIds.First();
-            var stepId = await JourneysControllerTestsHelper.AddStepAsync(
+            // Arrange
+            var journey = await JourneysControllerTestsHelper.GetJourneyAsync(
                 LibraryAdminClient(TestFactory.PlantWithAccess),
-                journeyIdUnderTest,
-                Guid.NewGuid().ToString(),
-                TestFactory.KnownTestData.ModeIds.First(),
-                KnownTestData.ResponsibleCode);
-            var step = await JourneysControllerTestsHelper.GetStepAsync(
-                LibraryAdminClient(TestFactory.PlantWithAccess),
-                journeyIdUnderTest,
-                stepId);
+                JourneyIdUnderTest);
+            var step = journey.Steps.Single(s => s.Id == StepIdUnderTest);
             var currentRowVersion = step.RowVersion;
+            var newTitle = Guid.NewGuid().ToString();
 
             // Act
             var newRowVersion = await JourneysControllerTestsHelper.UpdateStepAsync(
                 LibraryAdminClient(TestFactory.PlantWithAccess),
-                journeyIdUnderTest,
+                JourneyIdUnderTest,
                 step.Id,
-                Guid.NewGuid().ToString(),
+                newTitle,
+                ModeIdUnderTest,
+                KnownTestData.ResponsibleCode,
                 currentRowVersion);
 
             // Assert
             AssertRowVersionChange(currentRowVersion, newRowVersion);
+            journey = await JourneysControllerTestsHelper.GetJourneyAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                JourneyIdUnderTest);
+            step = journey.Steps.Single(s => s.Id == StepIdUnderTest);
+            Assert.AreEqual(newTitle, step.Title);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
+{
+    [TestClass]
+    public class JourneysControllerTests : JourneysControllerTestsBase
+    {
+        [TestMethod]
+        public async Task UpdateStep_AsAdmin_ShouldUpdateStepAndRowVersion()
+        {
+            // Assert
+            var journeyIdUnderTest = TestFactory.KnownTestData.JourneyIds.First();
+            var stepId = await JourneysControllerTestsHelper.AddStepAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                journeyIdUnderTest,
+                Guid.NewGuid().ToString(),
+                TestFactory.KnownTestData.ModeIds.First(),
+                KnownTestData.ResponsibleCode);
+            var step = await JourneysControllerTestsHelper.GetStepAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                journeyIdUnderTest,
+                stepId);
+            var currentRowVersion = step.RowVersion;
+
+            // Act
+            var newRowVersion = await JourneysControllerTestsHelper.UpdateStepAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                journeyIdUnderTest,
+                step.Id,
+                Guid.NewGuid().ToString(),
+                currentRowVersion);
+
+            // Assert
+            AssertRowVersionChange(currentRowVersion, newRowVersion);
+        }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTestsBase.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTestsBase.cs
@@ -9,15 +9,22 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
     public class JourneysControllerTestsBase : TestBase
     {
         protected int ModeIdUnderTest;
-        protected int JourneyIdUnderTest;
-        protected int StepIdUnderTest;
+        protected int JourneyAIdUnderTest;
+        protected int StepInJourneyAIdUnderTest;
+        protected int JourneyBIdUnderTest;
+        protected int StepInJourneyBIdUnderTest;
 
         [TestInitialize]
-        public void TestInitialize()
+        public async Task TestInitialize()
         {
             ModeIdUnderTest = TestFactory.KnownTestData.ModeIds.First();
-            JourneyIdUnderTest = TestFactory.KnownTestData.JourneyIds.First();
-            StepIdUnderTest = TestFactory.KnownTestData.StepIds.First();
+            var journeys = await JourneysControllerTestsHelper.GetJourneysAsync(LibraryAdminClient(TestFactory.PlantWithAccess));
+            var journeyA = journeys.Single(j => j.Title == KnownTestData.JourneyA);
+            JourneyAIdUnderTest = journeyA.Id;
+            StepInJourneyAIdUnderTest = journeyA.Steps.First().Id;
+            var journeyB = journeys.Single(j => j.Title == KnownTestData.JourneyB);
+            JourneyBIdUnderTest = journeyB.Id;
+            StepInJourneyBIdUnderTest = journeyB.Steps.First().Id;
 
             TestFactory
                 .ResponsibleApiServiceMock

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTestsBase.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTestsBase.cs
@@ -9,22 +9,22 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
     public class JourneysControllerTestsBase : TestBase
     {
         protected int ModeIdUnderTest;
-        protected int JourneyAIdUnderTest;
-        protected int StepInJourneyAIdUnderTest;
-        protected int JourneyBIdUnderTest;
-        protected int StepInJourneyBIdUnderTest;
+        protected int JourneyWithTagsIdUnderTest;
+        protected int StepInJourneyWithTagsIdUnderTest;
+        protected int JourneyNotInUseIdUnderTest;
+        protected int StepInJourneyNotInUseIdUnderTest;
 
         [TestInitialize]
         public async Task TestInitialize()
         {
             ModeIdUnderTest = TestFactory.KnownTestData.ModeIds.First();
             var journeys = await JourneysControllerTestsHelper.GetJourneysAsync(LibraryAdminClient(TestFactory.PlantWithAccess));
-            var journeyA = journeys.Single(j => j.Title == KnownTestData.JourneyA);
-            JourneyAIdUnderTest = journeyA.Id;
-            StepInJourneyAIdUnderTest = journeyA.Steps.First().Id;
-            var journeyB = journeys.Single(j => j.Title == KnownTestData.JourneyB);
-            JourneyBIdUnderTest = journeyB.Id;
-            StepInJourneyBIdUnderTest = journeyB.Steps.First().Id;
+            var journeyWithTags = journeys.Single(j => j.Title == KnownTestData.JourneyWithTags);
+            JourneyWithTagsIdUnderTest = journeyWithTags.Id;
+            StepInJourneyWithTagsIdUnderTest = journeyWithTags.Steps.First().Id;
+            var journeyNotInUse = journeys.Single(j => j.Title == KnownTestData.JourneyNotInUse);
+            JourneyNotInUseIdUnderTest = journeyNotInUse.Id;
+            StepInJourneyNotInUseIdUnderTest = journeyNotInUse.Steps.First().Id;
 
             TestFactory
                 .ResponsibleApiServiceMock

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTestsBase.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTestsBase.cs
@@ -1,0 +1,27 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Equinor.Procosys.Preservation.MainApi.Responsible;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
+{
+    [TestClass]
+    public class JourneysControllerTestsBase : TestBase
+    {
+        protected int ModeIdUnderTest;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            ModeIdUnderTest = TestFactory.KnownTestData.StandardTagIds.First();
+
+            TestFactory
+                .ResponsibleApiServiceMock
+                .Setup(service => service.TryGetResponsibleAsync(TestFactory.PlantWithAccess, KnownTestData.ResponsibleCode))
+                .Returns(Task.FromResult(new ProcosysResponsible
+                {
+                    Code = KnownTestData.ResponsibleCode, Description = KnownTestData.ResponsibleDescription
+                }));
+        }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTestsBase.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTestsBase.cs
@@ -9,11 +9,15 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
     public class JourneysControllerTestsBase : TestBase
     {
         protected int ModeIdUnderTest;
+        protected int JourneyIdUnderTest;
+        protected int StepIdUnderTest;
 
         [TestInitialize]
         public void TestInitialize()
         {
-            ModeIdUnderTest = TestFactory.KnownTestData.StandardTagIds.First();
+            ModeIdUnderTest = TestFactory.KnownTestData.ModeIds.First();
+            JourneyIdUnderTest = TestFactory.KnownTestData.JourneyIds.First();
+            StepIdUnderTest = TestFactory.KnownTestData.StepIds.First();
 
             TestFactory
                 .ResponsibleApiServiceMock

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTestsHelper.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTestsHelper.cs
@@ -9,6 +9,27 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
     public static class JourneysControllerTestsHelper
     {
         private const string _route = "Journeys";
+        
+        public static async Task<JourneyDetailsDto> GetJourneyAsync(
+            HttpClient client,
+            int journeyId,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var parameters = new ParameterCollection {{"includeVoided", "true"}};
+            var url = $"{_route}/{journeyId}{parameters}";
+            var response = await client.GetAsync(url);
+
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (expectedStatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            var content = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<JourneyDetailsDto>(content);
+        }
 
         public static async Task<int> CreateStepAsync(
             HttpClient client,
@@ -39,25 +60,6 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
             var jsonString = await response.Content.ReadAsStringAsync();
             return JsonConvert.DeserializeObject<int>(jsonString);
         }
-        
-        public static async Task<JourneyDetailsDto> GetJourneyAsync(
-            HttpClient client,
-            int journeyId,
-            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
-            string expectedMessageOnBadRequest = null)
-        {
-            var response = await client.GetAsync($"{_route}/{journeyId}");
-
-            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
-
-            if (expectedStatusCode != HttpStatusCode.OK)
-            {
-                return null;
-            }
-
-            var content = await response.Content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<JourneyDetailsDto>(content);
-        }
 
         public static async Task<string> UpdateStepAsync(
             HttpClient client,
@@ -82,6 +84,63 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
             var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
             var response = await client.PutAsync($"{_route}/{journeyId}/Steps/{stepId}", content);
 
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            return await response.Content.ReadAsStringAsync();
+        }
+
+        public static async Task<string> VoidStepAsync(
+            HttpClient client,
+            int journeyId,
+            int stepId,
+            string rowVersion,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+            => await VoidUnvoidStepAsync(client,
+                journeyId,
+                stepId,
+                rowVersion,
+                "Void",
+                expectedStatusCode,
+                expectedMessageOnBadRequest);
+
+        public static async Task<string> UnvoidStepAsync(
+            HttpClient client,
+            int journeyId,
+            int stepId,
+            string rowVersion,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+            => await VoidUnvoidStepAsync(client,
+                journeyId,
+                stepId,
+                rowVersion,
+                "Unvoid",
+                expectedStatusCode,
+                expectedMessageOnBadRequest);
+
+        private static async Task<string> VoidUnvoidStepAsync(
+            HttpClient client,
+            int journeyId,
+            int stepId,
+            string rowVersion,
+            string action,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                rowVersion
+            };
+
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response = await client.PutAsync($"{_route}/{journeyId}/Steps/{stepId}/{action}", content);
             await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
 
             if (response.StatusCode != HttpStatusCode.OK)

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTestsHelper.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTestsHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -9,6 +10,26 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
     public static class JourneysControllerTestsHelper
     {
         private const string _route = "Journeys";
+        
+        public static async Task<List<JourneyDto>> GetJourneysAsync(
+            HttpClient client,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var parameters = new ParameterCollection {{"includeVoided", "true"}};
+            var url = $"{_route}{parameters}";
+            var response = await client.GetAsync(url);
+
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (expectedStatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            var content = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<List<JourneyDto>>(content);
+        }
         
         public static async Task<JourneyDetailsDto> GetJourneyAsync(
             HttpClient client,

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTestsHelper.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTestsHelper.cs
@@ -10,56 +10,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
     {
         private const string _route = "Journeys";
 
-        public static async Task<string> UpdateStepAsync(
-            HttpClient client,
-            int journeyId,
-            int stepId,
-            string title,
-            string rowVersion,
-            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
-            string expectedMessageOnBadRequest = null)
-        {
-            var bodyPayload = new
-            {
-                title,
-                rowVersion
-            };
-
-            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
-            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
-            var response = await client.PutAsync($"{_route}/{journeyId}/Steps/{stepId}", content);
-
-            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
-
-            if (response.StatusCode != HttpStatusCode.OK)
-            {
-                return null;
-            }
-
-            return await response.Content.ReadAsStringAsync();
-        }
-        
-        public static async Task<StepDto> GetStepAsync(
-            HttpClient client,
-            int journeyId,
-            int stepId,
-            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
-            string expectedMessageOnBadRequest = null)
-        {
-            var response = await client.GetAsync($"{_route}/{journeyId}/Steps/{stepId}");
-
-            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
-
-            if (expectedStatusCode != HttpStatusCode.OK)
-            {
-                return null;
-            }
-
-            var content = await response.Content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<StepDto>(content);
-        }
-
-        public static async Task<int> AddStepAsync(
+        public static async Task<int> CreateStepAsync(
             HttpClient client,
             int journeyId,
             string title,
@@ -77,7 +28,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
 
             var serializePayload = JsonConvert.SerializeObject(bodyPayload);
             var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
-            var response = await client.PostAsync($"{_route}/{journeyId}/Steps", content);
+            var response = await client.PostAsync($"{_route}/{journeyId}/AddStep", content);
             await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
 
             if (response.StatusCode != HttpStatusCode.OK)
@@ -87,6 +38,58 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
 
             var jsonString = await response.Content.ReadAsStringAsync();
             return JsonConvert.DeserializeObject<int>(jsonString);
+        }
+        
+        public static async Task<JourneyDetailsDto> GetJourneyAsync(
+            HttpClient client,
+            int journeyId,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var response = await client.GetAsync($"{_route}/{journeyId}");
+
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (expectedStatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            var content = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<JourneyDetailsDto>(content);
+        }
+
+        public static async Task<string> UpdateStepAsync(
+            HttpClient client,
+            int journeyId,
+            int stepId,
+            string title,
+            int modeId,
+            string responsibleCode,
+            string rowVersion,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                title,
+                modeId,
+                responsibleCode,
+                rowVersion
+            };
+
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response = await client.PutAsync($"{_route}/{journeyId}/Steps/{stepId}", content);
+
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            return await response.Content.ReadAsStringAsync();
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTestsHelper.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTestsHelper.cs
@@ -1,0 +1,92 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
+{
+    public static class JourneysControllerTestsHelper
+    {
+        private const string _route = "Journeys";
+
+        public static async Task<string> UpdateStepAsync(
+            HttpClient client,
+            int journeyId,
+            int stepId,
+            string title,
+            string rowVersion,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                title,
+                rowVersion
+            };
+
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response = await client.PutAsync($"{_route}/{journeyId}/Steps/{stepId}", content);
+
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            return await response.Content.ReadAsStringAsync();
+        }
+        
+        public static async Task<StepDto> GetStepAsync(
+            HttpClient client,
+            int journeyId,
+            int stepId,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var response = await client.GetAsync($"{_route}/{journeyId}/Steps/{stepId}");
+
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (expectedStatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            var content = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<StepDto>(content);
+        }
+
+        public static async Task<int> AddStepAsync(
+            HttpClient client,
+            int journeyId,
+            string title,
+            int modeId,
+            string responsibleCode,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                title,
+                modeId,
+                responsibleCode
+            };
+
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response = await client.PostAsync($"{_route}/{journeyId}/Steps", content);
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                return -1;
+            }
+
+            var jsonString = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<int>(jsonString);
+        }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTestsHelper.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTestsHelper.cs
@@ -145,6 +145,28 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
                 expectedStatusCode,
                 expectedMessageOnBadRequest);
 
+        public static async Task DeleteStepAsync(
+            HttpClient client,
+            int journeyId,
+            int stepId,
+            string rowVersion,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                rowVersion
+            };
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var request = new HttpRequestMessage(HttpMethod.Delete, $"{_route}/{journeyId}/Steps/{stepId}")
+            {
+                Content = new StringContent(serializePayload, Encoding.UTF8, "application/json")
+            };
+
+            var response = await client.SendAsync(request);
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+        }
+
         private static async Task<string> VoidUnvoidStepAsync(
             HttpClient client,
             int journeyId,

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/StepDetailsDto.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/StepDetailsDto.cs
@@ -1,0 +1,14 @@
+﻿using Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate;
+
+namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
+{
+    public class StepDetailsDto
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public bool IsInUse { get; set; }
+        public bool IsVoided { get; set; }
+        public AutoTransferMethod AutoTransferMethod { get; set; }
+        public string RowVersion { get; set; }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/StepDto.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/StepDto.cs
@@ -1,9 +1,0 @@
-﻿namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
-{
-    public class StepDto
-    {
-        public int Id { get; set; }
-        public string Title { get; set; }
-        public string RowVersion { get; set; }
-    }
-}

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/StepDto.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/StepDto.cs
@@ -1,0 +1,13 @@
+﻿using Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate;
+
+namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
+{
+    public class StepDto
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public bool IsVoided { get; set; }
+        public AutoTransferMethod AutoTransferMethod { get; set; }
+        public string RowVersion { get; set; }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/StepDto.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/StepDto.cs
@@ -1,0 +1,9 @@
+﻿namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
+{
+    public class StepDto
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public string RowVersion { get; set; }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/KnownTestData.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/KnownTestData.cs
@@ -14,8 +14,10 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
         public static string RequirementTypeCode => "TestRT";
         public static string RequirementTypeDescription => "Test - RequirementType";
         public static string RequirementDefinition => "TestRD";
-        public static string Journey => "TestJourney";
-        public static string Step => "TestStep";
+        public static string JourneyA => "TestJourneyA";
+        public static string StepInJourneyA => "TestStepA";
+        public static string JourneyB => "TestJourneyB";
+        public static string StepInJourneyB => "TestStepB";
         public static string StandardTagNo => "Std-Test";
         public static string StandardTagDescription => "Test - StdTag";
         public static string SiteTagNo => "#SITE-Test";
@@ -27,9 +29,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
 
         public List<int> StandardTagIds = new List<int>();
         public List<int> SiteAreaTagIds = new List<int>();
-        public List<int> ModeIds = new List<int>();
-        public List<int> JourneyIds = new List<int>();
         public List<int> StepIds = new List<int>();
+        public List<int> ModeIds = new List<int>();
         public List<int> StandardTagActionIds = new List<int>();
         public List<int> SiteAreaTagActionIds = new List<int>();
         public List<int> StandardTagAttachmentIds = new List<int>();

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/KnownTestData.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/KnownTestData.cs
@@ -14,10 +14,10 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
         public static string RequirementTypeCode => "TestRT";
         public static string RequirementTypeDescription => "Test - RequirementType";
         public static string RequirementDefinition => "TestRD";
-        public static string JourneyA => "TestJourneyA";
-        public static string StepInJourneyA => "TestStepA";
-        public static string JourneyB => "TestJourneyB";
-        public static string StepInJourneyB => "TestStepB";
+        public static string JourneyWithTags => "TestJourneyA";
+        public static string StepInJourneyWithTags => "TestStepA";
+        public static string JourneyNotInUse => "TestJourneyB";
+        public static string StepInJourneyNotInUse => "TestStepB";
         public static string StandardTagNo => "Std-Test";
         public static string StandardTagDescription => "Test - StdTag";
         public static string SiteTagNo => "#SITE-Test";

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/KnownTestData.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/KnownTestData.cs
@@ -27,9 +27,9 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
 
         public List<int> StandardTagIds = new List<int>();
         public List<int> SiteAreaTagIds = new List<int>();
+        public List<int> ModeIds = new List<int>();
         public List<int> JourneyIds = new List<int>();
         public List<int> StepIds = new List<int>();
-        public List<int> ModeIds = new List<int>();
         public List<int> StandardTagActionIds = new List<int>();
         public List<int> SiteAreaTagActionIds = new List<int>();
         public List<int> StandardTagAttachmentIds = new List<int>();

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/KnownTestData.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/KnownTestData.cs
@@ -27,7 +27,9 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
 
         public List<int> StandardTagIds = new List<int>();
         public List<int> SiteAreaTagIds = new List<int>();
+        public List<int> JourneyIds = new List<int>();
         public List<int> StepIds = new List<int>();
+        public List<int> ModeIds = new List<int>();
         public List<int> StandardTagActionIds = new List<int>();
         public List<int> SiteAreaTagActionIds = new List<int>();
         public List<int> StandardTagAttachmentIds = new List<int>();

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/KnownTestData.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/KnownTestData.cs
@@ -29,8 +29,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
 
         public List<int> StandardTagIds = new List<int>();
         public List<int> SiteAreaTagIds = new List<int>();
-        public List<int> StepIds = new List<int>();
         public List<int> ModeIds = new List<int>();
+        public List<int> StepIds = new List<int>();
         public List<int> StandardTagActionIds = new List<int>();
         public List<int> SiteAreaTagActionIds = new List<int>();
         public List<int> StandardTagAttachmentIds = new List<int>();

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/KnownTestData.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/KnownTestData.cs
@@ -29,7 +29,6 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
 
         public List<int> StandardTagIds = new List<int>();
         public List<int> SiteAreaTagIds = new List<int>();
-        public List<int> ModeIds = new List<int>();
         public List<int> StepIds = new List<int>();
         public List<int> ModeIds = new List<int>();
         public List<int> StandardTagActionIds = new List<int>();

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Modes/ModesControllerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Modes/ModesControllerTests.cs
@@ -54,7 +54,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Modes
         [TestMethod]
         public async Task UpdateMode_AsAdmin_ShouldUpdateModeAndRowVersion()
         {
-            // Assert
+            // Arrange
             var id = await ModesControllerTestsHelper.CreateModeAsync(
                 LibraryAdminClient(TestFactory.PlantWithAccess),
                 Guid.NewGuid().ToString());
@@ -75,7 +75,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Modes
         [TestMethod]
         public async Task VoidMode_AsAdmin_ShouldVoidMode()
         {
-            // Assert
+            // Arrange
             var id = await ModesControllerTestsHelper.CreateModeAsync(
                 LibraryAdminClient(TestFactory.PlantWithAccess),
                 Guid.NewGuid().ToString());
@@ -98,7 +98,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Modes
         [TestMethod]
         public async Task UnvoidMode_AsAdmin_ShouldUnvoidMode()
         {
-            // Assert
+            // Arrange
             var id = await ModesControllerTestsHelper.CreateModeAsync(
                 LibraryAdminClient(TestFactory.PlantWithAccess),
                 Guid.NewGuid().ToString());
@@ -123,7 +123,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Modes
         [TestMethod]
         public async Task DeleteMode_AsAdmin_ShouldDeleteMode()
         {
-            // Assert
+            // Arrange
             var id = await ModesControllerTestsHelper.CreateModeAsync(
                 LibraryAdminClient(TestFactory.PlantWithAccess),
                 Guid.NewGuid().ToString());

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Modes/ModesControllerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Modes/ModesControllerTests.cs
@@ -9,6 +9,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Modes
     public class ModesControllerTests : TestBase
     {
         private int initialModesCount;
+        private int _modeIdUnderTest;
 
         [TestInitialize]
         public async Task TestInitialize()
@@ -16,49 +17,43 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Modes
             var modes = await ModesControllerTestsHelper.GetAllModesAsync(LibraryAdminClient(TestFactory.PlantWithAccess));
 
             initialModesCount = modes.Count;
+
+            _modeIdUnderTest = TestFactory.KnownTestData.ModeIds.First();
         }
 
         [TestMethod]
         public async Task CreateMode_AsAdmin_ShouldCreateMode()
         {
             // Act
-            var id = await ModesControllerTestsHelper.CreateModeAsync(
-                LibraryAdminClient(TestFactory.PlantWithAccess),
-                Guid.NewGuid().ToString());
-
-            // Assert
-            Assert.IsTrue(id > 0);
-            var modes = await ModesControllerTestsHelper.GetAllModesAsync(LibraryAdminClient(TestFactory.PlantWithAccess));
-            Assert.AreEqual(initialModesCount+1, modes.Count);
-            Assert.IsNotNull(modes.SingleOrDefault(m => m.Id == id));
-        }
-
-        [TestMethod]
-        public async Task GetMode_AsAdmin_ShouldGetMode()
-        {
-            // Arrange
             var title = Guid.NewGuid().ToString();
             var id = await ModesControllerTestsHelper.CreateModeAsync(
                 LibraryAdminClient(TestFactory.PlantWithAccess),
                 title);
 
+            // Assert
+            Assert.IsTrue(id > 0);
+            var modes = await ModesControllerTestsHelper.GetAllModesAsync(LibraryAdminClient(TestFactory.PlantWithAccess));
+            Assert.AreEqual(initialModesCount+1, modes.Count);
+            var mode = modes.SingleOrDefault(m => m.Id == id);
+            Assert.IsNotNull(mode);
+            Assert.AreEqual(title, mode.Title);
+        }
+
+        [TestMethod]
+        public async Task GetMode_AsAdmin_ShouldGetMode()
+        {
             // Act
-            var mode = await ModesControllerTestsHelper.GetModeAsync(LibraryAdminClient(TestFactory.PlantWithAccess), id);
+            var mode = await ModesControllerTestsHelper.GetModeAsync(LibraryAdminClient(TestFactory.PlantWithAccess), _modeIdUnderTest);
 
             // Assert
-            Assert.AreEqual(id, mode.Id);
-            Assert.AreEqual(title, mode.Title);
+            Assert.AreEqual(_modeIdUnderTest, mode.Id);
             Assert.IsNotNull(mode.RowVersion);
         }
 
         [TestMethod]
         public async Task UpdateMode_AsAdmin_ShouldUpdateModeAndRowVersion()
         {
-            // Arrange
-            var id = await ModesControllerTestsHelper.CreateModeAsync(
-                LibraryAdminClient(TestFactory.PlantWithAccess),
-                Guid.NewGuid().ToString());
-            var mode = await ModesControllerTestsHelper.GetModeAsync(LibraryAdminClient(TestFactory.PlantWithAccess), id);
+            var mode = await ModesControllerTestsHelper.GetModeAsync(LibraryAdminClient(TestFactory.PlantWithAccess), _modeIdUnderTest);
             var currentRowVersion = mode.RowVersion;
 
             // Act

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/PreservationContextExtension.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/PreservationContextExtension.cs
@@ -52,13 +52,16 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
 
             var requirementDef = SeedRequirement(dbContext, plant);
 
-            var journey = SeedJourney(dbContext, plant);
-            knownTestData.JourneyIds.Add(journey.Id);
-            var step = SeedStep(dbContext, journey, mode, responsible);
-            knownTestData.StepIds.Add(step.Id);
+            var journeyA = SeedJourney(dbContext, plant, KnownTestData.JourneyA);
+            var stepA = SeedStep(dbContext, journeyA, KnownTestData.StepInJourneyA, mode, responsible);
+            knownTestData.StepIds.Add(stepA.Id);
+
+            var journeyB = SeedJourney(dbContext, plant, KnownTestData.JourneyB);
+            var stepB = SeedStep(dbContext, journeyB, KnownTestData.StepInJourneyB, mode, responsible);
+            knownTestData.StepIds.Add(stepB.Id);
 
             var project = SeedProject(dbContext, plant);
-            var standardTag = SeedStandardTag(dbContext, project, step, requirementDef);
+            var standardTag = SeedStandardTag(dbContext, project, stepA, requirementDef);
             knownTestData.StandardTagIds.Add(standardTag.Id);
 
             var standardTagAttachment = SeedTagAttachment(dbContext, standardTag);
@@ -69,7 +72,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
             var standardTagActionAttachment = SeedActionAttachment(dbContext, standardTagAction);
             knownTestData.StandardTagActionAttachmentIds.Add(standardTagActionAttachment.Id);
 
-            var siteAreaTag = SeedSiteTag(dbContext, project, step, requirementDef);
+            var siteAreaTag = SeedSiteTag(dbContext, project, stepA, requirementDef);
             knownTestData.SiteAreaTagIds.Add(siteAreaTag.Id);
 
             var siteAreaTagAttachment = SeedTagAttachment(dbContext, siteAreaTag);
@@ -161,18 +164,18 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
             return tag;
         }
 
-        private static Journey SeedJourney(PreservationContext dbContext, string plant)
+        private static Journey SeedJourney(PreservationContext dbContext, string plant, string title)
         {
             var journeyRepository = new JourneyRepository(dbContext);
-            var journey = new Journey(plant, KnownTestData.Journey);
+            var journey = new Journey(plant, title);
             journeyRepository.Add(journey);
             dbContext.SaveChangesAsync().Wait();
             return journey;
         }
 
-        private static Step SeedStep(PreservationContext dbContext, Journey journey, Mode mode, Responsible responsible)
+        private static Step SeedStep(PreservationContext dbContext, Journey journey, string title, Mode mode, Responsible responsible)
         {
-            var step = new Step(journey.Plant, KnownTestData.Step, mode, responsible);
+            var step = new Step(journey.Plant, title, mode, responsible);
             journey.AddStep(step);
             dbContext.SaveChangesAsync().Wait();
             return step;

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/PreservationContextExtension.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/PreservationContextExtension.cs
@@ -46,12 +46,14 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
             var plant = plantProvider.Plant;
 
             var mode = SeedMode(dbContext, plant);
+            knownTestData.ModeIds.Add(mode.Id);
 
             var responsible = SeedResponsible(dbContext, plant);
 
             var requirementDef = SeedRequirement(dbContext, plant);
 
             var journey = SeedJourney(dbContext, plant);
+            knownTestData.JourneyIds.Add(journey.Id);
             var step = SeedStep(dbContext, journey, mode, responsible);
             knownTestData.StepIds.Add(step.Id);
 

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/PreservationContextExtension.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/PreservationContextExtension.cs
@@ -52,16 +52,16 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
 
             var requirementDef = SeedRequirement(dbContext, plant);
 
-            var journeyA = SeedJourney(dbContext, plant, KnownTestData.JourneyA);
-            var stepA = SeedStep(dbContext, journeyA, KnownTestData.StepInJourneyA, mode, responsible);
-            knownTestData.StepIds.Add(stepA.Id);
+            var journeyWithTags = SeedJourney(dbContext, plant, KnownTestData.JourneyWithTags);
+            var stepInJourneyWithTags = SeedStep(dbContext, journeyWithTags, KnownTestData.StepInJourneyWithTags, mode, responsible);
+            knownTestData.StepIds.Add(stepInJourneyWithTags.Id);
 
-            var journeyB = SeedJourney(dbContext, plant, KnownTestData.JourneyB);
-            var stepB = SeedStep(dbContext, journeyB, KnownTestData.StepInJourneyB, mode, responsible);
-            knownTestData.StepIds.Add(stepB.Id);
+            var journeyWithoutTags = SeedJourney(dbContext, plant, KnownTestData.JourneyNotInUse);
+            var stepInJourneyWithoutTags = SeedStep(dbContext, journeyWithoutTags, KnownTestData.StepInJourneyNotInUse, mode, responsible);
+            knownTestData.StepIds.Add(stepInJourneyWithoutTags.Id);
 
             var project = SeedProject(dbContext, plant);
-            var standardTag = SeedStandardTag(dbContext, project, stepA, requirementDef);
+            var standardTag = SeedStandardTag(dbContext, project, stepInJourneyWithTags, requirementDef);
             knownTestData.StandardTagIds.Add(standardTag.Id);
 
             var standardTagAttachment = SeedTagAttachment(dbContext, standardTag);
@@ -72,7 +72,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
             var standardTagActionAttachment = SeedActionAttachment(dbContext, standardTagAction);
             knownTestData.StandardTagActionAttachmentIds.Add(standardTagActionAttachment.Id);
 
-            var siteAreaTag = SeedSiteTag(dbContext, project, stepA, requirementDef);
+            var siteAreaTag = SeedSiteTag(dbContext, project, stepInJourneyWithTags, requirementDef);
             knownTestData.SiteAreaTagIds.Add(siteAreaTag.Id);
 
             var siteAreaTagAttachment = SeedTagAttachment(dbContext, siteAreaTag);

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTests.cs
@@ -216,7 +216,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         }
 
         [TestMethod]
-        public async Task GetAllActions_AsPreserver_ShouldGetAttachments()
+        public async Task GetAllActions_AsPreserver_ShouldGetActions()
         {
             // Act
             var actionDtos = await TagsControllerTestsHelper.GetAllActionsAsync(

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/TestFactory.cs
@@ -11,6 +11,7 @@ using Equinor.Procosys.Preservation.MainApi.Area;
 using Equinor.Procosys.Preservation.MainApi.Discipline;
 using Equinor.Procosys.Preservation.MainApi.Permission;
 using Equinor.Procosys.Preservation.MainApi.Plant;
+using Equinor.Procosys.Preservation.MainApi.Responsible;
 using Equinor.Procosys.Preservation.WebApi.Authorizations;
 using Equinor.Procosys.Preservation.WebApi.Middleware;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -40,6 +41,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
 
         private readonly Mock<IPlantApiService> _plantApiServiceMock = new Mock<IPlantApiService>();
         private readonly Mock<IPermissionApiService> _permissionApiServiceMock = new Mock<IPermissionApiService>();
+        public readonly Mock<IResponsibleApiService> ResponsibleApiServiceMock = new Mock<IResponsibleApiService>();
         public readonly Mock<IDisciplineApiService> DisciplineApiServiceMock = new Mock<IDisciplineApiService>();
         public readonly Mock<IAreaApiService> AreaApiServiceMock = new Mock<IAreaApiService>();
         public readonly Mock<IBlobStorage> BlobStorageMock = new Mock<IBlobStorage>();
@@ -120,6 +122,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
 
                 services.AddScoped(serviceProvider => _plantApiServiceMock.Object);
                 services.AddScoped(serviceProvider => _permissionApiServiceMock.Object);
+                services.AddScoped(serviceProvider => ResponsibleApiServiceMock.Object);
                 services.AddScoped(serviceProvider => DisciplineApiServiceMock.Object);
                 services.AddScoped(serviceProvider => AreaApiServiceMock.Object);
                 services.AddScoped(serviceProvider => BlobStorageMock.Object);


### PR DESCRIPTION
Same stuff for how validating if Step exists under a Journey.
In my point of view, the codereview of int.tests can be done with one eye.

Changes in real code:
* Commands which should return RowVersion as string, and endpoints for these, are changed to return updated RowVersion (not breaking change for client)
* IStepValidator.StepHasJourneyAsParentAsync removed. Not in use now
