### PR TITLE
77899 how validator check when children exists vol4

### DIFF
--- a/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/DeleteRequirementDefinition/DeleteRequirementDefinitionCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/DeleteRequirementDefinition/DeleteRequirementDefinitionCommandValidator.cs
@@ -17,10 +17,8 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.DeleteRe
             CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
-                .MustAsync((command, token) => BeAnExistingRequirementTypeAsync(command.RequirementTypeId, token))
-                .WithMessage(command => $"Requirement type doesn't exist! Requirement type={command.RequirementTypeId}")
-                .MustAsync((command, token) => BeAnExistingRequirementDefinitionInTypeAsync(command.RequirementTypeId, command.RequirementDefinitionId, token))
-                .WithMessage(command => $"Requirement definition doesn't exist within given requirement type! Requirement definition={command.RequirementDefinitionId}")
+                .MustAsync(BeAnExistingRequirementDefinitionAsync)
+                .WithMessage(command => "Requirement type and/or requirement definition doesn't exist!")
                 .MustAsync((command, token) => BeAVoidedRequirementDefinitionAsync(command.RequirementDefinitionId, token))
                 .WithMessage(command => $"Requirement definition is not voided! Requirement definition={command.RequirementDefinitionId}")
                 .MustAsync((command, token) => NotHaveAnyFieldsAsync(command.RequirementDefinitionId, token))
@@ -32,10 +30,8 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.DeleteRe
                 .Must(command => HaveAValidRowVersion(command.RowVersion))
                 .WithMessage(command => $"Not a valid row version! Row version={command.RowVersion}");
 
-            async Task<bool> BeAnExistingRequirementTypeAsync(int requirementTypeId, CancellationToken token)
-                => await requirementTypeValidator.ExistsAsync(requirementTypeId, token);
-            async Task<bool> BeAnExistingRequirementDefinitionInTypeAsync(int requirementTypeId, int requirementDefinitionId, CancellationToken token)
-                => await requirementTypeValidator.HasRequirementDefinitionAsync(requirementTypeId, requirementDefinitionId, token);
+            async Task<bool> BeAnExistingRequirementDefinitionAsync(DeleteRequirementDefinitionCommand command, CancellationToken token)
+                => await requirementTypeValidator.RequirementDefinitionExistsAsync(command.RequirementTypeId, command.RequirementDefinitionId, token);
             async Task<bool> BeAVoidedRequirementDefinitionAsync(int requirementDefinitionId, CancellationToken token)
                 => await requirementDefinitionValidator.IsVoidedAsync(requirementDefinitionId, token);
             async Task<bool> NotHaveAnyFieldsAsync(int requirementDefinitionId, CancellationToken token)

--- a/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/UnvoidRequirementDefinition/UnvoidRequirementDefinitionCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/UnvoidRequirementDefinition/UnvoidRequirementDefinitionCommandValidator.cs
@@ -18,19 +18,15 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.UnvoidRe
             CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
-                .MustAsync((command, token) => BeAnExistingRequirementTypeAsync(command.RequirementTypeId, token))
-                .WithMessage(command => $"Requirement type doesn't exist! Requirement type={command.RequirementTypeId}")
-                .MustAsync((command, token) => BeAnExistingRequirementDefinitionInTypeAsync(command.RequirementTypeId, command.RequirementDefinitionId, token))
-                .WithMessage(command => $"Requirement definition doesn't exist within given requirement type! Requirement definition={command.RequirementDefinitionId}")
+                .MustAsync(BeAnExistingRequirementDefinitionAsync)
+                .WithMessage(command => "Requirement type and/or requirement definition doesn't exist!")
                 .MustAsync((command, token) => BeAVoidedRequirementDefinitionAsync(command.RequirementDefinitionId, token))
                 .WithMessage(command => $"Requirement definition is not voided! Requirement definition={command.RequirementDefinitionId}")
                 .Must(command => HaveAValidRowVersion(command.RowVersion))
                 .WithMessage(command => $"Not a valid row version! Row version={command.RowVersion}");
 
-            async Task<bool> BeAnExistingRequirementTypeAsync(int requirementTypeId, CancellationToken token)
-                => await requirementTypeValidator.ExistsAsync(requirementTypeId, token); 
-            async Task<bool> BeAnExistingRequirementDefinitionInTypeAsync(int requirementTypeId, int requirementDefinitionId, CancellationToken token)
-                => await requirementTypeValidator.HasRequirementDefinitionAsync(requirementTypeId, requirementDefinitionId, token);
+            async Task<bool> BeAnExistingRequirementDefinitionAsync(UnvoidRequirementDefinitionCommand command, CancellationToken token)
+                => await requirementTypeValidator.RequirementDefinitionExistsAsync(command.RequirementTypeId, command.RequirementDefinitionId, token);
             async Task<bool> BeAVoidedRequirementDefinitionAsync(int requirementDefinitionId, CancellationToken token)
                 => await requirementDefinitionValidator.IsVoidedAsync(requirementDefinitionId, token);
             bool HaveAValidRowVersion(string rowVersion)

--- a/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/VoidRequirementDefinition/VoidRequirementDefinitionCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/RequirementTypeCommands/VoidRequirementDefinition/VoidRequirementDefinitionCommandValidator.cs
@@ -18,19 +18,15 @@ namespace Equinor.Procosys.Preservation.Command.RequirementTypeCommands.VoidRequ
             CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
-                .MustAsync((command, token) => BeAnExistingRequirementTypeAsync(command.RequirementTypeId, token))
-                .WithMessage(command => $"Requirement type doesn't exist! Requirement type={command.RequirementTypeId}")
-                .MustAsync((command, token) => BeAnExistingRequirementDefinitionInTypeAsync(command.RequirementTypeId, command.RequirementDefinitionId, token))
-                .WithMessage(command => $"Requirement definition doesn't exist within given requirement type! Requirement definition={command.RequirementDefinitionId}")
+                .MustAsync(BeAnExistingRequirementDefinitionAsync)
+                .WithMessage(command => "Requirement type and/or requirement definition doesn't exist!")
                 .MustAsync((command, token) => NotBeAVoidedRequirementDefinitionAsync(command.RequirementDefinitionId, token))
                 .WithMessage(command => $"Requirement definition is already voided! Requirement definition={command.RequirementDefinitionId}")
                 .Must(command => HaveAValidRowVersion(command.RowVersion))
                 .WithMessage(command => $"Not a valid row version! Row version={command.RowVersion}");
 
