### PR TITLE
79984 - Fix in test teardown do delete created Test DB

### DIFF
--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/TestBase.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/TestBase.cs
@@ -7,6 +7,9 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
     public abstract class TestBase
     {
         private readonly RowVersionValidator _rowVersionValidator = new RowVersionValidator();
+        
+        [AssemblyCleanup]
+        public static void AssemblyCleanup() => TestFactory.Instance.Dispose();
 
         public void AssertRowVersionChange(string oldRowVersion, string newRowVersion)
         {

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/TestFactory.cs
@@ -110,6 +110,11 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
             {
                 try { disposable.Dispose(); } catch { /* Ignore */ }
             }
+            
+            lock (s_padlock)
+            {
+                s_instance = null;
+            }
 
             base.Dispose();
         }
@@ -222,7 +227,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
 
         private string GetTestDbConnectionString(string projectDir)
         {
-            var dbName = "IntegrationTestsDB";
+            var dbName = "IntegrationTestsPresDB";
             var dbPath = Path.Combine(projectDir, $"{dbName}.mdf");
             
             // Set Initial Catalog to be able to delete database!


### PR DESCRIPTION
Minor adjustment needed, found when implementing for IPO. If not disposing in TestBase, DB remains on local disk.
Each test solution should also use differerent CatalogNames for created test DB. If not, this cause problem if test db for other solution remains on local DB from last run.