### PR TITLE
79800 row version validation

### DIFF
--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Tags/TagsController.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Tags/TagsController.cs
@@ -543,13 +543,13 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Tags
 
         [Authorize(Roles = Permissions.PRESERVATION_PLAN_WRITE)]
         [HttpPut("Transfer")]
-        public async Task<IActionResult> Transfer(
+        public async Task<ActionResult<List<IdAndRowVersion>>> Transfer(
             [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
             [Required]
             string plant,
             [FromBody] List<TagIdWithRowVersionDto> tagDtos)
         {
-            var tags = tagDtos.Select(t => new IdAndRowVersion(t.Id, t.RowVersion));
+            var tags = tagDtos?.Select(t => new IdAndRowVersion(t.Id, t.RowVersion));
             var result = await _mediator.Send(new TransferCommand(tags));
             return this.FromResult(result);
         }

--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Tags/TagsController.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Tags/TagsController.cs
@@ -583,13 +583,13 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Tags
 
         [Authorize(Roles = Permissions.PRESERVATION_PLAN_WRITE)]
         [HttpPut("CompletePreservation")]
-        public async Task<IActionResult> CompletePreservation(
+        public async Task<ActionResult<List<IdAndRowVersion>>> CompletePreservation(
             [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
             [Required]
             string plant,
             [FromBody] List<TagIdWithRowVersionDto> tagDtos)
         {
-            var tags = tagDtos.Select(t => new IdAndRowVersion(t.Id, t.RowVersion));
+            var tags = tagDtos?.Select(t => new IdAndRowVersion(t.Id, t.RowVersion));
             var result = await _mediator.Send(new CompletePreservationCommand(tags));
             return this.FromResult(result);
         }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/KnownTestData.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/KnownTestData.cs
@@ -18,7 +18,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
         public static string ReqTypeB => "TestRT-B";
         public static string ReqDefInReqTypeB => "TestRD-B";
         public static string JourneyWithTags => "TestJourneyA";
-        public static string StepInJourneyWithTags => "TestStepA";
+        public static string StepAInJourneyWithTags => "TestStepA";
+        public static string StepBInJourneyWithTags => "TestStepB";
         public static string JourneyNotInUse => "TestJourneyB";
         public static string StepInJourneyNotInUse => "TestStepB";
         public static string StandardTagNo => "Std-Test";

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/PreservationContextExtension.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/PreservationContextExtension.cs
@@ -66,7 +66,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
             SeedReqDef(dbContext, reqTypeB, KnownTestData.ReqDefInReqTypeB);
             
             var journeyWithTags = SeedJourney(dbContext, plant, KnownTestData.JourneyWithTags);
-            var stepInJourneyWithTags = SeedStep(dbContext, journeyWithTags, KnownTestData.StepInJourneyWithTags, mode, responsible);
+            var stepInJourneyWithTags = SeedStep(dbContext, journeyWithTags, KnownTestData.StepAInJourneyWithTags, mode, responsible);
+            SeedStep(dbContext, journeyWithTags, KnownTestData.StepBInJourneyWithTags, mode, responsible);
             
             var journeyWithoutTags = SeedJourney(dbContext, plant, KnownTestData.JourneyNotInUse);
             SeedStep(dbContext, journeyWithoutTags, KnownTestData.StepInJourneyNotInUse, mode, responsible);

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/IdAndRowVersion.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/IdAndRowVersion.cs
@@ -1,0 +1,8 @@
+﻿namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
+{
+    public class IdAndRowVersion
+    {
+        public int Id { get; set; }
+        public string RowVersion { get; set;}
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerNegativeTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerNegativeTests.cs
@@ -1407,7 +1407,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
                         RowVersion = "invalidrowversion"
                     }
                 },
-                HttpStatusCode.BadRequest);
+                HttpStatusCode.BadRequest,
+                "Not a valid row version!");
         }
 
         #endregion

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerNegativeTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerNegativeTests.cs
@@ -1412,5 +1412,250 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         }
 
         #endregion
