### PR TITLE
80421 details in history in excel bugfix

### DIFF
--- a/src/Equinor.Procosys.Preservation.Query/GetPreservationRecord/GetPreservationRecordQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetPreservationRecord/GetPreservationRecordQueryHandler.cs
@@ -104,7 +104,7 @@ namespace Equinor.Procosys.Preservation.Query.GetPreservationRecord
                 new RequirementDefinitionDetailDto(
                     requirementDto.RequirementDefinition.Id,
                     requirementDto.RequirementDefinition.Title), 
-                requirementDto.RequirementDefinition.DefaultIntervalWeeks,
+                tagRequirement.IntervalWeeks,
                 preservationPeriod.Comment, 
                 fields);
 

--- a/src/Equinor.Procosys.Preservation.Query/GetTagsQueries/GetTagsForExport/GetTagsForExcelQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetTagsQueries/GetTagsForExport/GetTagsForExcelQueryHandler.cs
@@ -165,21 +165,52 @@ namespace Equinor.Procosys.Preservation.Query.GetTagsQueries.GetTagsForExport
             preservationDetails.Append($"{field.Label}=");
 
             var currentValue = preservationPeriod.GetFieldValue(field.Id);
+            var value = string.Empty;
             switch (field.FieldType)
             {
                 case FieldType.Number:
-                    var number = (NumberValue) currentValue;
-                    preservationDetails.Append(number.Value.HasValue ? number.Value.ToString() : "N/A");
+                    value = GetNumberValueAsString(currentValue);
                     break;
                 case FieldType.CheckBox:
-                    var cb = currentValue is CheckBoxChecked;
-                    preservationDetails.Append(cb.ToString().ToLower());
+                    value = GetCheckBoxValueAsString(currentValue);
                     break;
                 case FieldType.Attachment:
-                    var av = (AttachmentValue) currentValue;
-                    preservationDetails.Append(av.FieldValueAttachment.FileName);
+                    value = GetAttachmentValueAsString(currentValue);
                     break;
             }
+            preservationDetails.Append(value);
+        }
+
+        private static string GetAttachmentValueAsString(FieldValue fieldValue)
+        {
+            if (!(fieldValue is AttachmentValue))
+            {
+                return "<NoData>";
+            }
+            var av = (AttachmentValue) fieldValue;
+            return av.FieldValueAttachment.FileName;
+
+        }
+
+        private static string GetCheckBoxValueAsString(FieldValue fieldValue)
+        {
+            if (!(fieldValue is CheckBoxChecked))
+            {
+                return "<NoData>";
+            }
+            // A CheckBox checked is true if fieldValue is of type CheckBoxChecked
+            return "true";
+        }
+
+        private static string GetNumberValueAsString(FieldValue fieldValue)
+        {
+            if (!(fieldValue is NumberValue))
+            {
+                return "<NoData>";
+            }
+            var number = (NumberValue) fieldValue;
+            return number.Value.HasValue ? number.Value.ToString() : "N/A";
+
         }
 
         private async Task<List<Tag>> GetTagsWithIncludesAsync(List<int> tagsIds, bool getHistory, CancellationToken cancellationToken)

--- a/src/Equinor.Procosys.Preservation.Query/GetTagsQueries/GetTagsForExport/GetTagsForExcelQueryHandler.cs
+++ b/src/Equinor.Procosys.Preservation.Query/GetTagsQueries/GetTagsForExport/GetTagsForExcelQueryHandler.cs
@@ -20,6 +20,7 @@ namespace Equinor.Procosys.Preservation.Query.GetTagsQueries.GetTagsForExport
 {
     public class GetTagsForExportQueryHandler : GetTagsQueryBase, IRequestHandler<GetTagsForExportQuery, Result<ExportDto>>
     {
+        private readonly string _noDataFoundMarker = "null";
         private readonly IReadOnlyContext _context;
         private readonly IPlantProvider _plantProvider;
         private readonly DateTime _utcNow;
@@ -119,7 +120,7 @@ namespace Equinor.Procosys.Preservation.Query.GetTagsQueries.GetTagsForExport
             }
         }
 
-        private static (string, StringBuilder) GetPreservationDetailsFromPeriod(
+        private (string, StringBuilder) GetPreservationDetailsFromPeriod(
             Guid preservationRecordGuid,
             Tag singleTag,
             List<RequirementDefinition> reqDefWithFields)
@@ -148,18 +149,13 @@ namespace Equinor.Procosys.Preservation.Query.GetTagsQueries.GetTagsForExport
             return (preservationPeriod.Comment, preservationDetails);
         }
 
