### PR TITLE
80306 history tab in excel

### DIFF
--- a/src/Equinor.Procosys.Preservation.Query/GetTagsQueries/GetTagsForExport/ExportHistoryDto.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetTagsQueries/GetTagsForExport/ExportHistoryDto.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace Equinor.Procosys.Preservation.Query.GetTagsQueries.GetTagsForExport
+{
+    public class ExportHistoryDto
+    {
+        public ExportHistoryDto(
+            int id,
+            string description,
+            DateTime createdAtUtc,
+            int? dueInWeeks)
+        {
+            Id = id;
+            Description = description;
+            CreatedAtUtc = createdAtUtc;
+            DueInWeeks = dueInWeeks;
+        }
+
+        public int Id { get; }
+        public string Description { get; }
+        public DateTime CreatedAtUtc { get; }
+        public int? DueInWeeks { get; }
+    }
+}

--- a/src/Equinor.Procosys.Preservation.Query/GetTagsQueries/GetTagsForExport/ExportTagDto.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetTagsQueries/GetTagsForExport/ExportTagDto.cs
@@ -12,6 +12,7 @@ namespace Equinor.Procosys.Preservation.Query.GetTagsQueries.GetTagsForExport
             int attachmentsCount,
             string commPkgNo,
             string disciplineCode,
+            List<ExportHistoryDto> history,
             bool isVoided,
             string journey,
             string mcPkgNo,
@@ -38,6 +39,7 @@ namespace Equinor.Procosys.Preservation.Query.GetTagsQueries.GetTagsForExport
             CommPkgNo = commPkgNo;
             Description = tagDescription;
             DisciplineCode = disciplineCode;
+            History = history;
             IsVoided = isVoided;
             Journey = journey;
             McPkgNo = mcPkgNo;
@@ -64,6 +66,7 @@ namespace Equinor.Procosys.Preservation.Query.GetTagsQueries.GetTagsForExport
         public string CommPkgNo { get; }
         public string Description { get; }
         public string DisciplineCode { get; }
+        public List<ExportHistoryDto> History { get; }
         public bool IsVoided { get; }
         public string Journey { get; }
         public string McPkgNo { get; }

--- a/src/Equinor.Procosys.Preservation.Query/GetTagsQueries/TagForQueryDto.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetTagsQueries/TagForQueryDto.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.HistoryAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate;
 
@@ -33,6 +35,7 @@ namespace Equinor.Procosys.Preservation.Query.GetTagsQueries
         public byte[] RowVersion { get; set; }
         public Journey JourneyWithSteps { get; set; }
         public Step NextStep { get; set; }
+        public List<History> History { get; set; }
 
         public ActionStatus? GetActionStatus()
         {

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetActionAttachments/GetActionAttachmentsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetActionAttachments/GetActionAttachmentsQueryHandlerTests.cs
@@ -65,7 +65,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetActionAttachments
         }
 
         [TestMethod]
-        public async Task Handler_ShouldReturnNotFound_IfTagIsNotFound()
+        public async Task Handler_ShouldReturnNotFound_WhenTagNotFound()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetActionDetails/GetActionDetailsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetActionDetails/GetActionDetailsQueryHandlerTests.cs
@@ -118,7 +118,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetActionDetails
         }
 
         [TestMethod]
-        public async Task Handler_ShouldReturnNotFound_IfTagIsNotFound()
+        public async Task Handler_ShouldReturnNotFound_WhenTagNotFound()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetActions/GetActionsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetActions/GetActionsQueryHandlerTests.cs
@@ -104,7 +104,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetActions
         }
 
         [TestMethod]
-        public async Task Handler_ShouldReturnNotFound_IfTagIsNotFound()
+        public async Task Handler_ShouldReturnNotFound_WhenTagNotFound()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetFieldValueAttachment/GetFieldValueAttachmentQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetFieldValueAttachment/GetFieldValueAttachmentQueryHandlerTests.cs
@@ -97,7 +97,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetFieldValueAttachment
         }
 
         [TestMethod]
-        public async Task Handler_ShouldReturnNotFound_IfTagIsNotFound()
+        public async Task Handler_ShouldReturnNotFound_WhenTagNotFound()
         {
             await using var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider);
 

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetHistoricalFieldValueAttachment/GetHistoricalFieldValueAttachmentQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetHistoricalFieldValueAttachment/GetHistoricalFieldValueAttachmentQueryHandlerTests.cs
@@ -174,7 +174,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetHistoricalFieldValueAttac
         }
 
         [TestMethod]
