### PR TITLE
Automatic update of 3 packages

### DIFF
--- a/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
+++ b/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClosedXML" Version="0.95.3" />
+    <PackageReference Include="ClosedXML" Version="0.95.4" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.3.0" />
     <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />

--- a/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
+++ b/src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj
@@ -25,7 +25,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.10" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.23.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.24.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />
     <PackageReference Include="ServiceResult.ApiExtensions" Version="1.0.1" />

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Equinor.Procosys.Preservation.Command.Tests.csproj
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Equinor.Procosys.Preservation.Command.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="9.3.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Moq" Version="4.15.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />

--- a/src/tests/Equinor.Procosys.Preservation.Domain.Tests/Equinor.Procosys.Preservation.Domain.Tests.csproj
+++ b/src/tests/Equinor.Procosys.Preservation.Domain.Tests/Equinor.Procosys.Preservation.Domain.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Moq" Version="4.15.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />

--- a/src/tests/Equinor.Procosys.Preservation.Infrastructure.Tests/Equinor.Procosys.Preservation.Infrastructure.Tests.csproj
+++ b/src/tests/Equinor.Procosys.Preservation.Infrastructure.Tests/Equinor.Procosys.Preservation.Infrastructure.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="MockQueryable.Moq" Version="5.0.0" />
     <PackageReference Include="Moq" Version="4.15.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />

--- a/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Equinor.Procosys.Preservation.MainApi.Tests.csproj
+++ b/src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Equinor.Procosys.Preservation.MainApi.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Moq" Version="4.15.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />

--- a/src/tests/Equinor.Procosys.Preservation.Query.Tests/Equinor.Procosys.Preservation.Query.Tests.csproj
+++ b/src/tests/Equinor.Procosys.Preservation.Query.Tests/Equinor.Procosys.Preservation.Query.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Moq" Version="4.15.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Equinor.Procosys.Preservation.WebApi.IntegrationTests.csproj
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Equinor.Procosys.Preservation.WebApi.IntegrationTests.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Moq" Version="4.15.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Equinor.Procosys.Preservation.WebApi.Tests.csproj
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Equinor.Procosys.Preservation.WebApi.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Moq" Version="4.15.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />


### PR DESCRIPTION
3 packages were updated in 8 projects:
`Microsoft.NET.Test.Sdk`, `Microsoft.Identity.Client`, `ClosedXML`
<details>
<summary>Details of updated packages</summary>

NuKeeper has generated a patch update of `Microsoft.NET.Test.Sdk` to `16.8.3` from `16.8.0`
`Microsoft.NET.Test.Sdk 16.8.3` was published at `2020-12-02T22:48:17Z`, 1 month ago

7 project updates:
Updated `src/tests/Equinor.Procosys.Preservation.Query.Tests/Equinor.Procosys.Preservation.Query.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.8.3` from `16.8.0`
Updated `src/tests/Equinor.Procosys.Preservation.Command.Tests/Equinor.Procosys.Preservation.Command.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.8.3` from `16.8.0`
Updated `src/tests/Equinor.Procosys.Preservation.WebApi.Tests/Equinor.Procosys.Preservation.WebApi.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.8.3` from `16.8.0`
Updated `src/tests/Equinor.Procosys.Preservation.MainApi.Tests/Equinor.Procosys.Preservation.MainApi.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.8.3` from `16.8.0`
Updated `src/tests/Equinor.Procosys.Preservation.Domain.Tests/Equinor.Procosys.Preservation.Domain.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.8.3` from `16.8.0`
Updated `src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Equinor.Procosys.Preservation.WebApi.IntegrationTests.csproj` to `Microsoft.NET.Test.Sdk` `16.8.3` from `16.8.0`
Updated `src/tests/Equinor.Procosys.Preservation.Infrastructure.Tests/Equinor.Procosys.Preservation.Infrastructure.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.8.3` from `16.8.0`

[Microsoft.NET.Test.Sdk 16.8.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/16.8.3)

NuKeeper has generated a minor update of `Microsoft.Identity.Client` to `4.24.0` from `4.23.0`
`Microsoft.Identity.Client 4.24.0` was published at `2020-12-05T00:17:56Z`, 1 month ago

1 project update:
Updated `src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj` to `Microsoft.Identity.Client` `4.24.0` from `4.23.0`

[Microsoft.Identity.Client 4.24.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.Identity.Client/4.24.0)

NuKeeper has generated a patch update of `ClosedXML` to `0.95.4` from `0.95.3`
`ClosedXML 0.95.4` was published at `2020-12-16T10:39:25Z`, 1 month ago

1 project update:
Updated `src/Equinor.Procosys.Preservation.WebApi/Equinor.Procosys.Preservation.WebApi.csproj` to `ClosedXML` `0.95.4` from `0.95.3`

[ClosedXML 0.95.4 on NuGet.org](https://www.nuget.org/packages/ClosedXML/0.95.4)

</details>


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