-            async Task<bool> BeAnExistingRequirementTypeAsync(int requirementTypeId, CancellationToken token)
-                => await requirementTypeValidator.ExistsAsync(requirementTypeId, token); 
-            async Task<bool> BeAnExistingRequirementDefinitionInTypeAsync(int requirementTypeId, int requirementDefinitionId, CancellationToken token)
-                => await requirementTypeValidator.HasRequirementDefinitionAsync(requirementTypeId, requirementDefinitionId, token);
+            async Task<bool> BeAnExistingRequirementDefinitionAsync(VoidRequirementDefinitionCommand command, CancellationToken token)
+                => await requirementTypeValidator.RequirementDefinitionExistsAsync(command.RequirementTypeId, command.RequirementDefinitionId, token);
             async Task<bool> NotBeAVoidedRequirementDefinitionAsync(int requirementDefinitionId, CancellationToken token)
                 => !await requirementDefinitionValidator.IsVoidedAsync(requirementDefinitionId, token);
             bool HaveAValidRowVersion(string rowVersion)

--- a/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/IRequirementDefinitionValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/IRequirementDefinitionValidator.cs
@@ -16,6 +16,5 @@ namespace Equinor.Procosys.Preservation.Command.Validators.RequirementDefinition
         Task<bool> TagFunctionRequirementsExistAsync(int requirementDefinitionId, CancellationToken token);
         Task<bool> AllExcludedFieldsAreVoidedAsync(int requirementDefinitionId, List<int> updateFieldIds, CancellationToken token);
         Task<bool> AnyExcludedFieldsIsInUseAsync(int requirementDefinitionId, List<int> updateFieldIds, CancellationToken token);
-        Task<bool> RequirementDefinitionHasRequirementTypeAsParentAsync(int requirementTypeId, int requirementDefinitionId, CancellationToken token);
     }
 }

--- a/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/RequirementDefinitionValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/RequirementDefinitionValidator.cs
@@ -107,11 +107,6 @@ namespace Equinor.Procosys.Preservation.Command.Validators.RequirementDefinition
                 select fv).AnyAsync(token);
         }
 