-        public async Task Handler_ShouldReturnNotFound_IfTagIsNotFound()
+        public async Task Handler_ShouldReturnNotFound_WhenTagNotFound()
         {
             await using var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider);
 

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetHistory/GetHistoryQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetHistory/GetHistoryQueryHandlerTests.cs
@@ -90,6 +90,20 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetHistory
                 Assert.AreEqual(0, result.Data.Count);
             }
         }
+        
+        [TestMethod]
+        public async Task HandleGetHistoryQuery_ShouldReturnNotFound_WhenTagNotFound()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new GetHistoryQueryHandler(context);
+                var result = await dut.Handle(new GetHistoryQuery(0), default);
+
+                Assert.IsNotNull(result);
+                Assert.AreEqual(ResultType.NotFound, result.ResultType);
+                Assert.IsNull(result.Data);
+            }
+        }
 
         private void AssertHistory(History expected, HistoryDto actual)
         {

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagAttachment/GetTagAttachmentQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagAttachment/GetTagAttachmentQueryHandlerTests.cs
@@ -78,7 +78,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagAttachment
         }
 
         [TestMethod]
-        public async Task Handler_ShouldReturnNotFound_IfTagIsNotFound()
+        public async Task Handler_ShouldReturnNotFound_WhenTagNotFound()
         {
             await using var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider);
 

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagAttachments/GetTagAttachmentsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagAttachments/GetTagAttachmentsQueryHandlerTests.cs
@@ -58,7 +58,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagAttachments
         }
 
         [TestMethod]
-        public async Task Handler_ShouldReturnNotFound_IfTagIsNotFound()
+        public async Task Handler_ShouldReturnNotFound_WhenTagNotFound()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagDetails/GetTagDetailsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagDetails/GetTagDetailsQueryHandlerTests.cs
@@ -146,7 +146,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagDetails
         }
 
         [TestMethod]
-        public async Task Handler_ShouldReturnNotFound_IfTagIsNotFound()
+        public async Task Handler_ShouldReturnNotFound_WhenTagNotFound()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagRequirements/GetTagRequirementsQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagRequirements/GetTagRequirementsQueryHandlerTests.cs
@@ -484,7 +484,7 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagRequirements
         }
 
         [TestMethod]
-        public async Task Handler_ShouldReturnNotFound_IfTagIsNotFound()
+        public async Task Handler_ShouldReturnNotFound_WhenTagNotFound()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProviderMock.Object, _eventDispatcher, _currentUserProvider))
             {

--- a/src/tests/Equinor.Procosys.Preservation.Test.Common/ReadOnlyTestsBase.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Test.Common/ReadOnlyTestsBase.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Equinor.Procosys.Preservation.Domain;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.HistoryAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.JourneyAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.ModeAggregate;
 using Equinor.Procosys.Preservation.Domain.AggregateModels.PersonAggregate;
@@ -185,6 +186,7 @@ namespace Equinor.Procosys.Preservation.Test.Common
             //  - 10 tags on project 2 (P2), all tags same as 10 first in P1
             //  - requirement period for all 30 tags is 2 weeks
             //  - all steps in all journeys has responsible 1
+            //  - All Tags has 1 history record
             var _projectName1 = "P1";
             var _projectName2 = "P2";
             var _journeyTitle1 = "J1";
@@ -290,6 +292,13 @@ namespace Equinor.Procosys.Preservation.Test.Common
                     });
 
                 testDataSet.Project2.AddTag(tag);
+            }
+            
+            context.SaveChangesAsync().Wait();
+            
+            foreach (var tag in context.Tags)
+            {
+                context.History.Add(new History(TestPlant, $"Description-{Guid.NewGuid()}", tag.ObjectGuid, ObjectType.Tag, EventType.TagCreated));
             }
             
             context.SaveChangesAsync().Wait();

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/IntegrationTestAuthHandler.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/IntegrationTestAuthHandler.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Encodings.Web;
@@ -51,13 +50,6 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
 
         private Task<List<Claim>> GatherTestUserClaimsAsync()
         {
-            var tokenDeserialized = new
-            {
-                Oid = Guid.Empty,
-                FullName = string.Empty,
-                IsAppToken = false
-            };
-
             var authorizationHeader = Request.Headers["Authorization"];
             var tokens = authorizationHeader.ToString()?.Split(' ');
             if (tokens == null || tokens.Length <= 1)
@@ -65,11 +57,12 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
                 throw new Exception("[Authorization] header missing");
             }
 
+            TestProfile profile;
             var tokenPart = tokens[1];
             try
             {
                 var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(tokenPart));
