### PR TITLE
79034 delete tagrequirement bugfix

### DIFF
--- a/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/Tag.cs
+++ b/src/Equinor.Procosys.Preservation.Domain/AggregateModels/ProjectAggregate/Tag.cs
@@ -445,11 +445,11 @@ namespace Equinor.Procosys.Preservation.Domain.AggregateModels.ProjectAggregate
                     if (Status == PreservationStatus.Active && !tagRequirement.HasActivePeriod)
                     {
                         tagRequirement.StartPreservation();
-                        UpdateNextDueTimeUtc();
                     }
 
                     AddDomainEvent(new RequirementUnvoidedEvent(Plant, ObjectGuid, tagRequirement.RequirementDefinitionId));
                 }
+                UpdateNextDueTimeUtc();
             }
 
             ChangeInterval(tagRequirement.Id, intervalWeeks);

--- a/src/tests/Equinor.Procosys.Preservation.Domain.Tests/AggregateModels/ProjectAggregate/TagTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Domain.Tests/AggregateModels/ProjectAggregate/TagTests.cs
@@ -1770,6 +1770,26 @@ namespace Equinor.Procosys.Preservation.Domain.Tests.AggregateModels.ProjectAggr
         }
                         
         [TestMethod]
+        public void UpdateRequirement_UnVoid_ShouldChangeNextDueTime_WhenPreservationStarted()
+        {
+            // Arrange
+            var dut = new Tag(TestPlant, TagType.Standard, "", "", _supplierStep, _twoReqs_FirstNotNeedInputTwoWeekInterval_SecondNotNeedInputThreeWeekInterval);
+            dut.StartPreservation();
+            
+            var twoWeekRequirement = dut.OrderedRequirements().First();
+            var threeWeekRequirement = dut.OrderedRequirements().Last();
+            Assert.AreEqual(twoWeekRequirement.NextDueTimeUtc, dut.NextDueTimeUtc);
+            dut.UpdateRequirement(twoWeekRequirement.Id, true, twoWeekRequirement.IntervalWeeks, "AAAAAAAAABA=");
+            Assert.AreEqual(threeWeekRequirement.NextDueTimeUtc, dut.NextDueTimeUtc);
+        
+            // Act
+            dut.UpdateRequirement(twoWeekRequirement.Id, false, twoWeekRequirement.IntervalWeeks, "AAAAAAAAABA=");
+
+            // Assert
+            Assert.AreEqual(twoWeekRequirement.NextDueTimeUtc, dut.NextDueTimeUtc);
+        }
+                        
+        [TestMethod]
         public void UpdateRequirement_Void_ShouldKeepDueTimeNull_BeforePreservationStarted()
         {
             // Arrange

--- a/src/tests/Equinor.Procosys.Preservation.Domain.Tests/AggregateModels/ProjectAggregate/TagTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Domain.Tests/AggregateModels/ProjectAggregate/TagTests.cs
@@ -1750,6 +1750,40 @@ namespace Equinor.Procosys.Preservation.Domain.Tests.AggregateModels.ProjectAggr
             Assert.IsFalse(requirement.HasActivePeriod);
             Assert.IsFalse(requirement.IsVoided);
         }
+                        
+        [TestMethod]
+        public void UpdateRequirement_Void_ShouldChangeNextDueTime_WhenPreservationStarted()
+        {
+            // Arrange
+            var dut = new Tag(TestPlant, TagType.Standard, "", "", _supplierStep, _twoReqs_FirstNotNeedInputTwoWeekInterval_SecondNotNeedInputThreeWeekInterval);
+            dut.StartPreservation();
+            
+            var twoWeekRequirement = dut.OrderedRequirements().First();
+            var threeWeekRequirement = dut.OrderedRequirements().Last();
+            Assert.AreEqual(twoWeekRequirement.NextDueTimeUtc, dut.NextDueTimeUtc);
+
+            // Act
+            dut.UpdateRequirement(twoWeekRequirement.Id, true, twoWeekRequirement.IntervalWeeks, "AAAAAAAAABA=");
+
+            // Assert
+            Assert.AreEqual(threeWeekRequirement.NextDueTimeUtc, dut.NextDueTimeUtc);
+        }
+                        
+        [TestMethod]
+        public void UpdateRequirement_Void_ShouldKeepDueTimeNull_BeforePreservationStarted()
+        {
+            // Arrange
+            var dut = new Tag(TestPlant, TagType.Standard, "", "", _supplierStep, _twoReqs_FirstNotNeedInputTwoWeekInterval_SecondNotNeedInputThreeWeekInterval);
+            
+            var twoWeekRequirement = dut.OrderedRequirements().First();
+            Assert.IsFalse(dut.NextDueTimeUtc.HasValue);
+
+            // Act
+            dut.UpdateRequirement(twoWeekRequirement.Id, true, twoWeekRequirement.IntervalWeeks, "AAAAAAAAABA=");
+
+            // Assert
+            Assert.IsFalse(dut.NextDueTimeUtc.HasValue);
+        }
 
         #endregion
 


### PR DESCRIPTION
BUG found while working with Delete Tag Requirement:
In Tag.UpdateRequirement when Voiding: Need to re-calculate next due on both Void and Unvoid. Tests added.

[AB#79034](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/79034) 