+        
+        #region CompletePreservation
+        [TestMethod]
+        public async Task CompletePreservation_AsAnonymous_ShouldReturnUnauthorized()
+            => await TagsControllerTestsHelper.CompletePreservationAsync(
+                AnonymousClient(TestFactory.UnknownPlant),
+                null,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task CompletePreservation_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await TagsControllerTestsHelper.CompletePreservationAsync(
+                AuthenticatedHackerClient(TestFactory.UnknownPlant),
+                null,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task CompletePreservation_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await TagsControllerTestsHelper.CompletePreservationAsync(
+                LibraryAdminClient(TestFactory.UnknownPlant),
+                null,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task CompletePreservation_AsHacker_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.CompletePreservationAsync(
+                AuthenticatedHackerClient(TestFactory.PlantWithAccess),
+                null,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task CompletePreservation_AsAdmin_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.CompletePreservationAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                null,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task CompletePreservation_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.CompletePreservationAsync(
+                PreserverClient(TestFactory.PlantWithAccess),
+                null,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task CompletePreservation_AsPlanner_ShouldReturnBadRequest_WhenIllegalRowVersion()
+        {
+            // Arrange 
+            var client = LibraryAdminClient(TestFactory.PlantWithAccess);
+            var newReqDefId = await CreateRequirementDefinitionAsync(client);
+            var stepId = JourneyWithTags.Steps.Last().Id;
+
+            client = PlannerClient(TestFactory.PlantWithAccess);
+            var newTagId = await TagsControllerTestsHelper.CreateAreaTagAsync(
+                client,
+                TestFactory.ProjectWithAccess,
+                AreaTagType.PreArea,
+                KnownDisciplineCode,
+                KnownAreaCode,
+                Guid.NewGuid().ToString(),
+                new List<TagRequirementDto>
+                {
+                    new TagRequirementDto
+                    {
+                        IntervalWeeks = 4,
+                        RequirementDefinitionId = newReqDefId
+                    }
+                },
+                stepId,
+                "Desc",
+                null,
+                null);
+            await TagsControllerTestsHelper.StartPreservationAsync(client, new List<int> {newTagId});
+
+            var tagsResult = await TagsControllerTestsHelper.GetAllTagsAsync(
+                client,
+                TestFactory.ProjectWithAccess);
+            var tagToCompletedPreservation = tagsResult.Tags.Single(t => t.Id == newTagId);
+            Assert.IsTrue(tagToCompletedPreservation.ReadyToBeCompleted, "Bad test setup: Didn't find tag ready to be completed");
+            
+            // Act
+            await TagsControllerTestsHelper.CompletePreservationAsync(
+                client,
+                new List<IdAndRowVersion>
+                {
+                    new IdAndRowVersion
+                    {
+                        Id = tagToCompletedPreservation.Id,
+                        RowVersion = "invalidrowversion"
+                    }
+                },
+                HttpStatusCode.BadRequest,
+                "Not a valid row version!");
+        }
+
+        #endregion
+        
+        #region StartPreservation
+        [TestMethod]
+        public async Task StartPreservation_AsAnonymous_ShouldReturnUnauthorized()
+            => await TagsControllerTestsHelper.StartPreservationAsync(
+                AnonymousClient(TestFactory.UnknownPlant),
+                null,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task StartPreservation_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await TagsControllerTestsHelper.StartPreservationAsync(
+                AuthenticatedHackerClient(TestFactory.UnknownPlant),
+                null,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task StartPreservation_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await TagsControllerTestsHelper.StartPreservationAsync(
+                LibraryAdminClient(TestFactory.UnknownPlant),
+                null,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task StartPreservation_AsHacker_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.StartPreservationAsync(
+                AuthenticatedHackerClient(TestFactory.PlantWithAccess),
+                null,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task StartPreservation_AsAdmin_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.StartPreservationAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess),
+                null,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task StartPreservation_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.StartPreservationAsync(
+                PreserverClient(TestFactory.PlantWithAccess),
+                null,
+                HttpStatusCode.Forbidden);
+
+        #endregion
+        
+        #region CreateAreaTag
+        [TestMethod]
+        public async Task CreateAreaTag_AsAnonymous_ShouldReturnUnauthorized()
+            => await TagsControllerTestsHelper.CreateAreaTagAsync(
+                AnonymousClient(TestFactory.UnknownPlant),
+                TestFactory.ProjectWithAccess,
+                AreaTagType.SiteArea,
+                KnownDisciplineCode,
+                null,
+                null,
+                null,
+                678,
+                "Desc",
+                null,
+                null,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task CreateAreaTag_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await TagsControllerTestsHelper.CreateAreaTagAsync(
+                AuthenticatedHackerClient(TestFactory.UnknownPlant),
+                TestFactory.ProjectWithAccess,
+                AreaTagType.SiteArea,
+                KnownDisciplineCode,
+                null,
+                null,
+                null,
+                678,
+                "Desc",
+                null,
+                null,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task CreateAreaTag_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await TagsControllerTestsHelper.CreateAreaTagAsync(
+                LibraryAdminClient(TestFactory.UnknownPlant),
+                TestFactory.ProjectWithAccess,
+                AreaTagType.SiteArea,
+                KnownDisciplineCode,
+                null,
+                null,
+                null,
+                678,
+                "Desc",
+                null,
+                null,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task CreateAreaTag_AsHacker_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.CreateAreaTagAsync(
+                AuthenticatedHackerClient(TestFactory.PlantWithAccess),
+                TestFactory.ProjectWithAccess,
+                AreaTagType.SiteArea,
+                KnownDisciplineCode,
+                null,
+                null,
+                null,
+                678,
+                "Desc",
+                null,
+                null,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task CreateAreaTag_AsAdmin_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.CreateAreaTagAsync(
+                LibraryAdminClient(TestFactory.PlantWithAccess), 
+                TestFactory.ProjectWithAccess,
+                AreaTagType.SiteArea,
+                KnownDisciplineCode,
+                null,
+                null,
+                null,
+                678,
+                "Desc",
+                null,
+                null,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task CreateAreaTag_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.CreateAreaTagAsync(
+                PreserverClient(TestFactory.PlantWithAccess), 
+                TestFactory.ProjectWithAccess,
+                AreaTagType.SiteArea,
+                KnownDisciplineCode,
+                null,
+                null,
+                null,
+                678,
+                "Desc",
+                null,
+                null,
+                HttpStatusCode.Forbidden);
+        #endregion
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.WebApi.Controllers.Tags;
-using Equinor.Procosys.Preservation.WebApi.IntegrationTests.RequirementTypes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
@@ -12,28 +11,18 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
     [TestClass]
     public class TagsControllerTests : TagsControllerTestsBase
     {
-        private HttpClient _preserverClient;
-        private HttpClient _plannerClient;
-
-        [TestInitialize]
-        public void Setup()
-        {
-            _preserverClient = PreserverClient(TestFactory.PlantWithAccess);
-            _plannerClient = PlannerClient(TestFactory.PlantWithAccess);
-        }
-
         [TestMethod]
         public async Task GetAllTags_AsPreserver_ShouldGetTags()
         {
             // Act
-            var tagResultDto = await TagsControllerTestsHelper.GetAllTagsAsync(
-                _preserverClient,
+            var tagsResult = await TagsControllerTestsHelper.GetAllTagsAsync(
+                PreserverClient(TestFactory.PlantWithAccess),
                 TestFactory.ProjectWithAccess);
 
             // Assert
-            Assert.IsTrue(tagResultDto.Tags.Count > 0);
+            Assert.IsTrue(tagsResult.Tags.Count > 0);
 
-            var siteAreaTag = tagResultDto.Tags.Single(t => t.Id == TagIdUnderTest_ForSiteAreaTagReadyForBulkPreserve_NotStarted);
+            var siteAreaTag = tagsResult.Tags.Single(t => t.Id == TagIdUnderTest_ForSiteAreaTagReadyForBulkPreserve_NotStarted);
             Assert.IsNotNull(siteAreaTag.TagNo);
             Assert.IsNotNull(siteAreaTag.RowVersion);
         }
@@ -43,7 +32,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         {
             // Act
             var siteAreaTag = await TagsControllerTestsHelper.GetTagAsync(
-                _preserverClient, 
+                PreserverClient(TestFactory.PlantWithAccess), 
                 TagIdUnderTest_ForSiteAreaTagReadyForBulkPreserve_NotStarted);
 
             // Assert
@@ -58,8 +47,9 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         public async Task DuplicateAreaTag_AsPlanner_ShouldReturnATagReadyToBeDuplicated()
         {
             // Arrange
+            var plannerClient = PlannerClient(TestFactory.PlantWithAccess);
             var tagsResult = await TagsControllerTestsHelper.GetAllTagsAsync(
-                _plannerClient,
+                plannerClient,
                 TestFactory.ProjectWithAccess);
             var initialTagsCount = tagsResult.Tags.Count;
             var readyToBeDuplicatedTag = tagsResult.Tags.First(t => t.ReadyToBeDuplicated);
@@ -67,7 +57,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
 
             // Act
             var id = await TagsControllerTestsHelper.DuplicateAreaTagAsync(
-                    _plannerClient, 
+                    plannerClient, 
                     readyToBeDuplicatedTag.Id, 
                     AreaTagType.SiteArea,
                     KnownDisciplineCode,
@@ -78,21 +68,17 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
                     null);
 
             // Assert
-            Assert.IsTrue(id > 0);
-            tagsResult = await TagsControllerTestsHelper.GetAllTagsAsync(
-                _plannerClient,
-                TestFactory.ProjectWithAccess);
-            Assert.AreEqual(initialTagsCount+1, tagsResult.Tags.Count);
-            Assert.IsNotNull(tagsResult.Tags.SingleOrDefault(t => t.Id == id));
+            await AssertNewTagCreated(plannerClient, id, initialTagsCount);
         }
 
         [TestMethod]
         public async Task UpdateTagStepAndRequirements_AsPlanner_ShouldChangeDescriptionOnAreaTag()
         {
             // Arrange
+            var plannerClient = PlannerClient(TestFactory.PlantWithAccess);
             var tagIdUnderTest = TagIdUnderTest_ForSiteAreaTagReadyForBulkPreserve_NotStarted;
             var tag = await TagsControllerTestsHelper.GetTagAsync(
-                _plannerClient, 
+                plannerClient, 
                 tagIdUnderTest);
             var oldDescription = tag.Description;
             var newDescription = Guid.NewGuid().ToString();
@@ -101,7 +87,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
 
             // Act
             var newRowVersion = await TagsControllerTestsHelper.UpdateTagStepAndRequirementsAsync(
-                _plannerClient,
+                plannerClient,
                 tag.Id,
                 newDescription,
                 tag.Step.Id,
@@ -110,7 +96,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
             // Assert
             AssertRowVersionChange(currentRowVersion, newRowVersion);
             tag = await TagsControllerTestsHelper.GetTagAsync(
-                _plannerClient, 
+                plannerClient, 
                 tagIdUnderTest);
             Assert.AreEqual(newDescription, tag.Description);
         }
@@ -119,14 +105,15 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         public async Task UpdateTagStepAndRequirements_AsPlanner_ShouldKeepSameDescriptionOnStandardTag()
         {
             // Arrange
+            var plannerClient = PlannerClient(TestFactory.PlantWithAccess);
             var tagIdUnderTest = TagIdUnderTest_ForStandardTagReadyForBulkPreserve_NotStarted;
-            var tag = await TagsControllerTestsHelper.GetTagAsync(_plannerClient, tagIdUnderTest);
+            var tag = await TagsControllerTestsHelper.GetTagAsync(plannerClient, tagIdUnderTest);
             var oldDescription = tag.Description;
             var currentRowVersion = tag.RowVersion;
 
             // Act
             var newRowVersion = await TagsControllerTestsHelper.UpdateTagStepAndRequirementsAsync(
-                _plannerClient,
+                plannerClient,
                 tag.Id,
                 oldDescription,
                 tag.Step.Id,
@@ -134,7 +121,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
 
             // Assert
             Assert.AreEqual(currentRowVersion, newRowVersion);
-            tag = await TagsControllerTestsHelper.GetTagAsync(_plannerClient, tagIdUnderTest);
+            tag = await TagsControllerTestsHelper.GetTagAsync(plannerClient, tagIdUnderTest);
             Assert.AreEqual(oldDescription, tag.Description);
         }
 
@@ -142,21 +129,20 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         public async Task UpdateTagStepAndRequirements_AsPlanner_ShouldUpdateAndAddRequirements()
         {
             // Arrange
+            var client = LibraryAdminClient(TestFactory.PlantWithAccess);
+            var newReqDefId = await CreateRequirementDefinitionAsync(client);
+
+            client = PlannerClient(TestFactory.PlantWithAccess);
             var tagIdUnderTest = TagIdUnderTest_ForStandardTagReadyForBulkPreserve_NotStarted;
-            var tag = await TagsControllerTestsHelper.GetTagAsync(_plannerClient, tagIdUnderTest);
+            var tag = await TagsControllerTestsHelper.GetTagAsync(client, tagIdUnderTest);
             var oldDescription = tag.Description;
-            var oldRequirements =  await TagsControllerTestsHelper.GetTagRequirementsAsync(_plannerClient, tagIdUnderTest);
+            var oldRequirements =  await TagsControllerTestsHelper.GetTagRequirementsAsync(client, tagIdUnderTest);
             var requirementToUpdate = oldRequirements.First();
-            var adminClient = LibraryAdminClient(TestFactory.PlantWithAccess);
-            var reqTypes = await RequirementTypesControllerTestsHelper.GetRequirementTypesAsync(adminClient);
-            var newReqTitle = Guid.NewGuid().ToString();
-            var newReqDefId = await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
-                adminClient, reqTypes.First().Id, newReqTitle);
 
             // Act
             var updatedIntervalWeeks = requirementToUpdate.IntervalWeeks + 1;
             await TagsControllerTestsHelper.UpdateTagStepAndRequirementsAsync(
-                _plannerClient,
+                client,
                 tag.Id,
                 oldDescription,
                 tag.Step.Id,
@@ -181,11 +167,10 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
                 });
 
             // Assert
-            var newRequirements =  await TagsControllerTestsHelper.GetTagRequirementsAsync(_plannerClient, tagIdUnderTest);
+            var newRequirements =  await TagsControllerTestsHelper.GetTagRequirementsAsync(client, tagIdUnderTest);
             Assert.AreEqual(oldRequirements.Count+1, newRequirements.Count);
             var newRequirement = newRequirements.SingleOrDefault(r => r.RequirementDefinition.Id == newReqDefId);
             Assert.IsNotNull(newRequirement);
-            Assert.AreEqual(newReqTitle, newRequirement.RequirementDefinition.Title);
             var updatedRequirement = newRequirements.SingleOrDefault(r => r.RequirementDefinition.Id == requirementToUpdate.Id);
             Assert.IsNotNull(updatedRequirement);
             Assert.AreEqual(updatedIntervalWeeks, updatedRequirement.IntervalWeeks);
@@ -195,8 +180,9 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         public async Task GetAllTagAttachments_AsPreserver_ShouldGetAttachments()
         {
             // Act
+            var preserverClient = PreserverClient(TestFactory.PlantWithAccess);
             var attachmentDtos = await TagsControllerTestsHelper.GetAllTagAttachmentsAsync(
-                _preserverClient,
+                preserverClient,
                 TagIdUnderTest_ForStandardTagWithAttachmentsAndActionAttachments);
 
             // Assert
@@ -212,22 +198,23 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         public async Task DeleteTagAttachment_AsPreserver_ShouldDeleteTagAttachment()
         {
             // Arrange
+            var preserverClient = PreserverClient(TestFactory.PlantWithAccess);
             var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithAttachmentsAndActionAttachments;
             var attachmentDtos = await TagsControllerTestsHelper.GetAllTagAttachmentsAsync(
-                _preserverClient,
+                preserverClient,
                 tagIdUnderTest);
             var tagAttachment = attachmentDtos.First();
 
             // Act
             await TagsControllerTestsHelper.DeleteTagAttachmentAsync(
-                _preserverClient,
+                preserverClient,
                 tagIdUnderTest,
                 tagAttachment.Id,
                 tagAttachment.RowVersion);
 
             // Assert
             attachmentDtos = await TagsControllerTestsHelper.GetAllTagAttachmentsAsync(
-                _preserverClient,
+                preserverClient,
                 tagIdUnderTest);
             Assert.IsNull(attachmentDtos.SingleOrDefault(m => m.Id == tagAttachment.Id));
         }
@@ -236,15 +223,16 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         public async Task GetAllActionAttachments_AsPreserver_ShouldGetAttachments()
         {
             // Arrange
+            var preserverClient = PreserverClient(TestFactory.PlantWithAccess);
             var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithAttachmentsAndActionAttachments;
             var actionsDtos = await TagsControllerTestsHelper.GetAllActionsAsync(
-                _preserverClient,
+                preserverClient,
                 tagIdUnderTest);
             var action = actionsDtos.First();
 
             // Act
             var attachmentDtos = await TagsControllerTestsHelper.GetAllActionAttachmentsAsync(
-                _preserverClient,
+                preserverClient,
                 tagIdUnderTest,
                 action.Id);
 
@@ -261,20 +249,21 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         public async Task DeleteActionAttachment_AsPreserver_ShouldDeleteActionAttachment()
         {
             // Arrange
+            var preserverClient = PreserverClient(TestFactory.PlantWithAccess);
             var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithAttachmentsAndActionAttachments;
             var actionsDtos = await TagsControllerTestsHelper.GetAllActionsAsync(
-                _preserverClient,
+                preserverClient,
                 tagIdUnderTest);
             var action = actionsDtos.First();
             var actionAttachmentDtos = await TagsControllerTestsHelper.GetAllActionAttachmentsAsync(
-                _preserverClient,
+                preserverClient,
                 tagIdUnderTest,
                 action.Id);
             var actionAttachment = actionAttachmentDtos.First();
 
             // Act
             await TagsControllerTestsHelper.DeleteActionAttachmentAsync(
-                _preserverClient,
+                preserverClient,
                 tagIdUnderTest,
                 action.Id,
                 actionAttachment.Id,
@@ -282,7 +271,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
 
             // Assert
             actionAttachmentDtos = await TagsControllerTestsHelper.GetAllActionAttachmentsAsync(
-                _preserverClient,
+                preserverClient,
                 tagIdUnderTest,
                 action.Id);
             Assert.IsNull(actionAttachmentDtos.SingleOrDefault(m => m.Id == actionAttachment.Id));
@@ -292,16 +281,17 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         public async Task GetAllActions_AsPreserver_ShouldGetActions()
         {
             // Arrange
+            var preserverClient = PreserverClient(TestFactory.PlantWithAccess);
             var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithAttachmentsAndActionAttachments;
             var actionIdUnderTest = await TagsControllerTestsHelper.CreateActionAsync(
-                _preserverClient,
+                preserverClient,
                 tagIdUnderTest,
                 Guid.NewGuid().ToString(),
                 Guid.NewGuid().ToString());
 
             // Act
             var actionDtos = await TagsControllerTestsHelper.GetAllActionsAsync(
-                _preserverClient,
+                preserverClient,
                 tagIdUnderTest);
 
             // Assert
@@ -317,16 +307,17 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         public async Task GetAction_AsPreserver_ShouldGetActionDetails()
         {
             // Arrange
+            var preserverClient = PreserverClient(TestFactory.PlantWithAccess);
             var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithAttachmentsAndActionAttachments;
             var actionIdUnderTest = await TagsControllerTestsHelper.CreateActionAsync(
-                _preserverClient,
+                preserverClient,
                 tagIdUnderTest,
                 Guid.NewGuid().ToString(),
                 Guid.NewGuid().ToString());
 
             // Act
             var actionDetailsDto = await TagsControllerTestsHelper.GetActionAsync(
-                _preserverClient,
+                preserverClient,
                 tagIdUnderTest,
                 actionIdUnderTest);
 
@@ -341,15 +332,16 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         public async Task UpdateAction_AsPreserver_ShouldUpdateAction()
         {
             // Arrange
+            var preserverClient = PreserverClient(TestFactory.PlantWithAccess);
             var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithAttachmentsAndActionAttachments;
             var actionIdUnderTest = await TagsControllerTestsHelper.CreateActionAsync(
-                _preserverClient,
+                preserverClient,
                 tagIdUnderTest,
                 Guid.NewGuid().ToString(),
                 Guid.NewGuid().ToString());
 
             var actionDetails = await TagsControllerTestsHelper.GetActionAsync(
-                _preserverClient, 
+                preserverClient, 
                 tagIdUnderTest,
                 actionIdUnderTest);
             var currentRowVersion = actionDetails.RowVersion;
@@ -358,7 +350,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
 
             // Act
             var newRowVersion = await TagsControllerTestsHelper.UpdateActionAsync(
-                _preserverClient,
+                preserverClient,
                 tagIdUnderTest,
                 actionIdUnderTest,
                 newTitle,
@@ -368,7 +360,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
             // Assert
             AssertRowVersionChange(currentRowVersion, newRowVersion);
             actionDetails = await TagsControllerTestsHelper.GetActionAsync(
-                _preserverClient, 
+                preserverClient, 
                 tagIdUnderTest,
                 actionIdUnderTest);
             Assert.AreEqual(newTitle, actionDetails.Title);
@@ -379,15 +371,16 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         public async Task CloseAction_AsPreserver_ShouldCloseAction()
         {
             // Arrange
+            var preserverClient = PreserverClient(TestFactory.PlantWithAccess);
             var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithAttachmentsAndActionAttachments;
             var actionIdUnderTest = await TagsControllerTestsHelper.CreateActionAsync(
-                _preserverClient,
+                preserverClient,
                 tagIdUnderTest,
                 Guid.NewGuid().ToString(),
                 Guid.NewGuid().ToString());
 
             var actionDetails = await TagsControllerTestsHelper.GetActionAsync(
-                _preserverClient, 
+                preserverClient, 
                 tagIdUnderTest,
                 actionIdUnderTest);
             var currentRowVersion = actionDetails.RowVersion;
@@ -395,7 +388,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
 
             // Act
             var newRowVersion = await TagsControllerTestsHelper.CloseActionAsync(
-                _preserverClient,
+                preserverClient,
                 tagIdUnderTest,
                 actionIdUnderTest,
                 currentRowVersion);
@@ -403,7 +396,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
             // Assert
             AssertRowVersionChange(currentRowVersion, newRowVersion);
             actionDetails = await TagsControllerTestsHelper.GetActionAsync(
-                _preserverClient, 
+                preserverClient, 
                 tagIdUnderTest,
                 actionIdUnderTest);
             Assert.IsNotNull(actionDetails.ClosedAtUtc);
@@ -413,29 +406,30 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         public async Task UploadActionAttachment_AsPreserver_ShouldUploadActionAttachment()
         {
             // Arrange
+            var preserverClient = PreserverClient(TestFactory.PlantWithAccess);
             var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithAttachmentsAndActionAttachments;
             var actionIdUnderTest = await TagsControllerTestsHelper.CreateActionAsync(
-                _preserverClient,
+                preserverClient,
                 tagIdUnderTest,
                 Guid.NewGuid().ToString(),
                 Guid.NewGuid().ToString());
 
             var actionDetails = await TagsControllerTestsHelper.GetActionAsync(
-                _preserverClient, 
+                preserverClient, 
                 tagIdUnderTest,
                 actionIdUnderTest);
             var attachmentCount = actionDetails.AttachmentCount;
 
             // Act
             await TagsControllerTestsHelper.UploadActionAttachmentAsync(
-                _preserverClient,
+                preserverClient,
                 tagIdUnderTest,
                 actionIdUnderTest,
                 FileToBeUploaded);
             
             // Assert
             actionDetails = await TagsControllerTestsHelper.GetActionAsync(
-                _preserverClient, 
+                preserverClient, 
                 tagIdUnderTest,
                 actionIdUnderTest);
             Assert.AreEqual(attachmentCount + 1, actionDetails.AttachmentCount);
@@ -445,20 +439,21 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         public async Task CreateAction_AsPreserver_ShouldCreateAction()
         {
             // Arrange
+            var preserverClient = PreserverClient(TestFactory.PlantWithAccess);
             var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithAttachmentsAndActionAttachments;
             var title = Guid.NewGuid().ToString();
             var description = Guid.NewGuid().ToString();
 
             // Act
             var id = await TagsControllerTestsHelper.CreateActionAsync(
-                _preserverClient,
+                preserverClient,
                 tagIdUnderTest,
                 title,
                 description);
             
             // Assert
             var actionDetails = await TagsControllerTestsHelper.GetActionAsync(
-                _preserverClient, 
+                preserverClient, 
                 tagIdUnderTest,
                 id);
             Assert.AreEqual(title, actionDetails.Title);
@@ -473,7 +468,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
             
             // Act
             var requirementDetailDtos = await TagsControllerTestsHelper.GetTagRequirementsAsync(
-                _preserverClient, 
+                PreserverClient(TestFactory.PlantWithAccess), 
                 tagIdUnderTest);
             
             // Assert
@@ -488,21 +483,22 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         public async Task UploadFieldValueAttachment_AsPreserver_ShouldUploadFieldValueAttachment()
         {
             // Arrange
+            var preserverClient = PreserverClient(TestFactory.PlantWithAccess);
             var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithAttachmentRequirement_Started;
 
-            var requirement = await TagsControllerTestsHelper.GetTagRequirementInfoAsync(_preserverClient, tagIdUnderTest);
+            var requirement = await TagsControllerTestsHelper.GetTagRequirementInfoAsync(preserverClient, tagIdUnderTest);
             Assert.IsNull(requirement.Fields.Single().CurrentValue, "Bad test setup: Attachment already uploaded");
 
             // Act
             await TagsControllerTestsHelper.UploadFieldValueAttachmentAsync(
-                _preserverClient,
+                preserverClient,
                 tagIdUnderTest,
                 requirement.Id,
                 requirement.Fields.First().Id,
                 FileToBeUploaded);
             
             // Assert
-            requirement = await TagsControllerTestsHelper.GetTagRequirementInfoAsync(_preserverClient, tagIdUnderTest);
+            requirement = await TagsControllerTestsHelper.GetTagRequirementInfoAsync(preserverClient, tagIdUnderTest);
             Assert.IsNotNull(requirement.Fields.Single().CurrentValue);
         }
 
@@ -510,15 +506,16 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         public async Task RecordCbValueAsync_AsPreserver_ShouldRecordCbValueAsync()
         {
             // Arrange
+            var preserverClient = PreserverClient(TestFactory.PlantWithAccess);
             var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithCbRequirement_Started;
 
-            var requirement = await TagsControllerTestsHelper.GetTagRequirementInfoAsync(_preserverClient, tagIdUnderTest);
+            var requirement = await TagsControllerTestsHelper.GetTagRequirementInfoAsync(preserverClient, tagIdUnderTest);
             Assert.IsNull(requirement.Fields.Single().CurrentValue, "Bad test setup: Value already recorded");
             var comment = Guid.NewGuid().ToString();
 
             // Act
             await TagsControllerTestsHelper.RecordCbValueAsync(
-                _preserverClient,
+                preserverClient,
                 tagIdUnderTest,
                 requirement.Id,
                 requirement.Fields.First().Id,
@@ -526,7 +523,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
                 true);
             
             // Assert
-            requirement = await TagsControllerTestsHelper.GetTagRequirementInfoAsync(_preserverClient, tagIdUnderTest);
+            requirement = await TagsControllerTestsHelper.GetTagRequirementInfoAsync(preserverClient, tagIdUnderTest);
             Assert.IsNotNull(requirement.Fields.Single().CurrentValue);
         }
 
@@ -534,15 +531,16 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         public async Task PreserveRequirement_AsPreserver_ShouldPreserveRequirement()
         {
             // Arrange
+            var preserverClient = PreserverClient(TestFactory.PlantWithAccess);
             var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithInfoRequirement_Started;
-            var requirement = await TagsControllerTestsHelper.GetTagRequirementInfoAsync(_preserverClient, tagIdUnderTest);
+            var requirement = await TagsControllerTestsHelper.GetTagRequirementInfoAsync(preserverClient, tagIdUnderTest);
             var oldNextDueTimeUtc = requirement.NextDueTimeUtc;
 
             // Act
-            await TagsControllerTestsHelper.PreserveRequirementAsync(_preserverClient, tagIdUnderTest, requirement.Id);
+            await TagsControllerTestsHelper.PreserveRequirementAsync(preserverClient, tagIdUnderTest, requirement.Id);
 
             // Assert
-            requirement = await TagsControllerTestsHelper.GetTagRequirementInfoAsync(_preserverClient, tagIdUnderTest);
+            requirement = await TagsControllerTestsHelper.GetTagRequirementInfoAsync(preserverClient, tagIdUnderTest);
             Assert.AreNotEqual(oldNextDueTimeUtc, requirement.NextDueTimeUtc);
         }
 
@@ -550,16 +548,42 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         public async Task Transfer_AsPlanner_ShouldTransferTags()
         {
             // Arrange 
-            var tagResultDto = await TagsControllerTestsHelper.GetAllTagsAsync(
-                _plannerClient,
-                TestFactory.ProjectWithAccess);
-            var tagToTransfer = tagResultDto.Tags.FirstOrDefault(t => t.ReadyToBeTransferred);
-            Assert.IsNotNull(tagToTransfer, "Bad test setup: Didn't find tag ready to be transferred");
+            var client = LibraryAdminClient(TestFactory.PlantWithAccess);
+            var newReqDefId = await CreateRequirementDefinitionAsync(client);
+            var stepId = JourneyWithTags.Steps.First().Id;
 
+            client = PlannerClient(TestFactory.PlantWithAccess);
+            var newTagId = await TagsControllerTestsHelper.CreateAreaTagAsync(
+                client,
+                TestFactory.ProjectWithAccess,
+                AreaTagType.PreArea,
+                KnownDisciplineCode,
+                KnownAreaCode,
+                Guid.NewGuid().ToString(),
+                new List<TagRequirementDto>
+                {
+                    new TagRequirementDto
+                    {
+                        IntervalWeeks = 4,
+                        RequirementDefinitionId = newReqDefId
+                    }
+                },
+                stepId,
+                "Desc",
+                null,
+                null);
+            await TagsControllerTestsHelper.StartPreservationAsync(client, new List<int> {newTagId});
+
+            var tagsResult = await TagsControllerTestsHelper.GetAllTagsAsync(
+                client,
+                TestFactory.ProjectWithAccess);
+            var tagToTransfer = tagsResult.Tags.Single(t => t.Id == newTagId);
+            Assert.IsTrue(tagToTransfer.ReadyToBeTransferred, "Bad test setup: Didn't find tag ready to be transferred");
+            
             // Act
             var currentRowVersion = tagToTransfer.RowVersion;
             var idAndRowVersions = await TagsControllerTestsHelper.TransferAsync(
-                _plannerClient,
+                client,
                 new List<IdAndRowVersion>
                 {
                     new IdAndRowVersion
@@ -575,6 +599,55 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
 
             var requirementDetailDto = idAndRowVersions.Single();
             AssertRowVersionChange(currentRowVersion, requirementDetailDto.RowVersion);
+        }
+
+        [TestMethod]
+        public async Task CreateAreaTag_AsPlanner_ShouldCreateAreaTag()
+        {
+            // Arrange
+            var client = LibraryAdminClient(TestFactory.PlantWithAccess);
+            var newReqDefId = await CreateRequirementDefinitionAsync(client);
+            var stepId = JourneyWithTags.Steps.Last().Id;
+
+            client = PlannerClient(TestFactory.PlantWithAccess);
+            var tagsResult = await TagsControllerTestsHelper.GetAllTagsAsync(
+                client,
+                TestFactory.ProjectWithAccess);
+            var initialTagsCount = tagsResult.Tags.Count;
+
+            // Act
+            var id = await TagsControllerTestsHelper.CreateAreaTagAsync(
+                client,
+                TestFactory.ProjectWithAccess,
+                AreaTagType.PreArea,
+                KnownDisciplineCode,
+                KnownAreaCode,
+                Guid.NewGuid().ToString(),
+                new List<TagRequirementDto>
+                {
+                    new TagRequirementDto
+                    {
+                        IntervalWeeks = 4,
+                        RequirementDefinitionId = newReqDefId
+                    }
+                },
+                stepId,
+                "Desc",
+                null,
+                null);
+
+            // Assert
+            await AssertNewTagCreated(client, id, initialTagsCount);
+        }
+
+        private async Task AssertNewTagCreated(HttpClient client, int id, int initialTagsCount)
+        {
+            Assert.IsTrue(id > 0);
+            var tagsResult = await TagsControllerTestsHelper.GetAllTagsAsync(
+                client,
+                TestFactory.ProjectWithAccess);
+            Assert.AreEqual(initialTagsCount + 1, tagsResult.Tags.Count);
+            Assert.IsNotNull(tagsResult.Tags.SingleOrDefault(t => t.Id == id));
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTestsBase.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTestsBase.cs
@@ -1,6 +1,11 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.MainApi.Area;
 using Equinor.Procosys.Preservation.MainApi.Discipline;
+using Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys;
+using Equinor.Procosys.Preservation.WebApi.IntegrationTests.RequirementTypes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
@@ -22,6 +27,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         protected int TagIdUnderTest_ForStandardTagWithAttachmentsAndActionAttachments;
         protected int TagIdUnderTest_ForSiteAreaTagWithAttachmentsAndActionAttachments;
 
+        protected JourneyDto JourneyWithTags;
+
         protected TestFile FileToBeUploaded = new TestFile("test file content", "file.txt");
 
         [TestInitialize]
@@ -36,6 +43,9 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
             InitialTagsCount = result.MaxAvailable;
             Assert.IsTrue(InitialTagsCount > 0, "Bad test setup: Didn't find any tags at startup");
             Assert.AreEqual(InitialTagsCount, result.Tags.Count);
+
+            var journeys = await JourneysControllerTestsHelper.GetJourneysAsync(LibraryAdminClient(TestFactory.PlantWithAccess));
+            JourneyWithTags = journeys.Single(j => j.Title == KnownTestData.JourneyWithTags);
 
             TagIdUnderTest_ForStandardTagReadyForBulkPreserve_NotStarted
                 = TestFactory.KnownTestData.TagId_ForStandardTagReadyForBulkPreserve_NotStarted;
@@ -68,6 +78,14 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
                 {
                     Code = KnownAreaCode, Description = $"{KnownAreaCode} - Description"
                 }));
+        }
+
+        protected async Task<int> CreateRequirementDefinitionAsync(HttpClient client)
+        {
+            var reqTypes = await RequirementTypesControllerTestsHelper.GetRequirementTypesAsync(client);
+            var newReqDefId = await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
+                client, reqTypes.First().Id, Guid.NewGuid().ToString());
+            return newReqDefId;
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTestsHelper.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTestsHelper.cs
@@ -31,8 +31,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
                 return null;
             }
 
-            var content = await response.Content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<TagResultDto>(content);
+            var jsonString = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<TagResultDto>(jsonString);
         }
         
         public static async Task<TagDetailsDto> GetTagAsync(
@@ -50,8 +50,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
                 return null;
             }
 
-            var content = await response.Content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<TagDetailsDto>(content);
+            var jsonString = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<TagDetailsDto>(jsonString);
         }
 
         public static async Task<int> DuplicateAreaTagAsync(
@@ -141,8 +141,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
                 return null;
             }
 
-            var content = await response.Content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<List<TagAttachmentDto>>(content);
+            var jsonString = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<List<TagAttachmentDto>>(jsonString);
         }
 
         public static async Task DeleteTagAttachmentAsync(
@@ -183,8 +183,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
                 return null;
             }
 
-            var content = await response.Content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<List<ActionAttachmentDto>>(content);
+            var jsonString = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<List<ActionAttachmentDto>>(jsonString);
         }
 
         public static async Task DeleteActionAttachmentAsync(
@@ -225,8 +225,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
                 return null;
             }
 
-            var content = await response.Content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<List<ActionDto>>(content);
+            var jsonString = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<List<ActionDto>>(jsonString);
         }
 
         public static async Task<string> UpdateActionAsync(
@@ -275,8 +275,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
                 return null;
             }
 
-            var content = await response.Content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<ActionDetailsDto>(content);
+            var jsonString = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<ActionDetailsDto>(jsonString);
         }
 
         public static async Task<string> CloseActionAsync(
@@ -362,8 +362,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
                 return null;
             }
 
-            var content = await response.Content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<List<RequirementDetailsDto>>(content);
+            var jsonString = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<List<RequirementDetailsDto>>(jsonString);
         }
 
         public static async Task UploadFieldValueAttachmentAsync(
@@ -432,6 +432,29 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
             var response = await client.PostAsync($"{_route}/{tagId}/Requirements/{requirementId}/Preserve", null);
 
             await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+        }
+
+        public static async Task<IList<IdAndRowVersion>> TransferAsync(
+            HttpClient client,
+            IEnumerable<IdAndRowVersion> tagDtos,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = tagDtos;
+
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response = await client.PutAsync($"{_route}/Transfer", content);
+            
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            var jsonString = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<List<IdAndRowVersion>>(jsonString);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTestsHelper.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTestsHelper.cs
@@ -456,5 +456,86 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
             var jsonString = await response.Content.ReadAsStringAsync();
             return JsonConvert.DeserializeObject<List<IdAndRowVersion>>(jsonString);
         }
+
+        public static async Task<IList<IdAndRowVersion>> CompletePreservationAsync(
+            HttpClient client,
+            IEnumerable<IdAndRowVersion> tagDtos,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = tagDtos;
+
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response = await client.PutAsync($"{_route}/CompletePreservation", content);
+            
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            var jsonString = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<List<IdAndRowVersion>>(jsonString);
+        }
+
+        public static async Task StartPreservationAsync(
+            HttpClient client,
+            IEnumerable<int> tagIds,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = tagIds;
+
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response = await client.PutAsync($"{_route}/StartPreservation", content);
+            
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+        }
+
+        public static async Task<int> CreateAreaTagAsync(
+            HttpClient client,
+            string projectName,
+            AreaTagType areaTagType,
+            string disciplineCode,
+            string areaCode,
+            string tagNoSuffix,
+            List<TagRequirementDto> requirements,
+            int stepId,
+            string description,
+            string remark,
+            string storageArea,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                projectName,
+                areaTagType,
+                disciplineCode,
+                areaCode,
+                tagNoSuffix,
+                requirements,
+                stepId,
+                description,
+                remark,
+                storageArea
+            };
+
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response = await client.PostAsync($"{_route}/Area", content);
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                return -1;
+            }
+
+            var jsonString = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<int>(jsonString);
+        }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/TestFactory.cs
@@ -11,6 +11,7 @@ using Equinor.Procosys.Preservation.MainApi.Area;
 using Equinor.Procosys.Preservation.MainApi.Discipline;
 using Equinor.Procosys.Preservation.MainApi.Permission;
 using Equinor.Procosys.Preservation.MainApi.Plant;
+using Equinor.Procosys.Preservation.MainApi.Project;
 using Equinor.Procosys.Preservation.MainApi.Responsible;
 using Equinor.Procosys.Preservation.WebApi.Authorizations;
 using Equinor.Procosys.Preservation.WebApi.Middleware;
@@ -23,6 +24,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Newtonsoft.Json;
+using ProcosysProject = Equinor.Procosys.Preservation.MainApi.Permission.ProcosysProject;
 
 namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
 {
@@ -40,6 +42,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
         private readonly List<IDisposable> _disposables = new List<IDisposable>();
 
         private readonly Mock<IPlantApiService> _plantApiServiceMock = new Mock<IPlantApiService>();
+        private readonly Mock<IProjectApiService> _projectApiServiceMock = new Mock<IProjectApiService>();
         private readonly Mock<IPermissionApiService> _permissionApiServiceMock = new Mock<IPermissionApiService>();
         public readonly Mock<IResponsibleApiService> ResponsibleApiServiceMock = new Mock<IResponsibleApiService>();
         public readonly Mock<IDisciplineApiService> DisciplineApiServiceMock = new Mock<IDisciplineApiService>();
@@ -121,6 +124,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
                     jwtBearerOptions.ForwardAuthenticate = IntegrationTestAuthHandler.TestAuthenticationScheme);
 
                 services.AddScoped(serviceProvider => _plantApiServiceMock.Object);
+                services.AddScoped(serviceProvider => _projectApiServiceMock.Object);
                 services.AddScoped(serviceProvider => _permissionApiServiceMock.Object);
                 services.AddScoped(serviceProvider => ResponsibleApiServiceMock.Object);
                 services.AddScoped(serviceProvider => DisciplineApiServiceMock.Object);


### PR DESCRIPTION
Fixed CompletePreservationCommandValidator and TransferCommandValidator to ensure given RowVersion from client is a real RowVersion. Covered by new int. tests

No need to review int.tests