-        private static void GetPreservationDetailsFromField(
+        private void GetPreservationDetailsFromField(
             StringBuilder preservationDetails, Field field,
             PreservationPeriod preservationPeriod)
         {
             if (!field.FieldType.NeedsUserInput())
             {
                 return;
-            }
-
-            if (preservationDetails.Length > 0)
-            {
-                preservationDetails.Append(". ");
             }
 
             preservationDetails.Append($"{field.Label}=");
@@ -178,39 +174,38 @@ namespace Equinor.Procosys.Preservation.Query.GetTagsQueries.GetTagsForExport
                     value = GetAttachmentValueAsString(currentValue);
                     break;
             }
-            preservationDetails.Append(value);
+            preservationDetails.Append($"{value}. ");
         }
 
-        private static string GetAttachmentValueAsString(FieldValue fieldValue)
+        private string GetAttachmentValueAsString(FieldValue fieldValue)
         {
             if (!(fieldValue is AttachmentValue))
             {
-                return "<NoData>";
+                return _noDataFoundMarker;
             }
             var av = (AttachmentValue) fieldValue;
             return av.FieldValueAttachment.FileName;
 
         }
 
-        private static string GetCheckBoxValueAsString(FieldValue fieldValue)
+        private string GetCheckBoxValueAsString(FieldValue fieldValue)
         {
             if (!(fieldValue is CheckBoxChecked))
             {
-                return "<NoData>";
+                return _noDataFoundMarker;
             }
             // A CheckBox checked is true if fieldValue is of type CheckBoxChecked
             return "true";
         }
 
-        private static string GetNumberValueAsString(FieldValue fieldValue)
+        private string GetNumberValueAsString(FieldValue fieldValue)
         {
             if (!(fieldValue is NumberValue))
             {
-                return "<NoData>";
+                return _noDataFoundMarker;
             }
             var number = (NumberValue) fieldValue;
             return number.Value.HasValue ? number.Value.ToString() : "N/A";
-
         }
 
         private async Task<List<Tag>> GetTagsWithIncludesAsync(List<int> tagsIds, bool getHistory, CancellationToken cancellationToken)

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetPreservationRecord/GetPreservationRecordQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetPreservationRecord/GetPreservationRecordQueryHandlerTests.cs
@@ -36,8 +36,10 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetPreservationRecord
                 _requirementType = AddRequirementTypeWith1DefWithoutField(context, "RT", "RD", RequirementTypeIcon.Other, 1);
                 _requirementDefinitionWithoutOneField =
                     _requirementType.RequirementDefinitions.Single();
-                _interval = _requirementDefinitionWithoutOneField.DefaultIntervalWeeks * 2;
                 _infoField = AddInfoField(context, _requirementDefinitionWithoutOneField, "I");
+
+                // be sure to use different intervals in the TagRequirement and RequirementDefinition to be able to Assert on correct value for dto.IntervalWeeks
+                _interval = _requirementDefinitionWithoutOneField.DefaultIntervalWeeks * 2;
 
                 var requirementWithoutField = new TagRequirement(TestPlant, _interval, _requirementDefinitionWithoutOneField);
 

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagsQueries/GetTagsForExport/GetTagsForExportQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagsQueries/GetTagsForExport/GetTagsForExportQueryHandlerTests.cs
@@ -261,14 +261,14 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagsQueries.GetTagsForExp
                 Assert.AreEqual(history.DueInWeeks, historyDto.DueInWeeks);
                 Assert.AreEqual(history.CreatedAtUtc, historyDto.CreatedAtUtc);
                 Assert.AreEqual(comment, historyDto.PreservationComment);
-                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForNumberFirst}={number}"));
-                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForNumberSecond}=N/A"));
-                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForCheckBoxFirst}=true"));
-                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForAttFirst}={fileName}"));
+                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForNumberFirst}={number}."));
+                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForNumberSecond}=N/A."));
+                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForCheckBoxFirst}=true."));
+                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForAttFirst}={fileName}."));
                 Assert.IsFalse(historyDto.PreservationDetails.Contains(labelForInfo));
-                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForNumberThird}=<NoData>"));
-                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForCheckBoxSecond}=<NoData>"));
-                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForAttSecond}=<NoData>"));
+                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForNumberThird}=null."));
+                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForCheckBoxSecond}=null."));
+                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForAttSecond}=null."));
             }
         }
 

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagsQueries/GetTagsForExport/GetTagsForExportQueryHandlerTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/GetTagsQueries/GetTagsForExport/GetTagsForExportQueryHandlerTests.cs
@@ -175,8 +175,11 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagsQueries.GetTagsForExp
             var comment = "Comment";
             var labelForNumberFirst = "Label for Number - first";
             var labelForNumberSecond = "Label for Number - second";