-        public async Task<bool> RequirementDefinitionHasRequirementTypeAsParentAsync(int requirementTypeId, int requirementDefinitionId, CancellationToken token) =>
-            await (from rd in _context.QuerySet<RequirementDefinition>()
-                where rd.Id == requirementDefinitionId && EF.Property<int>(rd, "RequirementTypeId") == requirementTypeId
-                select rd).AnyAsync(token);
-
         private async Task<RequirementDefinition> GetRequirementDefinitionWithFieldsAsync(int requirementDefinitionId, CancellationToken token)
             => await (from rd in _context.QuerySet<RequirementDefinition>()
                     .Include(rd => rd.Fields)

--- a/src/Equinor.Procosys.Preservation.Command/Validators/RequirementTypeValidators/IRequirementTypeValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/RequirementTypeValidators/IRequirementTypeValidator.cs
@@ -9,7 +9,7 @@ namespace Equinor.Procosys.Preservation.Command.Validators.RequirementTypeValida
     {
         Task<bool> ExistsAsync(int requirementTypeId, CancellationToken token);
         Task<bool> AnyRequirementDefinitionExistsAsync(int requirementTypeId, CancellationToken token);
-        Task<bool> HasRequirementDefinitionAsync(int requirementTypeId, int requirementDefinitionId, CancellationToken token);
+        Task<bool> RequirementDefinitionExistsAsync(int requirementTypeId, int requirementDefinitionId, CancellationToken token);
         Task<bool> IsVoidedAsync(int requirementTypeId, CancellationToken token);
         Task<bool> ExistsWithSameCodeAsync(string code, CancellationToken token);
         Task<bool> ExistsWithSameTitleAsync(string title, CancellationToken token);

--- a/src/Equinor.Procosys.Preservation.Command/Validators/RequirementTypeValidators/RequirementTypeValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/RequirementTypeValidators/RequirementTypeValidator.cs
@@ -26,11 +26,11 @@ namespace Equinor.Procosys.Preservation.Command.Validators.RequirementTypeValida
             return reqType != null && reqType.RequirementDefinitions.Any();
         }
 
-        public async Task<bool> HasRequirementDefinitionAsync(int requirementTypeId, int requirementDefinitionId, CancellationToken token)
+        public async Task<bool> RequirementDefinitionExistsAsync(int requirementTypeId, int requirementDefinitionId, CancellationToken token)
         {
             var reqType = await GetRequirementTypeWithDefinitionsAsync(requirementTypeId, token);
 
-            return reqType != null && reqType.RequirementDefinitions.SingleOrDefault(d => d.Id == requirementDefinitionId) != null;
+            return reqType?.RequirementDefinitions.SingleOrDefault(d => d.Id == requirementDefinitionId) != null;
         }
 
         public async Task<bool> IsVoidedAsync(int requirementTypeId, CancellationToken token)

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/RequirementTypes/CreateRequirementDefinitionDto.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/RequirementTypes/CreateRequirementDefinitionDto.cs
@@ -9,6 +9,6 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.RequirementTypes
         public RequirementUsage Usage { get; set; }
         public string Title { get; set; }
         public int DefaultIntervalWeeks { get; set; }
-        public IList<FieldDto> Fields { get; set; }
+        public IList<FieldDto> Fields { get; set; } = new List<FieldDto>();
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/UnvoidRequirementDefinition/UnvoidRequirementDefinitionCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/UnvoidRequirementDefinition/UnvoidRequirementDefinitionCommandValidatorTests.cs
@@ -25,8 +25,9 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.Un
         public void Setup_OkState()
         {
             _reqTypeValidatorMock = new Mock<IRequirementTypeValidator>();
-            _reqTypeValidatorMock.Setup(r => r.ExistsAsync(_requirementTypeId, default)).Returns(Task.FromResult(true));
-            _reqTypeValidatorMock.Setup(r => r.HasRequirementDefinitionAsync(_requirementTypeId, _requirementDefinitionId, default)).Returns(Task.FromResult(true));
+            _reqTypeValidatorMock
+                .Setup(r => r.RequirementDefinitionExistsAsync(_requirementTypeId, _requirementDefinitionId, default))
+                .Returns(Task.FromResult(true));
 
             _reqDefinitionValidatorMock = new Mock<IRequirementDefinitionValidator>();
             _reqDefinitionValidatorMock.Setup(r => r.IsVoidedAsync(_requirementDefinitionId, default))
@@ -49,27 +50,17 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.Un
         }
 
         [TestMethod]
-        public void Validate_ShouldFail_WhenRequirementTypeNotExists()
+        public void Validate_ShouldFail_WhenRequirementDefinitionDoesNotExists()
         {
-            _reqTypeValidatorMock.Setup(r => r.ExistsAsync(_requirementTypeId, default)).Returns(Task.FromResult(false));
+            _reqTypeValidatorMock
+                .Setup(r => r.RequirementDefinitionExistsAsync(_requirementTypeId, _requirementDefinitionId, default))
+                .Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirement type doesn't exist!"));
-        }
-
-        [TestMethod]
-        public void Validate_ShouldFail_WhenTypeDontHaveDefinition()
-        {
-            _reqTypeValidatorMock.Setup(r => r.HasRequirementDefinitionAsync(_requirementTypeId, _requirementDefinitionId, default)).Returns(Task.FromResult(false));
-
-            var result = _dut.Validate(_command);
-
-            Assert.IsFalse(result.IsValid);
-            Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirement definition doesn't exist within given requirement type"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirement type and/or requirement definition doesn't exist!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/UpdateRequirementDefinition/UpdateRequirementDefinitionCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/UpdateRequirementDefinition/UpdateRequirementDefinitionCommandValidatorTests.cs
@@ -43,15 +43,13 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.Up
             _newFields = new List<FieldsForCommand>();
 
             _reqTypeValidatorMock = new Mock<IRequirementTypeValidator>();
-            _reqTypeValidatorMock.Setup(r => r.ExistsAsync(_requirementTypeId, default)).Returns(Task.FromResult(true));
+            _reqTypeValidatorMock
+                .Setup(r => r.RequirementDefinitionExistsAsync(_requirementTypeId, _requirementDefinitionId, default))
+                .Returns(Task.FromResult(true));
 
             _reqDefinitionValidatorMock = new Mock<IRequirementDefinitionValidator>();
-            _reqDefinitionValidatorMock.Setup(r => r.ExistsAsync(_requirementDefinitionId, default)).Returns(Task.FromResult(true));
             _reqDefinitionValidatorMock
                 .Setup(r => r.AllExcludedFieldsAreVoidedAsync(_requirementDefinitionId, new List<int> {_updateFieldId}, default))
-                .Returns(Task.FromResult(true));
-            _reqDefinitionValidatorMock
-                .Setup(rd => rd.RequirementDefinitionHasRequirementTypeAsParentAsync(_requirementTypeId, _requirementDefinitionId, default))
                 .Returns(Task.FromResult(true));
 
             _fieldValidatorMock = new Mock<IFieldValidator>();
@@ -83,41 +81,17 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.Up
         }
 
         [TestMethod]
-        public void Validate_ShouldFail_WhenRequirementTypeNotExists()
-        {
-            _reqTypeValidatorMock.Setup(r => r.ExistsAsync(_requirementTypeId, default)).Returns(Task.FromResult(false));
-
-            var result = _dut.Validate(_command);
-
-            Assert.IsFalse(result.IsValid);
-            Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirement type doesn't exist!"));
-        }
-
-        [TestMethod]
         public void Validate_ShouldFail_WhenRequirementDefinitionDoesNotExists()
         {
-            _reqDefinitionValidatorMock.Setup(r => r.ExistsAsync(_requirementDefinitionId, default)).Returns(Task.FromResult(false));
-
-            var result = _dut.Validate(_command);
-
-            Assert.IsFalse(result.IsValid);
-            Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirement definition doesn't exist!"));
-        }
-
-        [TestMethod]
-        public void Validate_ShouldFail_WhenBothRequirementTypeAndRequirementDefinitionExists_ButRequirementDefinitionHasOtherParent()
-        {
-            _reqDefinitionValidatorMock
-                .Setup(rd => rd.RequirementDefinitionHasRequirementTypeAsParentAsync(_requirementTypeId, _requirementDefinitionId, default))
+            _reqTypeValidatorMock
+                .Setup(r => r.RequirementDefinitionExistsAsync(_requirementTypeId, _requirementDefinitionId, default))
                 .Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Can not move a requirement definition to another requirement type!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirement type and/or requirement definition doesn't exist!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/VoidRequirementDefinition/VoidRequirementDefinitionCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/RequirementTypeCommands/VoidRequirementDefinition/VoidRequirementDefinitionCommandValidatorTests.cs
@@ -25,8 +25,9 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.Vo
         public void Setup_OkState()
         {
             _reqTypeValidatorMock = new Mock<IRequirementTypeValidator>();
-            _reqTypeValidatorMock.Setup(r => r.ExistsAsync(_requirementTypeId, default)).Returns(Task.FromResult(true));
-            _reqTypeValidatorMock.Setup(r => r.HasRequirementDefinitionAsync(_requirementTypeId, _requirementDefinitionId, default)).Returns(Task.FromResult(true));
+            _reqTypeValidatorMock
+                .Setup(r => r.RequirementDefinitionExistsAsync(_requirementTypeId, _requirementDefinitionId, default))
+                .Returns(Task.FromResult(true));
 
             _reqDefinitionValidatorMock = new Mock<IRequirementDefinitionValidator>();
 
@@ -46,27 +47,17 @@ namespace Equinor.Procosys.Preservation.Command.Tests.RequirementTypeCommands.Vo
         }
 
         [TestMethod]
-        public void Validate_ShouldFail_WhenRequirementTypeNotExists()
+        public void Validate_ShouldFail_WhenRequirementDefinitionDoesNotExists()
         {
-            _reqTypeValidatorMock.Setup(r => r.ExistsAsync(_requirementTypeId, default)).Returns(Task.FromResult(false));
+            _reqTypeValidatorMock
+                .Setup(r => r.RequirementDefinitionExistsAsync(_requirementTypeId, _requirementDefinitionId, default))
+                .Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirement type doesn't exist!"));
-        }
-
-        [TestMethod]
-        public void Validate_ShouldFail_WhenTypeDontHaveDefinition()
-        {
-            _reqTypeValidatorMock.Setup(r => r.HasRequirementDefinitionAsync(_requirementTypeId, _requirementDefinitionId, default)).Returns(Task.FromResult(false));
-
-            var result = _dut.Validate(_command);
-
-            Assert.IsFalse(result.IsValid);
-            Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirement definition doesn't exist within given requirement type"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirement type and/or requirement definition doesn't exist!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RequirementDefinitionValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RequirementDefinitionValidatorTests.cs
@@ -531,38 +531,5 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
                 Assert.IsTrue(result);
             }
         }
-
-        [TestMethod]
-        public async Task RequirementDefinitionHasRequirementTypeAsParentAsync_UnknownRequirementDefinitionId_ShouldReturnFalse()
-        {
-            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
-            {
-                var dut = new RequirementDefinitionValidator(context);
-                var result = await dut.RequirementDefinitionHasRequirementTypeAsParentAsync(_requirementType.Id, 126234, default);
-                Assert.IsFalse(result);
-            }
-        }
-
-        [TestMethod]
-        public async Task RequirementDefinitionHasRequirementTypeAsParentAsync_UnknownRequirementTypeId_ShouldReturnFalse()
-        {
-            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
-            {
-                var dut = new RequirementDefinitionValidator(context);
-                var result = await dut.RequirementDefinitionHasRequirementTypeAsParentAsync(126234, _reqDefForOther.Id, default);
-                Assert.IsFalse(result);
-            }
-        }
-
-        [TestMethod]
-        public async Task RequirementDefinitionHasRequirementTypeAsParentAsync_KnownIds_ShouldReturnTrue()
-        {
-            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
-            {
-                var dut = new RequirementDefinitionValidator(context);
-                var result = await dut.RequirementDefinitionHasRequirementTypeAsParentAsync(_requirementType.Id, _reqDefForOther.Id, default);
-                Assert.IsTrue(result);
-            }
-        }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/KnownTestData.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/KnownTestData.cs
@@ -11,9 +11,10 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
         public static string Mode => "TestMode";
         public static string ResponsibleCode => "TestResp";
         public static string ResponsibleDescription => "Test - Responsible";
-        public static string RequirementTypeCode => "TestRT";
-        public static string RequirementTypeDescription => "Test - RequirementType";
-        public static string RequirementDefinition => "TestRD";
+        public static string ReqTypeA => "TestRT-A";
+        public static string ReqDefInReqTypeA => "TestRD-A";
+        public static string ReqTypeB => "TestRT-B";
+        public static string ReqDefInReqTypeB => "TestRD-B";
         public static string Journey => "TestJourney";
         public static string Step => "TestStep";
         public static string StandardTagNo => "Std-Test";

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/PreservationContextExtension.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/PreservationContextExtension.cs
@@ -50,14 +50,18 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
 
             var responsible = SeedResponsible(dbContext, plant);
 
-            var requirementDef = SeedRequirement(dbContext, plant);
+            var reqTypeA = SeedReqType(dbContext, plant, KnownTestData.ReqTypeA);
+            var reqDefA = SeedReqDef(dbContext, reqTypeA, KnownTestData.ReqDefInReqTypeA);
+
+            var reqTypeB = SeedReqType(dbContext, plant, KnownTestData.ReqTypeB);
+            SeedReqDef(dbContext, reqTypeB, KnownTestData.ReqDefInReqTypeB);
 
             var journey = SeedJourney(dbContext, plant);
             var step = SeedStep(dbContext, journey, mode, responsible);
             knownTestData.StepIds.Add(step.Id);
 
             var project = SeedProject(dbContext, plant);
-            var standardTag = SeedStandardTag(dbContext, project, step, requirementDef);
+            var standardTag = SeedStandardTag(dbContext, project, step, reqDefA);
             knownTestData.StandardTagIds.Add(standardTag.Id);
 
             var standardTagAttachment = SeedTagAttachment(dbContext, standardTag);
@@ -68,7 +72,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
             var standardTagActionAttachment = SeedActionAttachment(dbContext, standardTagAction);
             knownTestData.StandardTagActionAttachmentIds.Add(standardTagActionAttachment.Id);
 
-            var siteAreaTag = SeedSiteTag(dbContext, project, step, requirementDef);
+            var siteAreaTag = SeedSiteTag(dbContext, project, step, reqDefA);
             knownTestData.SiteAreaTagIds.Add(siteAreaTag.Id);
 
             var siteAreaTagAttachment = SeedTagAttachment(dbContext, siteAreaTag);
@@ -177,21 +181,27 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
             return step;
         }
 