-                tokenDeserialized = JsonConvert.DeserializeAnonymousType(decoded, tokenDeserialized);
+                profile = JsonConvert.DeserializeObject<TestProfile>(decoded);
             }
             catch (Exception ex)
             {
@@ -78,41 +71,21 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
                     ex);
             }
 
-            var oid = tokenDeserialized.Oid.ToString();
-            var authType = tokenDeserialized.IsAppToken ? AuthType.Application : AuthType.Delegated;
+            var authType = profile.IsAppToken ? AuthType.Application : AuthType.Delegated;
 
-            var claims = new List<Claim> {new Claim(ClaimsExtensions.Oid, oid)};
+            var claims = new List<Claim> {new Claim(ClaimsExtensions.Oid, profile.Oid)};
 
             switch (authType)
             {
                 case AuthType.Delegated:
-                    if (string.IsNullOrEmpty(tokenDeserialized.FullName))
-                    {
-                        throw new ArgumentException("Missing name property in token");
-                    }
-
-                    AddNameClaims(claims, tokenDeserialized.FullName);
+                    claims.Add(new Claim(ClaimTypes.GivenName, profile.FirstName));
+                    claims.Add(new Claim(ClaimTypes.Surname, profile.LastName));
                     break;
                 case AuthType.Application:
                     throw new Exception($"{authType} authentication not supported yet");
             }
 
             return Task.FromResult(claims);