-            var labelForCheckBox = "Label for CheckBox";
-            var labelForAtt = "Label for Attachment";
+            var labelForNumberThird = "Label for Number - third";
+            var labelForCheckBoxFirst = "Label for CheckBox - first";
+            var labelForCheckBoxSecond = "Label for CheckBox - second";
+            var labelForAttFirst = "Label for Attachment - first";
+            var labelForAttSecond = "Label for Attachment - second";
             var labelForInfo = "Label for Info";
             History history;
             var number = 1282.91;
@@ -190,13 +193,13 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagsQueries.GetTagsForExp
                 var reqDef = new RequirementDefinition(TestPlant, "Title", 2, RequirementUsage.ForAll, 1);
                 var numberField1 = new Field(TestPlant, labelForNumberFirst, FieldType.Number, 1, "U", false);
                 var numberField2 = new Field(TestPlant, labelForNumberSecond, FieldType.Number, 2, "U", false);
-                var cbField = new Field(TestPlant, labelForCheckBox, FieldType.CheckBox, 3);
-                var attField = new Field(TestPlant, labelForAtt, FieldType.Attachment, 4);
+                var cbField1 = new Field(TestPlant, labelForCheckBoxFirst, FieldType.CheckBox, 3);
+                var attField1 = new Field(TestPlant, labelForAttFirst, FieldType.Attachment, 4);
                 var infoField = new Field(TestPlant, labelForInfo, FieldType.Info, 5);
                 reqDef.AddField(numberField1);
                 reqDef.AddField(numberField2);
-                reqDef.AddField(cbField);
-                reqDef.AddField(attField);
+                reqDef.AddField(cbField1);
+                reqDef.AddField(attField1);
                 reqDef.AddField(infoField);
                 context.RequirementTypes.First().AddRequirementDefinition(reqDef);
                 context.SaveChangesAsync().Wait();
@@ -211,11 +214,11 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagsQueries.GetTagsForExp
                     reqDef);
                 tagRequirement.RecordCheckBoxValues(new Dictionary<int, bool>
                     {
-                        {cbField.Id, true},
+                        {cbField1.Id, true},
                     },
                     reqDef);
                 tagRequirement.RecordAttachment(new FieldValueAttachment(TestPlant, Guid.NewGuid(), fileName), 
-                    attField.Id,
+                    attField1.Id,
                     reqDef);
                 tagRequirement.RecordNumberIsNaValues(new List<int>{numberField2.Id}, reqDef);
                 var activePeriodBeforePreservation = tagRequirement.ActivePeriod;
@@ -231,6 +234,16 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagsQueries.GetTagsForExp
                     PreservationRecordGuid = activePeriodBeforePreservation.PreservationRecord.ObjectGuid
                 };
                 context.History.Add(history);
+                context.SaveChangesAsync().Wait();
+
+                // also add other fields to requirement AFTER preservation done.
+                // This is possible in real life, resulting that old preservation periods will exist without values for those fields
+                var numberField3 = new Field(TestPlant, labelForNumberThird, FieldType.Number, 11, "U", false);
+                var cbField2 = new Field(TestPlant, labelForCheckBoxSecond, FieldType.CheckBox, 12);
+                var attField2 = new Field(TestPlant, labelForAttSecond, FieldType.Attachment, 13);
+                reqDef.AddField(numberField3);
+                reqDef.AddField(cbField2);
+                reqDef.AddField(attField2);
                 context.SaveChangesAsync().Wait();
             }
             
@@ -248,11 +261,14 @@ namespace Equinor.Procosys.Preservation.Query.Tests.GetTagsQueries.GetTagsForExp
                 Assert.AreEqual(history.DueInWeeks, historyDto.DueInWeeks);
                 Assert.AreEqual(history.CreatedAtUtc, historyDto.CreatedAtUtc);
                 Assert.AreEqual(comment, historyDto.PreservationComment);
-                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForNumberFirst}={number}."));
-                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForNumberSecond}=N/A."));
-                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForCheckBox}=true."));
-                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForAtt}={fileName}"));
+                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForNumberFirst}={number}"));
+                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForNumberSecond}=N/A"));
+                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForCheckBoxFirst}=true"));
+                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForAttFirst}={fileName}"));
                 Assert.IsFalse(historyDto.PreservationDetails.Contains(labelForInfo));
+                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForNumberThird}=<NoData>"));
+                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForCheckBoxSecond}=<NoData>"));
+                Assert.IsTrue(historyDto.PreservationDetails.Contains($"{labelForAttSecond}=<NoData>"));
             }
         }
 


### PR DESCRIPTION
Bugfix 1 when creating Excel with details: 
Need to handle that FieldValues for all Fields in a Requirement Def don't have to exists for all preservation periods since a field can be added to a Requirement Def after preservation periods are made

Bugfix 2: GetPreservationRecordQueryHandler - The interval was taken from the Requirement Definition, not from the actual TagRequirement (showed wrong in UI)