-        private static RequirementDefinition SeedRequirement(PreservationContext dbContext, string plant)
+        private static RequirementType SeedReqType(PreservationContext dbContext, string plant, string code)
         {
-            var requirementTypeRepository = new RequirementTypeRepository(dbContext);
-            var requirementType = new RequirementType(
+            var reqTypeRepository = new RequirementTypeRepository(dbContext);
+            var reqType = new RequirementType(
                 plant,
-                KnownTestData.RequirementTypeCode,
-                KnownTestData.RequirementTypeDescription,
+                code,
+                $"{code} - Description",
                 RequirementTypeIcon.Other,
                 10);
-            var requirementDef =
-                new RequirementDefinition(plant, KnownTestData.RequirementDefinition, 4, RequirementUsage.ForAll, 10);
-            requirementType.AddRequirementDefinition(requirementDef);
-            requirementTypeRepository.Add(requirementType);
+            reqTypeRepository.Add(reqType);
             dbContext.SaveChangesAsync().Wait();
-            return requirementDef;
+            return reqType;
+        }
+
+        private static RequirementDefinition SeedReqDef(PreservationContext dbContext, RequirementType reqType, string title)
+        {
+            var reqDef =
+                new RequirementDefinition(reqType.Plant, title, 4, RequirementUsage.ForAll, 10);
+            reqType.AddRequirementDefinition(reqDef);
+            dbContext.SaveChangesAsync().Wait();
+            return reqDef;
         }
 
         private static Responsible SeedResponsible(PreservationContext dbContext, string plant)

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/RequirementTypes/FieldDto.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/RequirementTypes/FieldDto.cs
@@ -1,0 +1,16 @@
+﻿using Equinor.Procosys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
+
+namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.RequirementTypes
+{
+    public class FieldDto
+    {
+        public int Id { get; set; }
+        public string Label { get; set; }
+        public bool IsVoided { get; set; }
+        public int SortKey { get; set; }
+        public FieldType FieldType { get; set; }
+        public string Unit { get; set; }
+        public bool? ShowPrevious { get; set; }
+        public string RowVersion { get; set; }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementDefinitionDto.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementDefinitionDto.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
+
+namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.RequirementTypes
+{
+    public class RequirementDefinitionDto
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public bool IsVoided { get; set; }
+        public int DefaultIntervalWeeks { get; set; }
+        public RequirementUsage Usage { get; set; }
+        public int SortKey { get; set; }
+        public bool NeedsUserInput { get; set; }
+        public IEnumerable<FieldDto> Fields { get; set; }
+        public string RowVersion { get; set;  }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypeDto.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypeDto.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
+
+namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.RequirementTypes
+{
+    public class RequirementTypeDto
+    {
+        public int Id { get; set; }
+        public string Code { get; set; }
+        public string Title { get; set; }
+        public RequirementTypeIcon Icon { get; set; }
+        public bool IsVoided { get; set; }
+        public int SortKey { get; set; }
+        public string RowVersion { get; set; }
+        public IEnumerable<RequirementDefinitionDto> RequirementDefinitions { get; set; }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypesControllerNegativeTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypesControllerNegativeTests.cs
@@ -53,6 +53,66 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.RequirementTypes
                 PreserverClient(TestFactory.PlantWithAccess),
                 HttpStatusCode.Forbidden);
         #endregion
+
+        #region CreateRequirementDefinition
+        [TestMethod]
+        public async Task CreateRequirementDefinition_AsAnonymous_ShouldReturnUnauthorized()
+            => await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
+                AnonymousClient(TestFactory.UnknownPlant),
+                9999,
+                "RequirementDefinition1",
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task CreateRequirementDefinition_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
+                AuthenticatedHackerClient(TestFactory.UnknownPlant),
+                9999,
+                "RequirementDefinition1",
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task CreateRequirementDefinition_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.UnknownPlant),
+                9999,
+                "RequirementDefinition1",
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task CreateRequirementDefinition_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
+                AuthenticatedHackerClient(TestFactory.PlantWithoutAccess),
+                9999,
+                "RequirementDefinition1",
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task CreateRequirementDefinition_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.PlantWithoutAccess),
+                9999,
+                "RequirementDefinition1",
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task CreateRequirementDefinition_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
+                PlannerClient(TestFactory.PlantWithAccess),
+                9999,
+                "RequirementDefinition1",
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task CreateRequirementDefinition_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
+                PreserverClient(TestFactory.PlantWithAccess),
+                9999,
+                "RequirementDefinition1",
+                HttpStatusCode.Forbidden);
+        #endregion
        
         #region UpdateRequirementDefinition
         [TestMethod]
@@ -146,6 +206,238 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.RequirementTypes
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "Requirement type and/or requirement definition doesn't exist!");
+        #endregion
+
+        #region VoidRequirementDefinition
+        [TestMethod]
+        public async Task VoidRequirementDefinition_AsAnonymous_ShouldReturnUnauthorized()
+            => await RequirementTypesControllerTestsHelper.VoidRequirementDefinitionAsync(
+                AnonymousClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task VoidRequirementDefinition_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.VoidRequirementDefinitionAsync(
+                AuthenticatedHackerClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task VoidRequirementDefinition_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.VoidRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task VoidRequirementDefinition_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await RequirementTypesControllerTestsHelper.VoidRequirementDefinitionAsync(
+                AuthenticatedHackerClient(TestFactory.PlantWithoutAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidRequirementDefinition_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await RequirementTypesControllerTestsHelper.VoidRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.PlantWithoutAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidRequirementDefinition_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.VoidRequirementDefinitionAsync(
+                PlannerClient(TestFactory.PlantWithAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidRequirementDefinition_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.VoidRequirementDefinitionAsync(
+                PreserverClient(TestFactory.PlantWithAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidRequirementDefinition_AsAdmin_ShouldReturnBadRequest_WhenUnknownRequirementTypeOrRequirementDefinitionId()
+            => await RequirementTypesControllerTestsHelper.VoidRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                ReqTypeAIdUnderTest,
+                ReqDefInReqTypeBIdUnderTest, // req def in other RequirementType
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "Requirement type and/or requirement definition doesn't exist!");
+        #endregion
+
+        #region UnvoidRequirementDefinition
+        [TestMethod]
+        public async Task UnvoidRequirementDefinition_AsAnonymous_ShouldReturnUnauthorized()
+            => await RequirementTypesControllerTestsHelper.UnvoidRequirementDefinitionAsync(
+                AnonymousClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task UnvoidRequirementDefinition_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.UnvoidRequirementDefinitionAsync(
+                AuthenticatedHackerClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task UnvoidRequirementDefinition_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.UnvoidRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task UnvoidRequirementDefinition_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await RequirementTypesControllerTestsHelper.UnvoidRequirementDefinitionAsync(
+                AuthenticatedHackerClient(TestFactory.PlantWithoutAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidRequirementDefinition_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await RequirementTypesControllerTestsHelper.UnvoidRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.PlantWithoutAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidRequirementDefinition_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.UnvoidRequirementDefinitionAsync(
+                PlannerClient(TestFactory.PlantWithAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidRequirementDefinition_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.UnvoidRequirementDefinitionAsync(
+                PreserverClient(TestFactory.PlantWithAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidRequirementDefinition_AsAdmin_ShouldReturnBadRequest_WhenUnknownRequirementTypeOrRequirementDefinitionId()
+            => await RequirementTypesControllerTestsHelper.UnvoidRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                ReqTypeAIdUnderTest,
+                ReqDefInReqTypeBIdUnderTest, // req def in other RequirementType
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "Requirement type and/or requirement definition doesn't exist!");
+        #endregion
+
+        #region DeleteRequirementDefinition
+        [TestMethod]
+        public async Task DeleteRequirementDefinition_AsAnonymous_ShouldReturnUnauthorized()
+            => await RequirementTypesControllerTestsHelper.DeleteRequirementDefinitionAsync(
+                AnonymousClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task DeleteRequirementDefinition_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.DeleteRequirementDefinitionAsync(
+                AuthenticatedHackerClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task DeleteRequirementDefinition_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.DeleteRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task DeleteRequirementDefinition_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await RequirementTypesControllerTestsHelper.DeleteRequirementDefinitionAsync(
+                AuthenticatedHackerClient(TestFactory.PlantWithoutAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task DeleteRequirementDefinition_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await RequirementTypesControllerTestsHelper.DeleteRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.PlantWithoutAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task DeleteRequirementDefinition_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.DeleteRequirementDefinitionAsync(
+                PlannerClient(TestFactory.PlantWithAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task DeleteRequirementDefinition_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.DeleteRequirementDefinitionAsync(
+                PreserverClient(TestFactory.PlantWithAccess),
+                9999,
+                8888,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task DeleteRequirementDefinition_AsAdmin_ShouldReturnBadRequest_WhenUnknownRequirementTypeOrRequirementDefinitionId()
+            => await RequirementTypesControllerTestsHelper.DeleteRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                ReqTypeAIdUnderTest,
+                ReqDefInReqTypeBIdUnderTest, // req def in other RequirementType
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "Requirement type and/or requirement definition doesn't exist!");
+
         #endregion
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypesControllerNegativeTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypesControllerNegativeTests.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.RequirementTypes
+{
+    [TestClass]
+    public class RequirementTypesControllerNegativeTests :  RequirementTypesControllerTestsBase
+    {
+        #region GetRequirementTypes
+        [TestMethod]
+        public async Task GetRequirementTypes_AsAnonymous_ShouldReturnUnauthorized()
+            => await RequirementTypesControllerTestsHelper.GetRequirementTypesAsync(
+                AnonymousClient(TestFactory.UnknownPlant),
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task GetRequirementTypes_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.GetRequirementTypesAsync(
+                AuthenticatedHackerClient(TestFactory.UnknownPlant),
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task GetRequirementTypes_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.GetRequirementTypesAsync(
+                LibraryAdminClient(TestFactory.UnknownPlant),
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task GetRequirementTypes_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await RequirementTypesControllerTestsHelper.GetRequirementTypesAsync(
+                AuthenticatedHackerClient(TestFactory.PlantWithoutAccess),
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task GetRequirementTypes_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await RequirementTypesControllerTestsHelper.GetRequirementTypesAsync(
+                LibraryAdminClient(TestFactory.PlantWithoutAccess),
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task GetRequirementTypes_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.GetRequirementTypesAsync(
+                PlannerClient(TestFactory.PlantWithAccess),
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task GetRequirementTypes_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.GetRequirementTypesAsync(
+                PreserverClient(TestFactory.PlantWithAccess),
+                HttpStatusCode.Forbidden);
+        #endregion
+       
+        #region UpdateRequirementDefinition
+        [TestMethod]
+        public async Task UpdateRequirementDefinition_AsAnonymous_ShouldReturnUnauthorized()
+            => await RequirementTypesControllerTestsHelper.UpdateRequirementDefinitionAsync(
+                AnonymousClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                Guid.NewGuid().ToString(),
+                4,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task UpdateRequirementDefinition_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.UpdateRequirementDefinitionAsync(
+                AuthenticatedHackerClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                Guid.NewGuid().ToString(),
+                4,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task UpdateRequirementDefinition_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.UpdateRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.UnknownPlant),
+                9999,
+                8888,
+                Guid.NewGuid().ToString(),
+                4,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task UpdateRequirementDefinition_AsHacker_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.UpdateRequirementDefinitionAsync(
+                AuthenticatedHackerClient(TestFactory.PlantWithAccess),
+                9999,
+                8888,
+                Guid.NewGuid().ToString(),
+                4,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateRequirementDefinition_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.UpdateRequirementDefinitionAsync(
+                PlannerClient(TestFactory.PlantWithAccess), 
+                9999,
+                8888,
+                Guid.NewGuid().ToString(),
+                4,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateRequirementDefinition_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.UpdateRequirementDefinitionAsync(
+                PreserverClient(TestFactory.PlantWithAccess), 
+                9999,
+                8888,
+                Guid.NewGuid().ToString(),
+                4,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateRequirementDefinition_AsPreserver_ShouldReturnBadRequest_WhenUnknownReqTypeId()
+            => await RequirementTypesControllerTestsHelper.UpdateRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                9999, 
+                8888,
+                Guid.NewGuid().ToString(),
+                4,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "Requirement type and/or requirement definition doesn't exist!");
+
+        [TestMethod]
+        public async Task UpdateRequirementDefinition_AsPreserver_ShouldReturnBadRequest_WhenUnknownReqDefId()
+            => await RequirementTypesControllerTestsHelper.UpdateRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                ReqTypeAIdUnderTest, 
+                ReqDefInReqTypeBIdUnderTest,   // known ReqDefId, but under other ReqType
+                Guid.NewGuid().ToString(),
+                4,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "Requirement type and/or requirement definition doesn't exist!");
+        #endregion
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypesControllerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypesControllerTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.RequirementTypes
+{
+    [TestClass]
+    public class RequirementTypesControllerTests : RequirementTypesControllerTestsBase
+    {
+        [TestMethod]
+        public async Task GetRequirementTypes_AsAdmin_ShouldGetRequirementTypesWithReqDefs()
+        {
+            // Act
+            var reqTypes = await RequirementTypesControllerTestsHelper.GetRequirementTypesAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess));
+
+            // Assert
+            Assert.IsNotNull(reqTypes);
+            Assert.AreNotEqual(0, reqTypes.Count);
+            var reqDef = reqTypes.First().RequirementDefinitions.FirstOrDefault();
+            Assert.IsNotNull(reqDef);
+        }
+
+        [TestMethod]
+        public async Task UpdateRequirementDefinition_AsAdmin_ShouldUpdateRequirementDefinitionAndRowVersion()
+        {
+            // Arrange
+            var reqTypeIdUnderTest = ReqTypeAIdUnderTest;
+            var reqDefIdUnderTest = ReqDefInReqTypeAIdUnderTest;
+            var reqDef = await GetReqDefDetails(reqTypeIdUnderTest, reqDefIdUnderTest);
+            var currentRowVersion = reqDef.RowVersion;
+            var newTitle = Guid.NewGuid().ToString();
+
+            // Act
+            var newRowVersion = await RequirementTypesControllerTestsHelper.UpdateRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                reqTypeIdUnderTest,
+                reqDef.Id,
+                newTitle,
+                4,
+                currentRowVersion);
+
+            // Assert
+            AssertRowVersionChange(currentRowVersion, newRowVersion);
+            reqDef = await GetReqDefDetails(reqTypeIdUnderTest, reqDefIdUnderTest);
+            Assert.AreEqual(newTitle, reqDef.Title);
+        }
+        private async Task<RequirementDefinitionDto> GetReqDefDetails(int reqTypeId, int reqDefId)
+        {
+            var reqType = await RequirementTypesControllerTestsHelper.GetRequirementTypesAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess));
+            return reqType
+                .Single(r => r.Id == reqTypeId)
+                .RequirementDefinitions
+                .Single(s => s.Id == reqDefId);
+        }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypesControllerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypesControllerTests.cs
@@ -23,12 +23,30 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.RequirementTypes
         }
 
         [TestMethod]
+        public async Task CreateRequirementDefinition_AsAdmin_ShouldCreateRequirementDefinition()
+        {
+            // Arrange
+            var reqTypeIdUnderTest = ReqTypeAIdUnderTest;
+            var title = Guid.NewGuid().ToString();
+
+            // Act
+            var reqDefId = await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                reqTypeIdUnderTest,
+                title);
+
+            // Assert
+            var reqDef = await GetRequirementDefinitionDetailsAsync(reqTypeIdUnderTest, reqDefId);
+            Assert.IsNotNull(reqDef);
+        }
+
+        [TestMethod]
         public async Task UpdateRequirementDefinition_AsAdmin_ShouldUpdateRequirementDefinitionAndRowVersion()
         {
             // Arrange
             var reqTypeIdUnderTest = ReqTypeAIdUnderTest;
             var reqDefIdUnderTest = ReqDefInReqTypeAIdUnderTest;
-            var reqDef = await GetReqDefDetails(reqTypeIdUnderTest, reqDefIdUnderTest);
+            var reqDef = await GetRequirementDefinitionDetailsAsync(reqTypeIdUnderTest, reqDefIdUnderTest);
             var currentRowVersion = reqDef.RowVersion;
             var newTitle = Guid.NewGuid().ToString();
 
@@ -43,17 +61,101 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.RequirementTypes
 
             // Assert
             AssertRowVersionChange(currentRowVersion, newRowVersion);
-            reqDef = await GetReqDefDetails(reqTypeIdUnderTest, reqDefIdUnderTest);
+            reqDef = await GetRequirementDefinitionDetailsAsync(reqTypeIdUnderTest, reqDefIdUnderTest);
             Assert.AreEqual(newTitle, reqDef.Title);
         }
-        private async Task<RequirementDefinitionDto> GetReqDefDetails(int reqTypeId, int reqDefId)
+
+        [TestMethod]
+        public async Task VoidRequirementDefinition_AsAdmin_ShouldVoidRequirementDefinition_AndUpdateAndRowVersion()
+        {
+            // Arrange
+            var reqTypeIdUnderTest = ReqTypeAIdUnderTest;
+            var reqDefId = await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                reqTypeIdUnderTest,
+                Guid.NewGuid().ToString());
+            var reqDef = await GetRequirementDefinitionDetailsAsync(reqTypeIdUnderTest, reqDefId);
+            var currentRowVersion = reqDef.RowVersion;
+            Assert.IsFalse(reqDef.IsVoided);
+
+            // Act
+            var newRowVersion = await RequirementTypesControllerTestsHelper.VoidRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                reqTypeIdUnderTest,
+                reqDefId,
+                currentRowVersion);
+
+            // Assert
+            AssertRowVersionChange(currentRowVersion, newRowVersion);
+            reqDef = await GetRequirementDefinitionDetailsAsync(reqTypeIdUnderTest, reqDefId);
+            Assert.IsTrue(reqDef.IsVoided);
+        }
+
+        [TestMethod]
+        public async Task UnvoidRequirementDefinition_AsAdmin_ShouldUnvoidRequirementDefinition_AndUpdateAndRowVersion()
+        {
+            // Arrange
+            var reqTypeIdUnderTest = ReqTypeAIdUnderTest;
+            var reqDefId = await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                reqTypeIdUnderTest,
+                Guid.NewGuid().ToString());
+            var reqDef = await GetRequirementDefinitionDetailsAsync(reqTypeIdUnderTest, reqDefId);
+            var currentRowVersion = await RequirementTypesControllerTestsHelper.VoidRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                reqTypeIdUnderTest,
+                reqDefId,
+                reqDef.RowVersion);
+
+            // Act
+            var newRowVersion = await RequirementTypesControllerTestsHelper.UnvoidRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                reqTypeIdUnderTest,
+                reqDefId,
+                currentRowVersion);
+
+            // Assert
+            AssertRowVersionChange(currentRowVersion, newRowVersion);
+            reqDef = await GetRequirementDefinitionDetailsAsync(reqTypeIdUnderTest, reqDefId);
+            Assert.IsFalse(reqDef.IsVoided);
+        }
+
+        [TestMethod]
+        public async Task DeleteRequirementDefinition_AsAdmin_ShouldDeleteRequirementDefinition()
+        {
+            // Arrange
+            var reqTypeIdUnderTest = ReqTypeAIdUnderTest;
+            var reqDefId = await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                reqTypeIdUnderTest,
+                Guid.NewGuid().ToString());
+            var reqDef = await GetRequirementDefinitionDetailsAsync(reqTypeIdUnderTest, reqDefId);
+            var currentRowVersion = await RequirementTypesControllerTestsHelper.VoidRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                reqTypeIdUnderTest,
+                reqDefId,
+                reqDef.RowVersion);
+
+            // Act
+            await RequirementTypesControllerTestsHelper.DeleteRequirementDefinitionAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                reqTypeIdUnderTest,
+                reqDefId,
+                currentRowVersion);
+
+            // Assert
+            reqDef = await GetRequirementDefinitionDetailsAsync(reqTypeIdUnderTest, reqDefId);
+            Assert.IsNull(reqDef);
+        }
+
+        private async Task<RequirementDefinitionDto> GetRequirementDefinitionDetailsAsync(int reqTypeId, int reqDefId)
         {
             var reqType = await RequirementTypesControllerTestsHelper.GetRequirementTypesAsync(
                 LibraryAdminClient(TestFactory.PlantWithAccess));
             return reqType
                 .Single(r => r.Id == reqTypeId)
                 .RequirementDefinitions
-                .Single(s => s.Id == reqDefId);
+                .SingleOrDefault(s => s.Id == reqDefId);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypesControllerTestsBase.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypesControllerTestsBase.cs
@@ -1,0 +1,28 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.RequirementTypes
+{
+    [TestClass]
+    public class RequirementTypesControllerTestsBase : TestBase
+    {
+        protected int ReqTypeAIdUnderTest;
+        protected int ReqDefInReqTypeAIdUnderTest;
+        protected int ReqTypeBIdUnderTest;
+        protected int ReqDefInReqTypeBIdUnderTest;
+
+        [TestInitialize]
+        public async Task TestInitialize()
+        {
+            var requirementTypes = await RequirementTypesControllerTestsHelper.GetRequirementTypesAsync(LibraryAdminClient(TestFactory.PlantWithAccess));
+            
+            var reqTypeA = requirementTypes.Single(j => j.Code == KnownTestData.ReqTypeA);
+            ReqTypeAIdUnderTest = reqTypeA.Id;
+            ReqDefInReqTypeAIdUnderTest = reqTypeA.RequirementDefinitions.First().Id;
+            
+            var reqTypeB = requirementTypes.Single(j => j.Code == KnownTestData.ReqTypeB);
+            ReqTypeBIdUnderTest = reqTypeB.Id;
+            ReqDefInReqTypeBIdUnderTest = reqTypeB.RequirementDefinitions.First().Id;        }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypesControllerTestsHelper.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypesControllerTestsHelper.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.RequirementTypes
+{
+    public static class RequirementTypesControllerTestsHelper
+    {
+        private const string _route = "RequirementTypes";
+
+        public static async Task<List<RequirementTypeDto>> GetRequirementTypesAsync(
+            HttpClient client,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var parameters = new ParameterCollection {{"includeVoided", "true"}};
+            var url = $"{_route}{parameters}";
+            var response = await client.GetAsync(url);
+
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (expectedStatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            var content = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<List<RequirementTypeDto>>(content);
+        }
+
+        public static async Task<string> UpdateRequirementDefinitionAsync(
+            HttpClient client,
+            int requirementTypeId,
+            int requirementDefinitionId,
+            string title,
+            int defaultIntervalWeeks,
+            string rowVersion,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                title,
+                defaultIntervalWeeks,
+                sortKey = 10,
+                rowVersion
+            };
+
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response = await client.PutAsync($"{_route}/{requirementTypeId}/RequirementDefinitions/{requirementDefinitionId}", content);
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            return await response.Content.ReadAsStringAsync();
+        }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypesControllerTestsHelper.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypesControllerTestsHelper.cs
@@ -30,6 +30,34 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.RequirementTypes
             var content = await response.Content.ReadAsStringAsync();
             return JsonConvert.DeserializeObject<List<RequirementTypeDto>>(content);
         }
+        
+        public static async Task<int> CreateRequirementDefinitionAsync(
+            HttpClient client,
+            int reqTypeId,
+            string title,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                title,
+                sortKey = 10,
+                defaultIntervalWeeks = 4
+            };
+
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response = await client.PostAsync($"{_route}/{reqTypeId}/RequirementDefinitions", content);
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                return -1;
+            }
+
+            var jsonString = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<int>(jsonString);
+        }
 
         public static async Task<string> UpdateRequirementDefinitionAsync(
             HttpClient client,
@@ -52,6 +80,85 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.RequirementTypes
             var serializePayload = JsonConvert.SerializeObject(bodyPayload);
             var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
             var response = await client.PutAsync($"{_route}/{requirementTypeId}/RequirementDefinitions/{requirementDefinitionId}", content);
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            return await response.Content.ReadAsStringAsync();
+        }
+
+        public static async Task<string> VoidRequirementDefinitionAsync(
+            HttpClient client,
+            int reqTypeId,
+            int reqDefId,
+            string rowVersion,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+            => await VoidUnvoidRequirementDefinitionAsync(client,
+                reqTypeId,
+                reqDefId,
+                rowVersion,
+                "Void",
+                expectedStatusCode,
+                expectedMessageOnBadRequest);
+
+        public static async Task<string> UnvoidRequirementDefinitionAsync(
+            HttpClient client,
+            int reqTypeId,
+            int reqDefId,
+            string rowVersion,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+            => await VoidUnvoidRequirementDefinitionAsync(client,
+                reqTypeId,
+                reqDefId,
+                rowVersion,
+                "Unvoid",
+                expectedStatusCode,
+                expectedMessageOnBadRequest);
+
+        public static async Task DeleteRequirementDefinitionAsync(
+            HttpClient client,
+            int reqTypeId,
+            int reqDefId,
+            string rowVersion,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                rowVersion
+            };
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var request = new HttpRequestMessage(HttpMethod.Delete, $"{_route}/{reqTypeId}/RequirementDefinitions/{reqDefId}")
+            {
+                Content = new StringContent(serializePayload, Encoding.UTF8, "application/json")
+            };
+
+            var response = await client.SendAsync(request);
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+        }
+
+        private static async Task<string> VoidUnvoidRequirementDefinitionAsync(
+            HttpClient client,
+            int reqTypeId,
+            int reqDefId,
+            string rowVersion,
+            string action,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                rowVersion
+            };
+
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response = await client.PutAsync($"{_route}/{reqTypeId}/RequirementDefinitions/{reqDefId}/{action}", content);
             await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
 
             if (response.StatusCode != HttpStatusCode.OK)

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerNegativeTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerNegativeTests.cs
@@ -646,7 +646,6 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
-
         [TestMethod]
         public async Task UpdateAction_AsPreserver_ShouldReturnBadRequest_WhenUnknownTagId()
             => await TagsControllerTestsHelper.UpdateActionAsync(


### PR DESCRIPTION
Same stuff for how validating if Req Def exists under a Req Type.
In my point of view, the codereview of int.tests can be done with one eye.

IRequirementDefinitionValidator.RequirementDefinitionHasRequirementTypeAsParentAsync removed. Not in use now

Hang in there .... this is the second last one :-p