### PR TITLE
80991 fix routes in preservation vol 1

### DIFF
--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Persons/PersonsController.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Persons/PersonsController.cs
@@ -23,6 +23,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Persons
 
         [Authorize(Roles = Permissions.PRESERVATION_READ)]
         [HttpPost("/SavedFilter")]
+        [HttpPost("SavedFilter")]
         public async Task<ActionResult<int>> CreateSavedFilter(
             [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
             [Required]
@@ -35,6 +36,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Persons
          
         [Authorize(Roles = Permissions.PRESERVATION_READ)]
         [HttpGet("/SavedFilters")]
+        [HttpGet("SavedFilters")]
         public async Task<ActionResult<List<SavedFilterDto>>> GetSavedFiltersInProject(
             [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
             [Required]
@@ -47,6 +49,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Persons
 
         [Authorize(Roles = Permissions.PRESERVATION_READ)]
         [HttpDelete("/SavedFilters/{id}")]
+        [HttpDelete("SavedFilters/{id}")]
         public async Task<ActionResult> DeleteSavedFilter(
             [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
             [Required]
@@ -60,6 +63,7 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Persons
 
         [Authorize(Roles = Permissions.PRESERVATION_READ)]
         [HttpPut("/SavedFilters/{id}")]
+        [HttpPut("SavedFilters/{id}")]
         public async Task<ActionResult> UpdateSavedFilter(
             [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
             [Required]


### PR DESCRIPTION
Part 1 of 2 for fixing routes under Persons controller. 
This part adds the new endpoints to be used instead of the old ones. Old ones are not removed.

[AB#80991](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/80991)