-        }
-
-        private void AddNameClaims(List<Claim> claims, string fullName)
-        {
-            var tokens = fullName.Split(' ');
-            if (tokens.Length > 1)
-            {
-                claims.Add(new Claim(ClaimTypes.Surname, tokens.Last()));
-                var givenName = string.Join(" ", tokens.Take(tokens.Length - 1));
-                claims.Add(new Claim(ClaimTypes.GivenName, givenName));
-            }
-            else
-            {
-                claims.Add(new Claim(ClaimTypes.GivenName, fullName));
-            }
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/PersonDto.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/PersonDto.cs
@@ -1,0 +1,9 @@
+﻿namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
+{
+    public class PersonDto
+    {
+        public int Id { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/ActionDetailsDto.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/ActionDetailsDto.cs
@@ -5,12 +5,16 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
     public class ActionDetailsDto
     {
         public int Id { get; set; }
+        public PersonDto CreatedBy { get; set; }
+        public DateTime CreatedAtUtc { get; set; }
         public string Title { get; set; }
-        public DateTime? DueTimeUtc { get; set;  }
         public string Description { get; set; }
+        public DateTime? DueTimeUtc { get; set; }
         public bool IsClosed { get; set; }
+        public PersonDto ClosedBy { get; set; }
         public DateTime? ClosedAtUtc { get; set; }
         public int AttachmentCount { get; set; }
+        public PersonDto ModifiedBy { get; set; }
         public DateTime? ModifiedAtUtc { get; set; }
         public string RowVersion { get; set; }
     }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/HistoryDto.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/HistoryDto.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Equinor.Procosys.Preservation.Domain.AggregateModels.HistoryAggregate;
+
+namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
+{
+    public class HistoryDto
+    {
+        public int Id { get; set; }
+        public string Description { get; set; }
+        public DateTime CreatedAtUtc { get; set; }
+        public PersonDto CreatedBy { get; set; }
+        public EventType EventType { get; set; }
+        public int? DueWeeks { get; set; }
+        public int? TagRequirementId { get; set; }
+        public Guid? PreservationRecordGuid { get; set; }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerNegativeTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerNegativeTests.cs
@@ -110,37 +110,37 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
             => await TagsControllerTestsHelper.ExportTagsToExcelAsync(
                 UserType.Anonymous, TestFactory.UnknownPlant,
                 TestFactory.ProjectWithAccess,
-                HttpStatusCode.Unauthorized);
+                expectedStatusCode:HttpStatusCode.Unauthorized);
 
         [TestMethod]
         public async Task ExportTagsToExcel_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
             => await TagsControllerTestsHelper.ExportTagsToExcelAsync(
                 UserType.Hacker, TestFactory.UnknownPlant,
                 TestFactory.ProjectWithAccess,
-                HttpStatusCode.BadRequest,
-                "is not a valid plant");
+                expectedStatusCode:HttpStatusCode.BadRequest,
+                expectedMessageOnBadRequest:"is not a valid plant");
 
         [TestMethod]
         public async Task ExportTagsToExcel_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
             => await TagsControllerTestsHelper.ExportTagsToExcelAsync(
                 UserType.LibraryAdmin, TestFactory.UnknownPlant,
                 TestFactory.ProjectWithAccess,
-                HttpStatusCode.BadRequest,
-                "is not a valid plant");
+                expectedStatusCode:HttpStatusCode.BadRequest,
+                expectedMessageOnBadRequest:"is not a valid plant");
 
         [TestMethod]
         public async Task ExportTagsToExcel_AsHacker_ShouldReturnForbidden_WhenPermissionMissing()
             => await TagsControllerTestsHelper.ExportTagsToExcelAsync(
                 UserType.Hacker, TestFactory.PlantWithAccess,
                 TestFactory.ProjectWithAccess,
-                HttpStatusCode.Forbidden);
+                expectedStatusCode:HttpStatusCode.Forbidden);
 
         [TestMethod]
         public async Task ExportTagsToExcel_AsAdmin_ShouldReturnForbidden_WhenPermissionMissing()
             => await TagsControllerTestsHelper.ExportTagsToExcelAsync(
                 UserType.LibraryAdmin, TestFactory.PlantWithAccess,
                 TestFactory.ProjectWithAccess,
-                HttpStatusCode.Forbidden);
+                expectedStatusCode:HttpStatusCode.Forbidden);
         #endregion
         
         #region GetTag
@@ -640,14 +640,14 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         public async Task GetAllActions_AsAnonymous_ShouldReturnUnauthorized()
             => await TagsControllerTestsHelper.GetAllActionsAsync(
                 UserType.Anonymous, TestFactory.UnknownPlant,
-                _tagId1_WithAttachment,
+                9999,
                 HttpStatusCode.Unauthorized);
 
         [TestMethod]
         public async Task GetAllActions_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
             => await TagsControllerTestsHelper.GetAllActionsAsync(
                 UserType.Hacker, TestFactory.UnknownPlant,
-                _tagId1_WithAttachment,
+                9999,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
 
@@ -655,7 +655,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
         public async Task GetAllActions_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
             => await TagsControllerTestsHelper.GetAllActionsAsync(
                 UserType.LibraryAdmin, TestFactory.UnknownPlant,
-                _tagId1_WithAttachment,
+                9999,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
 
@@ -1686,6 +1686,59 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
                 null,
                 null,
                 HttpStatusCode.Forbidden);
+        #endregion
+        
+        #region GetHistory
+        [TestMethod]
+        public async Task GetHistory_AsAnonymous_ShouldReturnUnauthorized()
+            => await TagsControllerTestsHelper.GetHistoryAsync(
+                UserType.Anonymous, 
+                TestFactory.UnknownPlant,
+                9999,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task GetHistory_AsHacker_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await TagsControllerTestsHelper.GetHistoryAsync(
+                UserType.Hacker,
+                TestFactory.UnknownPlant,
+                9999,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task GetHistory_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await TagsControllerTestsHelper.GetHistoryAsync(
+                UserType.LibraryAdmin,
+                TestFactory.UnknownPlant,
+                9999,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task GetHistory_AsHacker_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.GetHistoryAsync(
+                UserType.Hacker, 
+                TestFactory.PlantWithAccess,
+                9999,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task GetHistory_AsAdmin_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.GetHistoryAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                9999,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task GetHistory_AsPreserver_ShouldReturnNotFound_WhenUnknownTagId()
+            => await TagsControllerTestsHelper.GetHistoryAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                9999,
+                HttpStatusCode.NotFound);
+
         #endregion
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTestsHelper.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTestsHelper.cs
@@ -22,7 +22,10 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
             HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
             string expectedMessageOnBadRequest = null)
         {
-            var parameters = new ParameterCollection {{"projectName", projectName}};
+            var parameters = new ParameterCollection
+            {
+                {"ProjectName", projectName}
+            };
             var url = $"{_route}{parameters}";
             var response = await TestFactory.Instance.GetHttpClient(userType, plant).GetAsync(url);
 
@@ -41,10 +44,15 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
             UserType userType,
             string plant,
             string projectName,
+            string tagNoStartsWith = null,
             HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
             string expectedMessageOnBadRequest = null)
         {
-            var parameters = new ParameterCollection {{"projectName", projectName}};
+            var parameters = new ParameterCollection
+            {
+                {"ProjectName", projectName},
+                {"TagNoStartsWith", tagNoStartsWith}
+            };
             var url = $"{_route}/ExportTagsToExcel{parameters}";
             var response = await TestFactory.Instance.GetHttpClient(userType, plant).GetAsync(url);
 
@@ -566,6 +574,25 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
 
             var jsonString = await response.Content.ReadAsStringAsync();
             return JsonConvert.DeserializeObject<int>(jsonString);
+        }
+
+        public static async Task<List<HistoryDto>> GetHistoryAsync(
+            UserType userType, string plant,
+            int tagId,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var response = await TestFactory.Instance.GetHttpClient(userType, plant).GetAsync($"{_route}/{tagId}/History");
+
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (expectedStatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            var jsonString = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<List<HistoryDto>>(jsonString);
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/TestFactory.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using Equinor.Procosys.Preservation.BlobStorage;
 using Equinor.Procosys.Preservation.Infrastructure;
@@ -23,7 +22,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
-using Newtonsoft.Json;
 using ProcosysProject = Equinor.Procosys.Preservation.MainApi.Permission.ProcosysProject;
 
 namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
@@ -135,6 +133,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
             
             return testUser.HttpClient;
         }
+
+        public TestProfile GetTestProfile(UserType userType) => _testUsers[userType].Profile;
 
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
@@ -308,7 +308,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
                     Profile =
                         new TestProfile
                         {
-                            FullName = "Harry Hacker", 
+                            FirstName = "Harry",
+                            LastName = "Hacker", 
                             Oid = _hackerOid
                         },
                     ProCoSysPlants = new List<ProcosysPlant>
@@ -332,7 +333,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
                     Profile =
                         new TestProfile
                         {
-                            FullName = "Peder Preserver",
+                            FirstName = "Peder",
+                            LastName = "Preserver",
                             Oid = _preserverOid
                         },
                     ProCoSysPlants = commonProCoSysPlants,
@@ -360,7 +362,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
                     Profile =
                         new TestProfile
                         {
-                            FullName = "Pernilla Planner",
+                            FirstName = "Pernilla",
+                            LastName = "Planner",
                             Oid = _plannerOid
                         },
                     ProCoSysPlants = commonProCoSysPlants,
@@ -389,7 +392,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
                     Profile =
                         new TestProfile
                         {
-                            FullName = "Arne Admin",
+                            FirstName = "Arne",
+                            LastName = "Admin",
                             Oid = _libraryAdminOid
                         },
                     ProCoSysPlants = commonProCoSysPlants,
@@ -408,7 +412,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
         private void AddAnonymousUser() => _testUsers.Add(UserType.Anonymous, new TestUser());
 
         private void AuthenticateUser(ITestUser user)
-            => user.HttpClient.DefaultRequestHeaders.Add("Authorization", CreateBearerToken(user.Profile));
+            => user.HttpClient.DefaultRequestHeaders.Add("Authorization", user.Profile.CreateBearerToken());
 
         private void UpdatePlantInHeader(HttpClient client, string plant)
         {
@@ -421,21 +425,6 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
             {
                 client.DefaultRequestHeaders.Add(CurrentPlantMiddleware.PlantHeader, plant);
             }
-        }
-        
-        /// <summary>
-        /// Wraps profile by serializing, encoding and then converting to base 64 string.
-        /// "Bearer" is also added, making it ready to be added as Authorization header
-        /// </summary>
-        /// <param name="profile">The instance of the token to be wrapped</param>
-        /// <returns>Serialized, encoded string ready for authorization header</returns>
-        private string CreateBearerToken(TestProfile profile)
-        {
-            var serialized = JsonConvert.SerializeObject(profile);
-            var tokenBytes = Encoding.UTF8.GetBytes(serialized);
-            var tokenString = Convert.ToBase64String(tokenBytes);
-
-            return $"Bearer {tokenString}";
         }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/TestProfile.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/TestProfile.cs
@@ -1,13 +1,31 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Text;
+using Newtonsoft.Json;
 
 namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
 {
     public class TestProfile
     {
         public string Oid { get; set; }
-        public string FullName { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string FullName => $"{FirstName} {LastName}";
         public bool IsAppToken { get; set; } = false;
      
         public override string ToString() => $"{FullName} {Oid}";
+        
+        /// <summary>
+        /// Wraps profile by serializing, encoding and then converting to base 64 string.
+        /// "Bearer" is also added, making it ready to be added as Authorization header
+        /// </summary>
+        /// <returns>Serialized, encoded string ready for authorization header</returns>
+        public string CreateBearerToken()
+        {
+            var serialized = JsonConvert.SerializeObject(this);
+            var tokenBytes = Encoding.UTF8.GetBytes(serialized);
+            var tokenString = Convert.ToBase64String(tokenBytes);
+
+            return $"Bearer {tokenString}";
+        }
     }
 }


### PR DESCRIPTION
Main task is to create History sheet in Excel. The sheet is created only when 1 tag filtered in query.
During work a minor improvement was done in GetHistory endpoint: The endpoint now return 404 for unknown Tag instead of empty list of History records

Improvements done in integration test framework regading handling of FirstName and LastName in claims and bearertoken (these improvements can/should be taken into IPO too)