### PR TITLE
80991-fix routes in preservation vol2

### DIFF
--- a/src/Equinor.Procosys.Preservation.WebApi/Controllers/Persons/PersonsController.cs
+++ b/src/Equinor.Procosys.Preservation.WebApi/Controllers/Persons/PersonsController.cs
@@ -22,7 +22,6 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Persons
         public PersonsController(IMediator mediator) => _mediator = mediator;
 
         [Authorize(Roles = Permissions.PRESERVATION_READ)]
-        [HttpPost("/SavedFilter")]
         [HttpPost("SavedFilter")]
         public async Task<ActionResult<int>> CreateSavedFilter(
             [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
@@ -35,7 +34,6 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Persons
         }
          
         [Authorize(Roles = Permissions.PRESERVATION_READ)]
-        [HttpGet("/SavedFilters")]
         [HttpGet("SavedFilters")]
         public async Task<ActionResult<List<SavedFilterDto>>> GetSavedFiltersInProject(
             [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
@@ -48,7 +46,6 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Persons
         }
 
         [Authorize(Roles = Permissions.PRESERVATION_READ)]
-        [HttpDelete("/SavedFilters/{id}")]
         [HttpDelete("SavedFilters/{id}")]
         public async Task<ActionResult> DeleteSavedFilter(
             [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
@@ -62,7 +59,6 @@ namespace Equinor.Procosys.Preservation.WebApi.Controllers.Persons
         }
 
         [Authorize(Roles = Permissions.PRESERVATION_READ)]
-        [HttpPut("/SavedFilters/{id}")]
         [HttpPut("SavedFilters/{id}")]
         public async Task<ActionResult> UpdateSavedFilter(
             [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]


### PR DESCRIPTION
Part 2/2 of fixing routes under Persons controller.
This part removes the old routes which didn't have the /Persons prefix.

[AB#80991](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/80991)