### PR TITLE
82120 allow supplier requirement only for PO

### DIFF
--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateAreaTag/CreateAreaTagCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateAreaTag/CreateAreaTagCommandValidator.cs
@@ -24,22 +24,18 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.CreateAreaTag
             WhenAsync((command, token) => BeASupplierStepAsync(command.StepId, token), () =>
             {
                 RuleFor(command => command)
-                    .Must(command => BeUniqueRequirements(command.Requirements))
-                    .WithMessage(_ => "Requirement definitions must be unique!")
-                    .MustAsync((command, token) => RequirementUsageIsForSupplierAsync(command.Requirements, token))
-                    .WithMessage(_ => "Requirements must include requirements to be used for supplier!")
-                        .When(command => command.TagType == TagType.PoArea, ApplyConditionTo.CurrentValidator)
                     .MustAsync((command, token) => RequirementUsageIsForAllJourneysAsync(command.Requirements, token))
                     .WithMessage(_ => "Requirements must include requirements to be used both for supplier and other than suppliers!")
-                        .When(command => command.TagType != TagType.PoArea, ApplyConditionTo.CurrentValidator);
+                    .When(command => command.TagType != TagType.PoArea, ApplyConditionTo.CurrentValidator)
+                    .MustAsync((command, token) => RequirementUsageIsForSupplierAsync(command.Requirements, token))
+                    .WithMessage(_ => "Requirements must include requirements to be used for supplier!")
+                        .When(command => command.TagType == TagType.PoArea, ApplyConditionTo.CurrentValidator);
 
             }).Otherwise(() =>
             {
                 RuleFor(command => command)
                     .Must(command => command.TagType != TagType.PoArea)
                     .WithMessage(_ => $"Step for a {TagType.PoArea.GetTagNoPrefix()} tag need to be for supplier!")
-                    .Must(command => BeUniqueRequirements(command.Requirements))
-                    .WithMessage(_ => "Requirement definitions must be unique!")
                     .MustAsync((command, token) => RequirementUsageIsForJourneysWithoutSupplierAsync(command.Requirements, token))
                     .WithMessage(_ => "Requirements must include requirements to be used for other than suppliers!")
                     .MustAsync((command, token) => RequirementUsageIsNotForSupplierStepOnlyAsync(command.Requirements, token))
@@ -47,6 +43,8 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.CreateAreaTag
             });
 
             RuleFor(command => command)
+                .Must(command => BeUniqueRequirements(command.Requirements))
+                .WithMessage(_ => "Requirement definitions must be unique!")
                 .MustAsync((command, token) => NotBeAnExistingAndClosedProjectAsync(command.ProjectName, token))
                 .WithMessage(command => $"Project is closed! Project={command.ProjectName}")
                 .MustAsync((command, token) => NotBeAnExistingTagWithinProjectAsync(command.GetTagNo(), command.ProjectName, token))

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateAreaTag/CreateAreaTagCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateAreaTag/CreateAreaTagCommandValidator.cs
@@ -30,7 +30,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.CreateAreaTag
                     .MustAsync((command, token) => RequirementUsageIsForSupplierAsync(command.Requirements, token))
                     .WithMessage(_ => "Requirements must include requirements to be used for supplier!")
                         .When(command => command.TagType == TagType.PoArea, ApplyConditionTo.CurrentValidator)
-                    .MustAsync((command, token) => RequirementUsageIsNotForOtherThanSupplierStepAsync(command.Requirements, token))
+                    .MustAsync((command, token) => RequirementUsageIsNotForOtherThanSupplierAsync(command.Requirements, token))
                     .WithMessage(_ => "Requirements can not include requirements for other than suppliers!")
                         .When(command => command.TagType == TagType.PoArea, ApplyConditionTo.CurrentValidator);
 
@@ -41,7 +41,7 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.CreateAreaTag
                     .WithMessage(_ => $"Step for a {TagType.PoArea.GetTagNoPrefix()} tag need to be for supplier!")
                     .MustAsync((command, token) => RequirementUsageIsForJourneysWithoutSupplierAsync(command.Requirements, token))
                     .WithMessage(_ => "Requirements must include requirements to be used for other than suppliers!")
-                    .MustAsync((command, token) => RequirementUsageIsNotForSupplierStepOnlyAsync(command.Requirements, token))
+                    .MustAsync((command, token) => RequirementUsageIsNotForSupplierOnlyAsync(command.Requirements, token))
                     .WithMessage(_ => "Requirements can not include requirements just for suppliers!");
             });
 
@@ -87,13 +87,13 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.CreateAreaTag
                 return await requirementDefinitionValidator.UsageCoversForOtherThanSuppliersAsync(reqIds, token);
             }                        
 
-            async Task<bool> RequirementUsageIsNotForOtherThanSupplierStepAsync(IEnumerable<RequirementForCommand> requirements, CancellationToken token)
+            async Task<bool> RequirementUsageIsNotForOtherThanSupplierAsync(IEnumerable<RequirementForCommand> requirements, CancellationToken token)
             {
                 var reqIds = requirements.Select(dto => dto.RequirementDefinitionId).ToList();
                 return !await requirementDefinitionValidator.HasAnyForForOtherThanSuppliersUsageAsync(reqIds, token);
             }                        
 
-            async Task<bool> RequirementUsageIsNotForSupplierStepOnlyAsync(IEnumerable<RequirementForCommand> requirements, CancellationToken token)
+            async Task<bool> RequirementUsageIsNotForSupplierOnlyAsync(IEnumerable<RequirementForCommand> requirements, CancellationToken token)
             {
                 var reqIds = requirements.Select(dto => dto.RequirementDefinitionId).ToList();
                 return !await requirementDefinitionValidator.HasAnyForSupplierOnlyUsageAsync(reqIds, token);

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateAreaTag/CreateAreaTagCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateAreaTag/CreateAreaTagCommandValidator.cs
@@ -23,20 +23,27 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.CreateAreaTag
             
             WhenAsync((command, token) => BeASupplierStepAsync(command.StepId, token), () =>
             {
-                RuleFor(command => command.Requirements)
-                    .Must(BeUniqueRequirements)
-                    .WithMessage(command => "Requirement definitions must be unique!")
-                    .MustAsync((_, requirements, token) => RequirementUsageIsForAllJourneysAsync(requirements, token))
-                    .WithMessage(command => "Requirements must include requirements to be used both for supplier and other than suppliers!");
+                RuleFor(command => command)
+                    .Must(command => BeUniqueRequirements(command.Requirements))
+                    .WithMessage(_ => "Requirement definitions must be unique!")
+                    .MustAsync((command, token) => RequirementUsageIsForSupplierAsync(command.Requirements, token))
+                    .WithMessage(_ => "Requirements must include requirements to be used for supplier!")
+                        .When(command => command.TagType == TagType.PoArea, ApplyConditionTo.CurrentValidator)
+                    .MustAsync((command, token) => RequirementUsageIsForAllJourneysAsync(command.Requirements, token))
+                    .WithMessage(_ => "Requirements must include requirements to be used both for supplier and other than suppliers!")
+                        .When(command => command.TagType != TagType.PoArea, ApplyConditionTo.CurrentValidator);
+
             }).Otherwise(() =>
             {
-                RuleFor(command => command.Requirements)
-                    .Must(BeUniqueRequirements)
-                    .WithMessage(command => "Requirement definitions must be unique!")
-                    .MustAsync((_, requirements, token) => RequirementUsageIsForJourneysWithoutSupplierAsync(requirements, token))
-                    .WithMessage(command => "Requirements must include requirements to be used for other than suppliers!")
-                    .MustAsync((_, requirements, token) => RequirementUsageIsNotForSupplierStepOnlyAsync(requirements, token))
-                    .WithMessage(command => "Requirements can not include requirements just for suppliers!");
+                RuleFor(command => command)
+                    .Must(command => command.TagType != TagType.PoArea)
+                    .WithMessage(_ => $"Step for a {TagType.PoArea.GetTagNoPrefix()} tag need to be for supplier!")
+                    .Must(command => BeUniqueRequirements(command.Requirements))
+                    .WithMessage(_ => "Requirement definitions must be unique!")
+                    .MustAsync((command, token) => RequirementUsageIsForJourneysWithoutSupplierAsync(command.Requirements, token))
+                    .WithMessage(_ => "Requirements must include requirements to be used for other than suppliers!")
+                    .MustAsync((command, token) => RequirementUsageIsNotForSupplierStepOnlyAsync(command.Requirements, token))
+                    .WithMessage(_ => "Requirements can not include requirements just for suppliers!");
             });
 
             RuleFor(command => command)
@@ -47,15 +54,12 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.CreateAreaTag
                 .MustAsync((command, token) => BeAnExistingStepAsync(command.StepId, token))
                 .WithMessage(command => $"Step doesn't exist! Step={command.StepId}")
                 .MustAsync((command, token) => NotBeAVoidedStepAsync(command.StepId, token))
-                .WithMessage(command => $"Step is voided! Step={command.StepId}")
-                .MustAsync((command, token) => BeASupplierStepAsync(command.StepId, token))
-                .WithMessage(command => $"Step for a {TagType.PoArea.GetTagNoPrefix()} need to be for supplier!")
-                    .When(command => command.TagType == TagType.PoArea, ApplyConditionTo.CurrentValidator);
+                .WithMessage(command => $"Step is voided! Step={command.StepId}");
 
             RuleForEach(command => command.Requirements)
-                .MustAsync((_, req, __, token) => BeAnExistingRequirementDefinitionAsync(req, token))
+                .MustAsync((_, req, _, token) => BeAnExistingRequirementDefinitionAsync(req, token))
                 .WithMessage((_, req) => $"Requirement definition doesn't exist! Requirement definition={req.RequirementDefinitionId}")
-                .MustAsync((_, req, __, token) => NotBeAVoidedRequirementDefinitionAsync(req, token))
+                .MustAsync((_, req, _, token) => NotBeAVoidedRequirementDefinitionAsync(req, token))
                 .WithMessage((_, req) => $"Requirement definition is voided! Requirement definition={req.RequirementDefinitionId}");
 
             bool BeUniqueRequirements(IEnumerable<RequirementForCommand> requirements)
@@ -68,6 +72,12 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.CreateAreaTag
             {
                 var reqIds = requirements.Select(dto => dto.RequirementDefinitionId).ToList();
                 return await requirementDefinitionValidator.UsageCoversBothForSupplierAndOtherAsync(reqIds, token);
+            }                        
+
+            async Task<bool> RequirementUsageIsForSupplierAsync(IEnumerable<RequirementForCommand> requirements, CancellationToken token)
+            {
+                var reqIds = requirements.Select(dto => dto.RequirementDefinitionId).ToList();
+                return await requirementDefinitionValidator.UsageCoversForSuppliersAsync(reqIds, token);
             }                        
 
             async Task<bool> RequirementUsageIsForJourneysWithoutSupplierAsync(IEnumerable<RequirementForCommand> requirements, CancellationToken token)

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateTags/CreateTagsCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateTags/CreateTagsCommandValidator.cs
@@ -30,23 +30,23 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.CreateTags
             {
                 RuleFor(command => command.Requirements)
                     .Must(BeUniqueRequirements)
-                    .WithMessage(command => "Requirement definitions must be unique!")
+                    .WithMessage(_ => "Requirement definitions must be unique!")
                     .MustAsync((_, requirements, token) => RequirementUsageIsForAllJourneysAsync(requirements, token))
-                    .WithMessage(command => "Requirements must include requirements to be used both for supplier and other than suppliers!");
+                    .WithMessage(_ => "Requirements must include requirements to be used both for supplier and other than suppliers!");
             }).Otherwise(() =>
             {
                 RuleFor(command => command.Requirements)
                     .Must(BeUniqueRequirements)
-                    .WithMessage(command => "Requirement definitions must be unique!")
+                    .WithMessage(_ => "Requirement definitions must be unique!")
                     .MustAsync((_, requirements, token) => RequirementUsageIsForJourneysWithoutSupplierAsync(requirements, token))
-                    .WithMessage(command => "Requirements must include requirements to be used for other than suppliers!")
+                    .WithMessage(_ => "Requirements must include requirements to be used for other than suppliers!")
                     .MustAsync((_, requirements, token) => RequirementUsageIsNotForSupplierStepOnlyAsync(requirements, token))
-                    .WithMessage(command => "Requirements can not include requirements just for suppliers!");
+                    .WithMessage(_ => "Requirements can not include requirements just for suppliers!");
             });
 
             RuleForEach(command => command.TagNos)
                 .MustAsync((command, tagNo, _, token) => NotBeAnExistingTagWithinProjectAsync(tagNo, command.ProjectName, token))
-                .WithMessage((command, tagNo) => $"Tag already exists in scope for project! Tag={tagNo}");
+                .WithMessage((_, tagNo) => $"Tag already exists in scope for project! Tag={tagNo}");
 
             RuleFor(command => command)
                 .MustAsync((command, token) => NotBeAnExistingAndClosedProjectAsync(command.ProjectName, token))
@@ -57,10 +57,10 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.CreateTags
                 .WithMessage(command => $"Step is voided! Step={command.StepId}");
 
             RuleForEach(command => command.Requirements)
-                .MustAsync((_, req, __, token) => BeAnExistingRequirementDefinitionAsync(req, token))
+                .MustAsync((_, req, _, token) => BeAnExistingRequirementDefinitionAsync(req, token))
                 .WithMessage((_, req) =>
                     $"Requirement definition doesn't exist! Requirement definition={req.RequirementDefinitionId}")
-                .MustAsync((_, req, __, token) => NotBeAVoidedRequirementDefinitionAsync(req, token))
+                .MustAsync((_, req, _, token) => NotBeAVoidedRequirementDefinitionAsync(req, token))
                 .WithMessage((_, req) =>
                     $"Requirement definition is voided! Requirement definition={req.RequirementDefinitionId}");
                         

--- a/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateTags/CreateTagsCommandValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/TagCommands/CreateTags/CreateTagsCommandValidator.cs
@@ -29,15 +29,11 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.CreateTags
             WhenAsync((command, token) => BeASupplierStepAsync(command.StepId, token), () =>
             {
                 RuleFor(command => command.Requirements)
-                    .Must(BeUniqueRequirements)
-                    .WithMessage(_ => "Requirement definitions must be unique!")
                     .MustAsync((_, requirements, token) => RequirementUsageIsForAllJourneysAsync(requirements, token))
                     .WithMessage(_ => "Requirements must include requirements to be used both for supplier and other than suppliers!");
             }).Otherwise(() =>
             {
                 RuleFor(command => command.Requirements)
-                    .Must(BeUniqueRequirements)
-                    .WithMessage(_ => "Requirement definitions must be unique!")
                     .MustAsync((_, requirements, token) => RequirementUsageIsForJourneysWithoutSupplierAsync(requirements, token))
                     .WithMessage(_ => "Requirements must include requirements to be used for other than suppliers!")
                     .MustAsync((_, requirements, token) => RequirementUsageIsNotForSupplierStepOnlyAsync(requirements, token))
@@ -49,6 +45,8 @@ namespace Equinor.Procosys.Preservation.Command.TagCommands.CreateTags
                 .WithMessage((_, tagNo) => $"Tag already exists in scope for project! Tag={tagNo}");
 
             RuleFor(command => command)
+                .Must(command => BeUniqueRequirements(command.Requirements))
+                .WithMessage(_ => "Requirement definitions must be unique!")
                 .MustAsync((command, token) => NotBeAnExistingAndClosedProjectAsync(command.ProjectName, token))
                 .WithMessage(command => $"Project is closed! Project={command.ProjectName}")
                 .MustAsync((command, token) => BeAnExistingStepAsync(command.StepId, token))

--- a/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/IRequirementDefinitionValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/IRequirementDefinitionValidator.cs
@@ -10,6 +10,7 @@ namespace Equinor.Procosys.Preservation.Command.Validators.RequirementDefinition
         Task<bool> ExistsFieldAsync(int requirementDefinitionId, int fieldId, CancellationToken token);
         Task<bool> IsVoidedAsync(int requirementDefinitionId, CancellationToken token);
         Task<bool> UsageCoversBothForSupplierAndOtherAsync(List<int> requirementDefinitionIds, CancellationToken token);
+        Task<bool> UsageCoversForSuppliersAsync(List<int> requirementDefinitionIds, CancellationToken token);
         Task<bool> UsageCoversForOtherThanSuppliersAsync(List<int> requirementDefinitionIds, CancellationToken token);
         Task<bool> HasAnyForSupplierOnlyUsageAsync(List<int> requirementDefinitionIds, CancellationToken token);
         Task<bool> HasAnyFieldsAsync(int requirementDefinitionId, CancellationToken token);

--- a/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/IRequirementDefinitionValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/IRequirementDefinitionValidator.cs
@@ -13,6 +13,7 @@ namespace Equinor.Procosys.Preservation.Command.Validators.RequirementDefinition
         Task<bool> UsageCoversForSuppliersAsync(List<int> requirementDefinitionIds, CancellationToken token);
         Task<bool> UsageCoversForOtherThanSuppliersAsync(List<int> requirementDefinitionIds, CancellationToken token);
         Task<bool> HasAnyForSupplierOnlyUsageAsync(List<int> requirementDefinitionIds, CancellationToken token);
+        Task<bool> HasAnyForForOtherThanSuppliersUsageAsync(List<int> requirementDefinitionIds, CancellationToken token);
         Task<bool> HasAnyFieldsAsync(int requirementDefinitionId, CancellationToken token);
         Task<bool> TagRequirementsExistAsync(int requirementDefinitionId, CancellationToken token);
         Task<bool> TagFunctionRequirementsExistAsync(int requirementDefinitionId, CancellationToken token);

--- a/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/RequirementDefinitionValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/RequirementDefinitionValidator.cs
@@ -71,6 +71,12 @@ namespace Equinor.Procosys.Preservation.Command.Validators.RequirementDefinition
             return reqDefs.Any(rd => rd.Usage == RequirementUsage.ForSuppliersOnly);
         }
 
+        public async Task<bool> HasAnyForForOtherThanSuppliersUsageAsync(List<int> requirementDefinitionIds, CancellationToken token)
+        {
+            var reqDefs = await GetRequirementDefinitionsAsync(requirementDefinitionIds, token);
+            return reqDefs.Any(rd => rd.Usage == RequirementUsage.ForOtherThanSuppliers);
+        }
+
         public async Task<bool> HasAnyFieldsAsync(int requirementDefinitionId, CancellationToken token)
         {
             var reqDef = await GetRequirementDefinitionWithFieldsAsync(requirementDefinitionId, token);

--- a/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/RequirementDefinitionValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/RequirementDefinitionValidators/RequirementDefinitionValidator.cs
@@ -47,6 +47,13 @@ namespace Equinor.Procosys.Preservation.Command.Validators.RequirementDefinition
                        reqDefs.Any(rd => rd.Usage == RequirementUsage.ForOtherThanSuppliers));
         }
 
+        public async Task<bool> UsageCoversForSuppliersAsync(List<int> requirementDefinitionIds, CancellationToken token)
+        {
+            var reqDefs = await GetRequirementDefinitionsAsync(requirementDefinitionIds, token);
+            return reqDefs.Any(rd => rd.Usage == RequirementUsage.ForAll) ||
+                   reqDefs.Any(rd => rd.Usage == RequirementUsage.ForSuppliersOnly);
+        }
+
         public async Task<bool> UsageCoversForOtherThanSuppliersAsync(
             List<int> requirementDefinitionIds,
             CancellationToken token)

--- a/src/Equinor.Procosys.Preservation.Command/Validators/TagValidators/ITagValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/TagValidators/ITagValidator.cs
@@ -54,7 +54,14 @@ namespace Equinor.Procosys.Preservation.Command.Validators.TagValidators
         Task<bool> HasRequirementAsync(int tagId, int tagRequirementId, CancellationToken token);
         
         Task<bool> AllRequirementsWillBeUniqueAsync(int tagId, List<int> requirementDefinitionIdsToBeAdded, CancellationToken token);
-        
+
+        Task<bool> RequirementUsageWillCoversForSuppliersAsync(
+            int tagId,
+            List<int> tagRequirementIdsToBeUnvoided,
+            List<int> tagRequirementIdsToBeVoided,
+            List<int> requirementDefinitionIdsToBeAdded,
+            CancellationToken token);
+
         Task<bool> RequirementUsageWillCoverBothForSupplierAndOtherAsync(
             int tagId,
             List<int> tagRequirementIdsToBeUnvoided,

--- a/src/Equinor.Procosys.Preservation.Command/Validators/TagValidators/ITagValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/TagValidators/ITagValidator.cs
@@ -76,6 +76,13 @@ namespace Equinor.Procosys.Preservation.Command.Validators.TagValidators
             List<int> requirementDefinitionIdsToBeAdded,
             CancellationToken token);
 
+        Task<bool> RequirementHasAnyForForOtherThanSuppliersUsageAsync(
+            int tagId,
+            List<int> tagRequirementIdsToBeUnvoided,
+            List<int> tagRequirementIdsToBeVoided,
+            List<int> requirementDefinitionIdsToBeAdded,
+            CancellationToken token);
+
         Task<bool> IsInUseAsync(long tagId, CancellationToken token);
         
         Task<bool> HasStepAsync(int tagId, int stepId, CancellationToken token);

--- a/src/Equinor.Procosys.Preservation.Command/Validators/TagValidators/TagValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/TagValidators/TagValidator.cs
@@ -253,6 +253,31 @@ namespace Equinor.Procosys.Preservation.Command.Validators.TagValidators
             return allRequirementDefinitionIds.Count == allRequirementDefinitionIds.Distinct().Count();
         }
 
+        public async Task<bool> RequirementUsageWillCoversForSuppliersAsync(
+            int tagId,
+            List<int> tagRequirementIdsToBeUnvoided,
+            List<int> tagRequirementIdsToBeVoided,
+            List<int> requirementDefinitionIdsToBeAdded,
+            CancellationToken token)
+        {
+            List<int> requirementDefinitionIds;
+            Tag tag;
+            (tag, requirementDefinitionIds) = await GetNonVoidedRequirementDefinitionIds(
+                tagId,
+                tagRequirementIdsToBeUnvoided,
+                tagRequirementIdsToBeVoided,
+                requirementDefinitionIdsToBeAdded,
+                token);
+
+            if (tag == null)
+            {
+                return false;
+            }
+
+            return await _requirementDefinitionValidator.UsageCoversForSuppliersAsync(requirementDefinitionIds, token);
+        }
+            
+
         public async Task<bool> RequirementUsageWillCoverBothForSupplierAndOtherAsync(
             int tagId,
             List<int> tagRequirementIdsToBeUnvoided,

--- a/src/Equinor.Procosys.Preservation.Command/Validators/TagValidators/TagValidator.cs
+++ b/src/Equinor.Procosys.Preservation.Command/Validators/TagValidators/TagValidator.cs
@@ -325,7 +325,29 @@ namespace Equinor.Procosys.Preservation.Command.Validators.TagValidators
 
             return await _requirementDefinitionValidator.UsageCoversForOtherThanSuppliersAsync(requirementDefinitionIds, token);
         }
-        
+
+        public async Task<bool> RequirementHasAnyForForOtherThanSuppliersUsageAsync(int tagId,
+            List<int> tagRequirementIdsToBeUnvoided,
+            List<int> tagRequirementIdsToBeVoided, List<int> requirementDefinitionIdsToBeAdded, CancellationToken token)
+        {
+            List<int> requirementDefinitionIds;
+            Tag tag;
+            (tag, requirementDefinitionIds) = await GetNonVoidedRequirementDefinitionIds(
+                tagId,
+                tagRequirementIdsToBeUnvoided,
+                tagRequirementIdsToBeVoided,
+                requirementDefinitionIdsToBeAdded,
+                token);
+
+            if (tag == null)
+            {
+                return false;
+            }
+
+            return await _requirementDefinitionValidator.HasAnyForForOtherThanSuppliersUsageAsync(requirementDefinitionIds, token);
+        }
+            
+
         public async Task<bool> VerifyTagDescriptionAsync(int tagId, string description, CancellationToken token)
         {
             var tag = await GetTagWithoutIncludes(tagId, token);

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateAreaTag/CreateAreaTagCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateAreaTag/CreateAreaTagCommandValidatorTests.cs
@@ -329,6 +329,11 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateAreaTag
         [TestMethod]
         public void Validate_ShouldFail_WhenRequirementsNotUnique()
         {
+            _rdValidatorMock
+                .Setup(r => r.UsageCoversBothForSupplierAndOtherAsync(
+                    new List<int> {_rdForSupplierId, _rdForOtherThanSupplierId, _rdForSupplierId}, default))
+                .Returns(Task.FromResult(true));
+            
             var command = new CreateAreaTagCommand(
                 _projectName,
                 TagType.PreArea,
@@ -340,6 +345,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateAreaTag
                 new List<RequirementForCommand>
                 {
                     new RequirementForCommand(_rdForSupplierId, 1),
+                    new RequirementForCommand(_rdForOtherThanSupplierId, 1),
                     new RequirementForCommand(_rdForSupplierId, 1)
                 },
                 "DescriptionA",

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateAreaTag/CreateAreaTagCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateAreaTag/CreateAreaTagCommandValidatorTests.cs
@@ -19,12 +19,13 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateAreaTag
         private Mock<IStepValidator> _stepValidatorMock;
         private Mock<IProjectValidator> _projectValidatorMock;
         private Mock<IRequirementDefinitionValidator> _rdValidatorMock;
-        private CreateAreaTagCommand _command;
+        private CreateAreaTagCommand _createPreAreaTagCommand;
+        private CreateAreaTagCommand _createPoAreaTagCommand;
 
         private string _projectName = "Project";
         private int _stepId = 1;
-        private int _rd1Id = 2;
-        private int _rd2Id = 3;
+        private int _rdForSupplierId = 2;
+        private int _rdForOtherThanSupplierId = 3;
 
         [TestInitialize]
         public void Setup_OkState()
@@ -38,11 +39,12 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateAreaTag
             _projectValidatorMock = new Mock<IProjectValidator>();
 
             _rdValidatorMock = new Mock<IRequirementDefinitionValidator>();
-            _rdValidatorMock.Setup(r => r.ExistsAsync(_rd1Id, default)).Returns(Task.FromResult(true));
-            _rdValidatorMock.Setup(r => r.ExistsAsync(_rd2Id, default)).Returns(Task.FromResult(true));
-            _rdValidatorMock.Setup(r => r.UsageCoversBothForSupplierAndOtherAsync(new List<int>{_rd1Id, _rd2Id}, default)).Returns(Task.FromResult(true));
+            _rdValidatorMock.Setup(r => r.ExistsAsync(_rdForSupplierId, default)).Returns(Task.FromResult(true));
+            _rdValidatorMock.Setup(r => r.ExistsAsync(_rdForOtherThanSupplierId, default)).Returns(Task.FromResult(true));
+            _rdValidatorMock.Setup(r => r.UsageCoversBothForSupplierAndOtherAsync(new List<int>{_rdForSupplierId, _rdForOtherThanSupplierId}, default)).Returns(Task.FromResult(true));
+            _rdValidatorMock.Setup(r => r.UsageCoversForSuppliersAsync(new List<int>{_rdForSupplierId}, default)).Returns(Task.FromResult(true));
 
-            _command = new CreateAreaTagCommand(
+            _createPreAreaTagCommand = new CreateAreaTagCommand(
                 _projectName,
                 TagType.PreArea,
                 "D",
@@ -52,8 +54,24 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateAreaTag
                 _stepId,
                 new List<RequirementForCommand>
                 {
-                    new RequirementForCommand(_rd1Id, 1),
-                    new RequirementForCommand(_rd2Id, 1)
+                    new RequirementForCommand(_rdForSupplierId, 1),
+                    new RequirementForCommand(_rdForOtherThanSupplierId, 1)
+                },
+                "Desc",
+                "Remark",
+                "SA");
+
+            _createPoAreaTagCommand = new CreateAreaTagCommand(
+                _projectName,
+                TagType.PoArea,
+                "D",
+                "A",
+                null,
+                null,
+                _stepId,
+                new List<RequirementForCommand>
+                {
+                    new RequirementForCommand(_rdForSupplierId, 1)
                 },
                 "Desc",
                 "Remark",
@@ -67,9 +85,17 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateAreaTag
         }
 
         [TestMethod]
-        public void Validate_ShouldBeValid_WhenOkState()
+        public void Validate_ShouldBeValid_ForPreArea_WhenOkState()
         {
-            var result = _dut.Validate(_command);
+            var result = _dut.Validate(_createPreAreaTagCommand);
+
+            Assert.IsTrue(result.IsValid);
+        }
+
+        [TestMethod]
+        public void Validate_ShouldBeValid_ForPoArea_WhenOkState()
+        {
+            var result = _dut.Validate(_createPoAreaTagCommand);
 
             Assert.IsTrue(result.IsValid);
         }
@@ -77,9 +103,9 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateAreaTag
         [TestMethod]
         public void Validate_ShouldFail_WhenAnyTagAlreadyExists()
         {
-            _tagValidatorMock.Setup(r => r.ExistsAsync(_command.GetTagNo(), _projectName, default)).Returns(Task.FromResult(true));
+            _tagValidatorMock.Setup(r => r.ExistsAsync(_createPreAreaTagCommand.GetTagNo(), _projectName, default)).Returns(Task.FromResult(true));
             
-            var result = _dut.Validate(_command);
+            var result = _dut.Validate(_createPreAreaTagCommand);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
@@ -91,7 +117,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateAreaTag
         {
             _projectValidatorMock.Setup(r => r.IsExistingAndClosedAsync(_projectName, default)).Returns(Task.FromResult(true));
             
-            var result = _dut.Validate(_command);
+            var result = _dut.Validate(_createPreAreaTagCommand);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
@@ -103,7 +129,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateAreaTag
         {
             _stepValidatorMock.Setup(r => r.ExistsAsync(_stepId, default)).Returns(Task.FromResult(false));
             
-            var result = _dut.Validate(_command);
+            var result = _dut.Validate(_createPreAreaTagCommand);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
@@ -115,7 +141,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateAreaTag
         {
             _stepValidatorMock.Setup(r => r.IsVoidedAsync(_stepId, default)).Returns(Task.FromResult(true));
             
-            var result = _dut.Validate(_command);
+            var result = _dut.Validate(_createPreAreaTagCommand);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
@@ -125,31 +151,33 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateAreaTag
         [TestMethod]
         public void Validate_ShouldFail_WhenAnyRequirementDefinitionNotExists()
         {
-            _rdValidatorMock.Setup(r => r.ExistsAsync(_rd2Id, default)).Returns(Task.FromResult(false));
+            _rdValidatorMock.Setup(r => r.ExistsAsync(_rdForOtherThanSupplierId, default)).Returns(Task.FromResult(false));
             
-            var result = _dut.Validate(_command);
+            var result = _dut.Validate(_createPreAreaTagCommand);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirement definition doesn't exist!"));
-            Assert.IsTrue(result.Errors[0].ErrorMessage.Contains(_rd2Id.ToString()));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.Contains(_rdForOtherThanSupplierId.ToString()));
         }
 
         [TestMethod]
         public void Validate_ShouldFail_WhenAnyRequirementDefinitionIsVoided()
         {
-            _rdValidatorMock.Setup(r => r.IsVoidedAsync(_rd2Id, default)).Returns(Task.FromResult(true));
+            _rdValidatorMock.Setup(r => r.IsVoidedAsync(_rdForOtherThanSupplierId, default)).Returns(Task.FromResult(true));
             
-            var result = _dut.Validate(_command);
+            var result = _dut.Validate(_createPreAreaTagCommand);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirement definition is voided!"));
-            Assert.IsTrue(result.Errors[0].ErrorMessage.Contains(_rd2Id.ToString()));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.Contains(_rdForOtherThanSupplierId.ToString()));
         }
 
+        #region special validation for PreArea tags
+
         [TestMethod]
-        public void Validate_ShouldFailForNonSupplierStep_WhenNoRequirementsGiven()
+        public void Validate_ShouldFailForNonSupplierStep_ForPreArea_WhenNoRequirementsGiven()
         {
             _stepValidatorMock.Setup(r => r.IsForSupplierAsync(_stepId, default)).Returns(Task.FromResult(false));
             var command = new CreateAreaTagCommand(
@@ -173,24 +201,24 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateAreaTag
         }
 
         [TestMethod]
-        public void Validate_ShouldBeValidForNonSupplierStep_WhenRequirementsForOtherGiven()
+        public void Validate_ShouldBeValidForNonSupplierStep_ForPreArea_WhenRequirementsForOtherGiven()
         {
             _stepValidatorMock.Setup(r => r.IsForSupplierAsync(_stepId, default)).Returns(Task.FromResult(false));
-            _rdValidatorMock.Setup(r => r.UsageCoversForOtherThanSuppliersAsync(new List<int>{_rd1Id, _rd2Id}, default)).Returns(Task.FromResult(true));
+            _rdValidatorMock.Setup(r => r.UsageCoversForOtherThanSuppliersAsync(new List<int>{_rdForSupplierId, _rdForOtherThanSupplierId}, default)).Returns(Task.FromResult(true));
 
-            var result = _dut.Validate(_command);
+            var result = _dut.Validate(_createPreAreaTagCommand);
 
             Assert.IsTrue(result.IsValid);
         }
         
         [TestMethod]
-        public void Validate_ShouldFailForNonSupplierStep_WhenRequirementForSupplierOnlyGiven()
+        public void Validate_ShouldFailForNonSupplierStep_ForPreArea_WhenRequirementForSupplierOnlyGiven()
         {
             _stepValidatorMock.Setup(r => r.IsForSupplierAsync(_stepId, default)).Returns(Task.FromResult(false));
-            _rdValidatorMock.Setup(r => r.UsageCoversForOtherThanSuppliersAsync(new List<int>{_rd1Id, _rd2Id}, default)).Returns(Task.FromResult(true));
-            _rdValidatorMock.Setup(r => r.HasAnyForSupplierOnlyUsageAsync(new List<int>{_rd1Id, _rd2Id}, default)).Returns(Task.FromResult(true));
+            _rdValidatorMock.Setup(r => r.UsageCoversForOtherThanSuppliersAsync(new List<int>{_rdForSupplierId, _rdForOtherThanSupplierId}, default)).Returns(Task.FromResult(true));
+            _rdValidatorMock.Setup(r => r.HasAnyForSupplierOnlyUsageAsync(new List<int>{_rdForSupplierId, _rdForOtherThanSupplierId}, default)).Returns(Task.FromResult(true));
 
-            var result = _dut.Validate(_command);
+            var result = _dut.Validate(_createPreAreaTagCommand);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
@@ -198,12 +226,12 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateAreaTag
         }
         
         [TestMethod]
-        public void Validate_ShouldFailForNonSupplierStep_WhenRequirementForOtherNotGiven()
+        public void Validate_ShouldFailForNonSupplierStep_ForPreArea_WhenRequirementForOtherNotGiven()
         {
             _stepValidatorMock.Setup(r => r.IsForSupplierAsync(_stepId, default)).Returns(Task.FromResult(false));
-            _rdValidatorMock.Setup(r => r.UsageCoversBothForSupplierAndOtherAsync(new List<int>{_rd1Id, _rd2Id}, default)).Returns(Task.FromResult(false));
+            _rdValidatorMock.Setup(r => r.UsageCoversBothForSupplierAndOtherAsync(new List<int>{_rdForSupplierId, _rdForOtherThanSupplierId}, default)).Returns(Task.FromResult(false));
 
-            var result = _dut.Validate(_command);
+            var result = _dut.Validate(_createPreAreaTagCommand);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
@@ -211,7 +239,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateAreaTag
         }
 
         [TestMethod]
-        public void Validate_ShouldFailForSupplierStep_WhenNoRequirementsGiven()
+        public void Validate_ShouldFailForSupplierStep_ForPreArea_WhenNoRequirementsGiven()
         {
             var command = new CreateAreaTagCommand(
                 _projectName,
@@ -234,16 +262,69 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateAreaTag
         }
 
         [TestMethod]
-        public void Validate_ShouldFailForSupplierStep_WhenRequirementForSupplierNotGiven()
+        public void Validate_ShouldFailForSupplierStep_ForPreArea_WhenRequirementForSupplierNotGiven()
         {
-            _rdValidatorMock.Setup(r => r.UsageCoversBothForSupplierAndOtherAsync(new List<int>{_rd1Id, _rd2Id}, default)).Returns(Task.FromResult(false));
+            _rdValidatorMock.Setup(r => r.UsageCoversBothForSupplierAndOtherAsync(new List<int>{_rdForSupplierId, _rdForOtherThanSupplierId}, default)).Returns(Task.FromResult(false));
             
-            var result = _dut.Validate(_command);
+            var result = _dut.Validate(_createPreAreaTagCommand);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirements must include requirements to be used both for supplier and other than suppliers!"));
         }
+
+        #endregion
+
+        #region Special validation for PoArea tags
+
+        [TestMethod]
+        public void Validate_ShouldFailForNonSupplierStep_WhenPoArea()
+        {
+            _stepValidatorMock.Setup(r => r.IsForSupplierAsync(_stepId, default)).Returns(Task.FromResult(false));
+            
+            var result = _dut.Validate(_createPoAreaTagCommand);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith($"Step for a {TagType.PoArea.GetTagNoPrefix()} tag need to be for supplier!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFailForSupplierStep_ForPoArea_WhenNoRequirementsGiven()
+        {
+            var command = new CreateAreaTagCommand(
+                _projectName,
+                TagType.PoArea,
+                "DisciplineA",
+                "AreaA",
+                null,
+                null,
+                _stepId,
+                new List<RequirementForCommand>(),
+                "DescriptionA",
+                "RemarkA",
+                "SA_A");
+            
+            var result = _dut.Validate(command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirements must include requirements to be used for supplier!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFailForSupplierStep_ForPoArea_WhenRequirementForSupplierNotGiven()
+        {
+            _rdValidatorMock.Setup(r => r.UsageCoversForSuppliersAsync(new List<int>{_rdForSupplierId}, default)).Returns(Task.FromResult(false));
+            
+            var result = _dut.Validate(_createPoAreaTagCommand);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirements must include requirements to be used for supplier!"));
+        }
+
+        #endregion
 
         [TestMethod]
         public void Validate_ShouldFail_WhenRequirementsNotUnique()
@@ -258,8 +339,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateAreaTag
                 _stepId,
                 new List<RequirementForCommand>
                 {
-                    new RequirementForCommand(_rd1Id, 1),
-                    new RequirementForCommand(_rd1Id, 1)
+                    new RequirementForCommand(_rdForSupplierId, 1),
+                    new RequirementForCommand(_rdForSupplierId, 1)
                 },
                 "DescriptionA",
                 "RemarkA",
@@ -278,7 +359,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateAreaTag
             _stepValidatorMock.Setup(r => r.ExistsAsync(_stepId, default)).Returns(Task.FromResult(false));
             _stepValidatorMock.Setup(r => r.IsVoidedAsync(_stepId, default)).Returns(Task.FromResult(true));
             
-            var result = _dut.Validate(_command);
+            var result = _dut.Validate(_createPreAreaTagCommand);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
@@ -287,10 +368,10 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateAreaTag
         [TestMethod]
         public void Validate_ShouldFailWith1Error_WhenErrorsInDifferentRules()
         {
-            _tagValidatorMock.Setup(r => r.ExistsAsync(_command.GetTagNo(), _projectName, default)).Returns(Task.FromResult(true));
-            _rdValidatorMock.Setup(r => r.ExistsAsync(_rd2Id, default)).Returns(Task.FromResult(false));
+            _tagValidatorMock.Setup(r => r.ExistsAsync(_createPreAreaTagCommand.GetTagNo(), _projectName, default)).Returns(Task.FromResult(true));
+            _rdValidatorMock.Setup(r => r.ExistsAsync(_rdForOtherThanSupplierId, default)).Returns(Task.FromResult(false));
             
-            var result = _dut.Validate(_command);
+            var result = _dut.Validate(_createPreAreaTagCommand);
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateTags/CreateTagsCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/CreateTags/CreateTagsCommandValidatorTests.cs
@@ -272,6 +272,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.CreateTags
         [TestMethod]
         public void Validate_ShouldFail_WhenRequirementsNotUnique()
         {
+            _rdValidatorMock.Setup(r => r.UsageCoversBothForSupplierAndOtherAsync(new List<int>{_rd1Id, _rd1Id}, default)).Returns(Task.FromResult(true));
             var command = new CreateTagsCommand(
                 new List<string>{_tagNo1}, 
                 _projectName,

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandValidatorTests.cs
@@ -514,8 +514,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
         public void Validate_ShouldFail_ForPoAreaTag_WhenTargetStepNotForSupplier()
         {
             // Arrange
-            _stepValidatorMock.Setup(r => r.IsForSupplierAsync(_stepId, default)).Returns(Task.FromResult(false));
             _tagValidatorMock.Setup(t => t.VerifyTagTypeAsync(_tagId, TagType.PoArea, default)).Returns(Task.FromResult(true));
+            _stepValidatorMock.Setup(r => r.IsForSupplierAsync(_stepId, default)).Returns(Task.FromResult(false));
 
             // Act
             var result = _dut.Validate(_addTwoReqsCommand);
@@ -543,6 +543,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
         public void Validate_ShouldFail_ForPoAreaTag_WhenNoRequirementForSupplier()
         {
             // Arrange
+            _tagValidatorMock.Setup(t => t.VerifyTagTypeAsync(_tagId, TagType.PoArea, default)).Returns(Task.FromResult(true));
             _tagValidatorMock.Setup(t => t.RequirementUsageWillCoversForSuppliersAsync(
                     _tagId,
                     new List<int>(),
@@ -550,7 +551,6 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
                     new List<int> {_rdForSupplierId, _rdForOtherThanSupplierId},
                     default))
                 .Returns(Task.FromResult(false));
-            _tagValidatorMock.Setup(t => t.VerifyTagTypeAsync(_tagId, TagType.PoArea, default)).Returns(Task.FromResult(true));
 
             // Act
             var result = _dut.Validate(_addTwoReqsCommand);
@@ -559,6 +559,28 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirements must include requirements to be used for supplier!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldFail_ForPoAreaTag_WhenRequirementForOtherThanSupplier()
+        {
+            // Arrange
+            _tagValidatorMock.Setup(t => t.VerifyTagTypeAsync(_tagId, TagType.PoArea, default)).Returns(Task.FromResult(true));
+            _tagValidatorMock.Setup(t => t.RequirementHasAnyForForOtherThanSuppliersUsageAsync(
+                    _tagId,
+                    new List<int>(),
+                    new List<int>(),
+                    new List<int> {_rdForSupplierId, _rdForOtherThanSupplierId},
+                    default))
+                .Returns(Task.FromResult(true));
+
+            // Act
+            var result = _dut.Validate(_addTwoReqsCommand);
+
+            // Assert
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Requirements can not include requirements for other than suppliers!"));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandValidatorTests.cs
@@ -25,12 +25,10 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
 
         private int _stepId = 1;
 
-        private int _tagReqForAll1Id = 12;
-        private int _tagReqForAll2Id = 13;
-        private int _tagReqForOtherId = 14;
-        private int _tagReqForSupplierId = 15;
-        private int _reqDefForAll1Id = 2;
-        private int _reqDefForAll2Id = 3;
+        private int _tagReqForSupplierId = 12;
+        private int _tagReqForOtherThanSupplierId = 13;
+        private int _rdForSupplierId = 2;
+        private int _rdForOtherThanSupplierId = 3;
         private int _reqDef3Id = 4;
         private int _tagId = 123;
         private const string RowVersion = "AAAAAAAAD6U=";
@@ -40,24 +38,22 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
         {
             _tagValidatorMock = new Mock<ITagValidator>();
             _tagValidatorMock.Setup(t => t.ExistsAsync(_tagId, default)).Returns(Task.FromResult(true));
-            _tagValidatorMock.Setup(t => t.HasRequirementAsync(_tagId, _tagReqForAll1Id, default)).Returns(Task.FromResult(true));
-            _tagValidatorMock.Setup(t => t.HasRequirementAsync(_tagId, _tagReqForAll2Id, default)).Returns(Task.FromResult(true));
-            _tagValidatorMock.Setup(t => t.HasRequirementAsync(_tagId, _tagReqForOtherId, default)).Returns(Task.FromResult(true));
             _tagValidatorMock.Setup(t => t.HasRequirementAsync(_tagId, _tagReqForSupplierId, default)).Returns(Task.FromResult(true));
+            _tagValidatorMock.Setup(t => t.HasRequirementAsync(_tagId, _tagReqForOtherThanSupplierId, default)).Returns(Task.FromResult(true));
             
-            _tagValidatorMock.Setup(t => t.AllRequirementsWillBeUniqueAsync(_tagId, new List<int>{_reqDefForAll1Id, _reqDefForAll2Id}, default)).Returns(Task.FromResult(true));
+            _tagValidatorMock.Setup(t => t.AllRequirementsWillBeUniqueAsync(_tagId, new List<int>{_rdForSupplierId, _rdForOtherThanSupplierId}, default)).Returns(Task.FromResult(true));
             _tagValidatorMock.Setup(t => t.RequirementUsageWillCoverBothForSupplierAndOtherAsync(
                     _tagId,
                     new List<int>(),
                     new List<int>(),
-                    new List<int> {_reqDefForAll1Id, _reqDefForAll2Id},
+                    new List<int> {_rdForSupplierId, _rdForOtherThanSupplierId},
                     default))
                 .Returns(Task.FromResult(true));
             _tagValidatorMock.Setup(t => t.RequirementUsageWillCoverForOtherThanSuppliersAsync(
                     _tagId,
                     new List<int>(),
                     new List<int>(),
-                    new List<int> {_reqDefForAll1Id, _reqDefForAll2Id},
+                    new List<int> {_rdForSupplierId, _rdForOtherThanSupplierId},
                     default))
                 .Returns(Task.FromResult(true));
             _tagValidatorMock.Setup(t => t.HasStepAsync(_tagId, _stepId, default)).Returns(Task.FromResult(true));
@@ -69,8 +65,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
             _projectValidatorMock = new Mock<IProjectValidator>();
 
             _rdValidatorMock = new Mock<IRequirementDefinitionValidator>();
-            _rdValidatorMock.Setup(r => r.ExistsAsync(_reqDefForAll1Id, default)).Returns(Task.FromResult(true));
-            _rdValidatorMock.Setup(r => r.ExistsAsync(_reqDefForAll2Id, default)).Returns(Task.FromResult(true));
+            _rdValidatorMock.Setup(r => r.ExistsAsync(_rdForSupplierId, default)).Returns(Task.FromResult(true));
+            _rdValidatorMock.Setup(r => r.ExistsAsync(_rdForOtherThanSupplierId, default)).Returns(Task.FromResult(true));
 
             _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
             _rowVersionValidatorMock.Setup(r => r.IsValid(RowVersion)).Returns(true);
@@ -89,8 +85,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
                 null, 
                 new List<RequirementForCommand>
                 {
-                    new RequirementForCommand(_reqDefForAll1Id, 1), 
-                    new RequirementForCommand(_reqDefForAll2Id, 1)
+                    new RequirementForCommand(_rdForSupplierId, 1), 
+                    new RequirementForCommand(_rdForOtherThanSupplierId, 1)
                 },
                 null, 
                 RowVersion);
@@ -183,7 +179,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
             _tagValidatorMock.Setup(t => t.RequirementUsageWillCoverBothForSupplierAndOtherAsync(
                     _tagId,
                     new List<int>(),
-                    new List<int> {_tagReqForAll1Id, _tagReqForAll2Id},
+                    new List<int> {_tagReqForSupplierId, _tagReqForOtherThanSupplierId},
                     new List<int> {_reqDef3Id},
                     default))
                 .Returns(Task.FromResult(true));
@@ -193,8 +189,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
                 _stepId,
                 new List<UpdateRequirementForCommand>
                 {
-                    new UpdateRequirementForCommand(_tagReqForAll1Id, 1, true, RowVersion),
-                    new UpdateRequirementForCommand(_tagReqForAll2Id, 1, true, RowVersion)
+                    new UpdateRequirementForCommand(_tagReqForSupplierId, 1, true, RowVersion),
+                    new UpdateRequirementForCommand(_tagReqForOtherThanSupplierId, 1, true, RowVersion)
                 },
                 new List<RequirementForCommand>
                 {
@@ -220,7 +216,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
             _tagValidatorMock.Setup(t => t.RequirementUsageWillCoverForOtherThanSuppliersAsync(
                     _tagId,
                     new List<int>(),
-                    new List<int> {_tagReqForAll1Id, _tagReqForAll2Id},
+                    new List<int> {_tagReqForSupplierId, _tagReqForOtherThanSupplierId},
                     new List<int> {_reqDef3Id}, default))
                 .Returns(Task.FromResult(true));
             var command = new UpdateTagStepAndRequirementsCommand(
@@ -229,8 +225,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
                 _stepId,
                 new List<UpdateRequirementForCommand>
                 {
-                    new UpdateRequirementForCommand(_tagReqForAll1Id, 1, true, RowVersion),
-                    new UpdateRequirementForCommand(_tagReqForAll2Id, 1, true, RowVersion)
+                    new UpdateRequirementForCommand(_tagReqForSupplierId, 1, true, RowVersion),
+                    new UpdateRequirementForCommand(_tagReqForOtherThanSupplierId, 1, true, RowVersion)
                 },
                 new List<RequirementForCommand> {new RequirementForCommand(_reqDef3Id, 1)},
                 null, 
@@ -247,7 +243,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
         public void Validate_ShouldFail_WhenAnyRequirementAlreadyExists()
         {
             // Arrange
-            _tagValidatorMock.Setup(t => t.AllRequirementsWillBeUniqueAsync(_tagId, new List<int>{_reqDefForAll1Id, _reqDefForAll2Id}, default)).Returns(Task.FromResult(false));
+            _tagValidatorMock.Setup(t => t.AllRequirementsWillBeUniqueAsync(_tagId, new List<int>{_rdForSupplierId, _rdForOtherThanSupplierId}, default)).Returns(Task.FromResult(false));
 
             // Act
             var result = _dut.Validate(_addTwoReqsCommand);
@@ -262,13 +258,13 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
         public void Validate_ShouldFail_WhenRequirementToUpdateNotExists()
         {
             // Arrange
-            _tagValidatorMock.Setup(t => t.HasRequirementAsync(_tagId, _tagReqForAll1Id, default)).Returns(Task.FromResult(false));
-            _tagValidatorMock.Setup(t => t.AllRequirementsWillBeUniqueAsync(_tagId, new List<int>{_reqDefForAll2Id}, default)).Returns(Task.FromResult(true));
+            _tagValidatorMock.Setup(t => t.HasRequirementAsync(_tagId, _tagReqForSupplierId, default)).Returns(Task.FromResult(false));
+            _tagValidatorMock.Setup(t => t.AllRequirementsWillBeUniqueAsync(_tagId, new List<int>{_rdForOtherThanSupplierId}, default)).Returns(Task.FromResult(true));
             _tagValidatorMock.Setup(t => t.RequirementUsageWillCoverBothForSupplierAndOtherAsync(
                     _tagId,
-                    new List<int>{_tagReqForAll1Id},
+                    new List<int>{_tagReqForSupplierId},
                     new List<int>(),
-                    new List<int> {_reqDefForAll2Id},
+                    new List<int> {_rdForOtherThanSupplierId},
                     default))
                 .Returns(Task.FromResult(true));
             var command = new UpdateTagStepAndRequirementsCommand(
@@ -277,11 +273,11 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
                 _stepId,
                 new List<UpdateRequirementForCommand>
                 {
-                    new UpdateRequirementForCommand(_tagReqForAll1Id, 1, false, RowVersion)
+                    new UpdateRequirementForCommand(_tagReqForSupplierId, 1, false, RowVersion)
                 },
                 new List<RequirementForCommand>
                 {
-                    new RequirementForCommand(_reqDefForAll2Id, 1)
+                    new RequirementForCommand(_rdForOtherThanSupplierId, 1)
                 },
                 null, 
                 RowVersion);
@@ -299,13 +295,13 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
         public void Validate_ShouldFail_WhenRequirementToDeleteNotExists()
         {
             // Arrange
-            _tagValidatorMock.Setup(t => t.HasRequirementAsync(_tagId, _tagReqForAll1Id, default)).Returns(Task.FromResult(false));
-            _tagValidatorMock.Setup(t => t.AllRequirementsWillBeUniqueAsync(_tagId, new List<int>{_reqDefForAll2Id}, default)).Returns(Task.FromResult(true));
+            _tagValidatorMock.Setup(t => t.HasRequirementAsync(_tagId, _tagReqForSupplierId, default)).Returns(Task.FromResult(false));
+            _tagValidatorMock.Setup(t => t.AllRequirementsWillBeUniqueAsync(_tagId, new List<int>{_rdForOtherThanSupplierId}, default)).Returns(Task.FromResult(true));
             _tagValidatorMock.Setup(t => t.RequirementUsageWillCoverBothForSupplierAndOtherAsync(
                     _tagId,
                     new List<int>(),
                     new List<int>(),
-                    new List<int> {_reqDefForAll2Id}, default))
+                    new List<int> {_rdForOtherThanSupplierId}, default))
                 .Returns(Task.FromResult(true));
             var command = new UpdateTagStepAndRequirementsCommand(
                 _tagId,
@@ -314,11 +310,11 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
                 null,
                 new List<RequirementForCommand>
                 {
-                    new RequirementForCommand(_reqDefForAll2Id, 1)
+                    new RequirementForCommand(_rdForOtherThanSupplierId, 1)
                 },
                 new List<DeleteRequirementForCommand>
                 {
-                    new DeleteRequirementForCommand(_tagReqForAll1Id, RowVersion)
+                    new DeleteRequirementForCommand(_tagReqForSupplierId, RowVersion)
                 },
                 RowVersion);
 
@@ -335,12 +331,12 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
         public void Validate_ShouldFail_WhenRequirementToDeleteNotVoided()
         {
             // Arrange
-            _tagValidatorMock.Setup(t => t.AllRequirementsWillBeUniqueAsync(_tagId, new List<int>{_reqDefForAll2Id}, default)).Returns(Task.FromResult(true));
+            _tagValidatorMock.Setup(t => t.AllRequirementsWillBeUniqueAsync(_tagId, new List<int>{_rdForOtherThanSupplierId}, default)).Returns(Task.FromResult(true));
             _tagValidatorMock.Setup(t => t.RequirementUsageWillCoverBothForSupplierAndOtherAsync(
                     _tagId,
                     new List<int>(),
                     new List<int>(),
-                    new List<int> {_reqDefForAll2Id},
+                    new List<int> {_rdForOtherThanSupplierId},
                     default))
                 .Returns(Task.FromResult(true));
             var command = new UpdateTagStepAndRequirementsCommand(
@@ -350,11 +346,11 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
                 null,
                 new List<RequirementForCommand>
                 {
-                    new RequirementForCommand(_reqDefForAll2Id, 1)
+                    new RequirementForCommand(_rdForOtherThanSupplierId, 1)
                 },
                 new List<DeleteRequirementForCommand>
                 {
-                    new DeleteRequirementForCommand(_tagReqForAll1Id, RowVersion)
+                    new DeleteRequirementForCommand(_tagReqForSupplierId, RowVersion)
                 },
                 RowVersion);
 
@@ -371,15 +367,15 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
         public void Validate_ShouldBeValid_WhenRequirementToDelete_IsVoidedInAdvance()
         {
             // Arrange
-            _tagValidatorMock.Setup(t => t.AllRequirementsWillBeUniqueAsync(_tagId, new List<int>{_reqDefForAll2Id}, default)).Returns(Task.FromResult(true));
+            _tagValidatorMock.Setup(t => t.AllRequirementsWillBeUniqueAsync(_tagId, new List<int>{_rdForOtherThanSupplierId}, default)).Returns(Task.FromResult(true));
             _tagValidatorMock.Setup(t => t.RequirementUsageWillCoverBothForSupplierAndOtherAsync(
                     _tagId,
                     new List<int>(),
                     new List<int>(),
-                    new List<int> {_reqDefForAll2Id},
+                    new List<int> {_rdForOtherThanSupplierId},
                     default))
                 .Returns(Task.FromResult(true));
-            _tagValidatorMock.Setup(t => t.IsRequirementVoidedAsync(_tagId, _tagReqForAll1Id, default)).Returns(Task.FromResult(true));
+            _tagValidatorMock.Setup(t => t.IsRequirementVoidedAsync(_tagId, _tagReqForSupplierId, default)).Returns(Task.FromResult(true));
             var command = new UpdateTagStepAndRequirementsCommand(
                 _tagId,
                 null,
@@ -387,11 +383,11 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
                 null,
                 new List<RequirementForCommand>
                 {
-                    new RequirementForCommand(_reqDefForAll2Id, 1)
+                    new RequirementForCommand(_rdForOtherThanSupplierId, 1)
                 },
                 new List<DeleteRequirementForCommand>
                 {
-                    new DeleteRequirementForCommand(_tagReqForAll1Id, RowVersion)
+                    new DeleteRequirementForCommand(_tagReqForSupplierId, RowVersion)
                 },
                 RowVersion);
 
@@ -406,12 +402,12 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
         public void Validate_ShouldBeValid_WhenRequirementToDelete_WillBeVoidedInSameCommand()
         {
             // Arrange
-            _tagValidatorMock.Setup(t => t.AllRequirementsWillBeUniqueAsync(_tagId, new List<int>{_reqDefForAll2Id}, default)).Returns(Task.FromResult(true));
+            _tagValidatorMock.Setup(t => t.AllRequirementsWillBeUniqueAsync(_tagId, new List<int>{_rdForOtherThanSupplierId}, default)).Returns(Task.FromResult(true));
             _tagValidatorMock.Setup(t => t.RequirementUsageWillCoverBothForSupplierAndOtherAsync(
                     _tagId,
                     new List<int>(),
-                    new List<int> {_tagReqForAll1Id},
-                    new List<int> {_reqDefForAll2Id},
+                    new List<int> {_tagReqForSupplierId},
+                    new List<int> {_rdForOtherThanSupplierId},
                     default))
                 .Returns(Task.FromResult(true));
             var command = new UpdateTagStepAndRequirementsCommand(
@@ -420,15 +416,15 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
                 _stepId,
                 new List<UpdateRequirementForCommand>
                 {
-                    new UpdateRequirementForCommand(_tagReqForAll1Id, 1, true, RowVersion)
+                    new UpdateRequirementForCommand(_tagReqForSupplierId, 1, true, RowVersion)
                 }, 
                 new List<RequirementForCommand>
                 {
-                    new RequirementForCommand(_reqDefForAll2Id, 1)
+                    new RequirementForCommand(_rdForOtherThanSupplierId, 1)
                 },
                 new List<DeleteRequirementForCommand>
                 {
-                    new DeleteRequirementForCommand(_tagReqForAll1Id, RowVersion)
+                    new DeleteRequirementForCommand(_tagReqForSupplierId, RowVersion)
                 },
                 RowVersion);
 
@@ -535,8 +531,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
                 null,
                 new List<RequirementForCommand>
                 {
-                    new RequirementForCommand(_reqDefForAll1Id, 1),
-                    new RequirementForCommand(_reqDefForAll2Id, 1)
+                    new RequirementForCommand(_rdForSupplierId, 1),
+                    new RequirementForCommand(_rdForOtherThanSupplierId, 1)
                 },
                 null, 
                 invalidRowVersion);
@@ -560,8 +556,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
                 null,
                 new List<RequirementForCommand>
                 {
-                    new RequirementForCommand(_reqDefForAll1Id, 1),
-                    new RequirementForCommand(_reqDefForAll2Id, 1)
+                    new RequirementForCommand(_rdForSupplierId, 1),
+                    new RequirementForCommand(_rdForOtherThanSupplierId, 1)
                 },
                 null, 
                 RowVersion);
@@ -584,8 +580,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
                 null,
                 new List<RequirementForCommand>
                 {
-                    new RequirementForCommand(_reqDefForAll1Id, 1),
-                    new RequirementForCommand(_reqDefForAll2Id, 1)
+                    new RequirementForCommand(_rdForSupplierId, 1),
+                    new RequirementForCommand(_rdForOtherThanSupplierId, 1)
                 },
                 null, 
                 RowVersion);
@@ -605,8 +601,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
                 null,
                 new List<RequirementForCommand>
                 {
-                    new RequirementForCommand(_reqDefForAll1Id, 1),
-                    new RequirementForCommand(_reqDefForAll2Id, 1)
+                    new RequirementForCommand(_rdForSupplierId, 1),
+                    new RequirementForCommand(_rdForOtherThanSupplierId, 1)
                 },
                 null, 
                 RowVersion);
@@ -630,8 +626,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
                 null,
                 new List<RequirementForCommand>
                 {
-                    new RequirementForCommand(_reqDefForAll1Id, 1),
-                    new RequirementForCommand(_reqDefForAll2Id, 1)
+                    new RequirementForCommand(_rdForSupplierId, 1),
+                    new RequirementForCommand(_rdForOtherThanSupplierId, 1)
                 },
                 null, 
                 RowVersion);

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RequirementDefinitionValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RequirementDefinitionValidatorTests.cs
@@ -209,6 +209,78 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
             }
         }
 
+
+        [TestMethod]
+        public async Task HasAnyForForOtherThanSuppliersUsageAsync_UsageForAllRequirement_ShouldReturnFalse()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var reqIds = new List<int> {_reqDefForAll.Id};
+                var dut = new RequirementDefinitionValidator(context);
+                var result = await dut.HasAnyForForOtherThanSuppliersUsageAsync(reqIds, default);
+                Assert.IsFalse(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task HasAnyForForOtherThanSuppliersUsageAsync_UsageForOtherRequirement_ShouldReturnTrue()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var reqIds = new List<int> {_reqDefForOther.Id};
+                var dut = new RequirementDefinitionValidator(context);
+                var result = await dut.HasAnyForForOtherThanSuppliersUsageAsync(reqIds, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task HasAnyForForOtherThanSuppliersUsageAsync_UsageForSupplierRequirement_ShouldReturnFalse()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var reqIds = new List<int> {_reqDefForSupplier.Id};
+                var dut = new RequirementDefinitionValidator(context);
+                var result = await dut.HasAnyForForOtherThanSuppliersUsageAsync(reqIds, default);
+                Assert.IsFalse(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task HasAnyForForOtherThanSuppliersUsageAsync_UsageForSupplierAndOtherAndForAllRequirement_ShouldReturnTrue()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var reqIds = new List<int> {_reqDefForSupplier.Id, _reqDefForOther.Id, _reqDefForAll.Id};
+                var dut = new RequirementDefinitionValidator(context);
+                var result = await dut.HasAnyForForOtherThanSuppliersUsageAsync(reqIds, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task HasAnyForForOtherThanSuppliersUsageAsync_UnknownRequirement_ShouldReturnFalse()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var reqIds = new List<int> {0};
+                var dut = new RequirementDefinitionValidator(context);
+                var result = await dut.HasAnyForForOtherThanSuppliersUsageAsync(reqIds, default);
+                Assert.IsFalse(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task HasAnyForForOtherThanSuppliersUsageAsync_NoRequirements_ShouldReturnFalse()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var reqIds = new List<int>();
+                var dut = new RequirementDefinitionValidator(context);
+                var result = await dut.HasAnyForForOtherThanSuppliersUsageAsync(reqIds, default);
+                Assert.IsFalse(result);
+            }
+        }
         [TestMethod]
         public async Task UsageCoversForOtherThanSuppliersAsync_UsageForAllRequirement_ShouldReturnTrue()
         {

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RequirementDefinitionValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/RequirementDefinitionValidatorTests.cs
@@ -282,6 +282,78 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         }
 
         [TestMethod]
+        public async Task UsageCoversForSuppliersAsync_UsageForAllRequirement_ShouldReturnTrue()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var reqIds = new List<int> {_reqDefForAll.Id};
+                var dut = new RequirementDefinitionValidator(context);
+                var result = await dut.UsageCoversForSuppliersAsync(reqIds, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task UsageCoversForSuppliersAsync_UsageForOtherRequirement_ShouldReturnFalse()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var reqIds = new List<int> {_reqDefForOther.Id};
+                var dut = new RequirementDefinitionValidator(context);
+                var result = await dut.UsageCoversForSuppliersAsync(reqIds, default);
+                Assert.IsFalse(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task UsageCoversForSuppliersAsync_UsageForSupplierRequirement_ShouldReturnTrue()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var reqIds = new List<int> {_reqDefForSupplier.Id};
+                var dut = new RequirementDefinitionValidator(context);
+                var result = await dut.UsageCoversForSuppliersAsync(reqIds, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task UsageCoversForSuppliersAsync_UsageForSupplierAndOtherAndForAllRequirement_ShouldReturnTrue()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var reqIds = new List<int> {_reqDefForSupplier.Id, _reqDefForOther.Id, _reqDefForAll.Id};
+                var dut = new RequirementDefinitionValidator(context);
+                var result = await dut.UsageCoversForSuppliersAsync(reqIds, default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task UsageCoversForSuppliersAsync_UnknownRequirement_ShouldReturnFalse()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var reqIds = new List<int> {0};
+                var dut = new RequirementDefinitionValidator(context);
+                var result = await dut.UsageCoversForSuppliersAsync(reqIds, default);
+                Assert.IsFalse(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task UsageCoversForSuppliersAsync_NoRequirements_ShouldReturnFalse()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var reqIds = new List<int>();
+                var dut = new RequirementDefinitionValidator(context);
+                var result = await dut.UsageCoversForSuppliersAsync(reqIds, default);
+                Assert.IsFalse(result);
+            }
+        }
+
+        [TestMethod]
         public async Task UsageCoversBothForSupplierAndOtherAsync_UsageForAllRequirement_ShouldReturnTrue()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/TagValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/TagValidatorTests.cs
@@ -1247,6 +1247,74 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
                 Assert.IsTrue(result);
             }
         }
+        
+        [TestMethod]
+        public async Task RequirementUsageWillCoversForSuppliersAsync_ShouldReturnTrue_WhenRequirementsCoversAll()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithAllReqsId);
+                var dut = new TagValidator(context, new RequirementDefinitionValidator(context));
+                var result = await dut.RequirementUsageWillCoversForSuppliersAsync(
+                    tag.Id,
+                    new List<int>(),
+                    new List<int>(),
+                    new List<int>(),
+                    default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task RequirementUsageWillCoversForSuppliersAsync_ShouldReturnFalse_WhenVoidingRequirementsForAllAndForSupplier()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithAllReqsId);
+                var dut = new TagValidator(context, new RequirementDefinitionValidator(context));
+                var result = await dut.RequirementUsageWillCoversForSuppliersAsync(
+                    tag.Id, 
+                    new List<int>(),
+                    new List<int>{_tagReqForAll1Id, _tagReqForSupplierId},
+                    new List<int>(),
+                    default);
+                Assert.IsFalse(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task RequirementUsageWillCoversForSuppliersAsync_ShouldReturnTrue_WhenVoidingRequirementsForAllAndForOther()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithAllReqsId);
+                var dut = new TagValidator(context, new RequirementDefinitionValidator(context));
+                var result = await dut.RequirementUsageWillCoversForSuppliersAsync(
+                    tag.Id,
+                    new List<int>(),
+                    new List<int>{_tagReqForAll1Id, _tagReqForOtherId}, 
+                    new List<int>(), 
+                    default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task RequirementUsageWillCoversForSuppliersAsync_ShouldReturnTrue_WhenVoidingAllRequirementsAndAddingNew()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithAllReqsId);
+                var dut = new TagValidator(context, new RequirementDefinitionValidator(context));
+                var result = await dut.RequirementUsageWillCoversForSuppliersAsync(
+                    tag.Id,
+                    new List<int>(),
+                    new List<int>{_tagReqForAll1Id, _tagReqForSupplierId}, 
+                    new List<int>{_reqDefForAll2Id}, 
+                    default);
+                Assert.IsTrue(result);
+            }
+        }
 
         [TestMethod]
         public async Task RequirementUsageWillCoverForOtherThanSuppliersAsync_ShouldReturnTrue_WhenRequirementsCoversAll()

--- a/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/TagValidatorTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.Command.Tests/Validators/TagValidatorTests.cs
@@ -41,7 +41,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
         private int _reqDefForAll2Id;
         private int _tagReqForAll1Id;
         private int _tagReqForSupplierId;
-        private int _tagReqForOtherId;
+        private int _tagReqForOther1Id;
+        private int _reqDefForOther2Id;
         private int _firstStepId;
         private int _poAreaTagActionId;
         private int _poAreaTagAttachmentId;
@@ -62,8 +63,10 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
                 var reqDefForAll2 = AddRequirementTypeWith1DefWithoutField(context, "R2", "D2", RequirementTypeIcon.Other).RequirementDefinitions.First();
                 var reqDefForSupplier = new RequirementDefinition(TestPlant, "D2", 2, RequirementUsage.ForSuppliersOnly, 1);
                 requirementType.AddRequirementDefinition(reqDefForSupplier);
-                var reqDefForOther = new RequirementDefinition(TestPlant, "D3", 2, RequirementUsage.ForOtherThanSuppliers, 1);
-                requirementType.AddRequirementDefinition(reqDefForOther);
+                var reqDefForOther1 = new RequirementDefinition(TestPlant, "D3", 2, RequirementUsage.ForOtherThanSuppliers, 1);
+                var reqDefForOther2 = new RequirementDefinition(TestPlant, "D4", 2, RequirementUsage.ForOtherThanSuppliers, 1);
+                requirementType.AddRequirementDefinition(reqDefForOther1);
+                requirementType.AddRequirementDefinition(reqDefForOther2);
                 context.SaveChangesAsync().Wait();
 
                 var firstStep = journey.Steps.First();
@@ -73,7 +76,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
                     {
                         new TagRequirement(TestPlant, IntervalWeeks, reqDefForAll1), 
                         new TagRequirement(TestPlant, IntervalWeeks, reqDefForSupplier), 
-                        new TagRequirement(TestPlant, IntervalWeeks, reqDefForOther)
+                        new TagRequirement(TestPlant, IntervalWeeks, reqDefForOther1)
                     });
 
                 var standardTagCompleted = AddTag(context, project, TagType.Standard, TagNo2, "",
@@ -86,7 +89,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
                 var standardTagWithTwoReqsInLastStep = AddTag(context, project, TagType.Standard, TagNo3, "",
                     journey.Steps.Last(), new List<TagRequirement>
                     {
-                        new TagRequirement(TestPlant, IntervalWeeks, reqDefForOther),
+                        new TagRequirement(TestPlant, IntervalWeeks, reqDefForOther1),
                         new TagRequirement(TestPlant, IntervalWeeks, reqDefForAll1)
                     });
 
@@ -126,7 +129,8 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
                 _reqDefForAll2Id = reqDefForAll2.Id;
                 _tagReqForAll1Id = standardTagNotStartedInFirstStep.Requirements.Single(r => r.RequirementDefinitionId == reqDefForAll1.Id).Id;
                 _tagReqForSupplierId = standardTagNotStartedInFirstStep.Requirements.Single(r => r.RequirementDefinitionId == reqDefForSupplier.Id).Id;
-                _tagReqForOtherId = standardTagNotStartedInFirstStep.Requirements.Single(r => r.RequirementDefinitionId == reqDefForOther.Id).Id;
+                _reqDefForOther2Id = reqDefForOther2.Id;
+                _tagReqForOther1Id = standardTagNotStartedInFirstStep.Requirements.Single(r => r.RequirementDefinitionId == reqDefForOther1.Id).Id;
                 _standardTagNotStartedInFirstStepId = _tagWithAllReqsId = standardTagNotStartedInFirstStep.Id;
                 _standardTagStartedAndInLastStepId = _tagWithOneReqsId = standardTagStartedInLastStep.Id;
                 _tagWithTwoReqsId = standardTagWithTwoReqsInLastStep.Id;
@@ -1195,7 +1199,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
                 var result = await dut.RequirementUsageWillCoverBothForSupplierAndOtherAsync(
                     tag.Id,
                     new List<int>(),
-                    new List<int>{_tagReqForAll1Id, _tagReqForOtherId}, 
+                    new List<int>{_tagReqForAll1Id, _tagReqForOther1Id}, 
                     new List<int>(), 
                     default);
                 Assert.IsFalse(result);
@@ -1292,7 +1296,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
                 var result = await dut.RequirementUsageWillCoversForSuppliersAsync(
                     tag.Id,
                     new List<int>(),
-                    new List<int>{_tagReqForAll1Id, _tagReqForOtherId}, 
+                    new List<int>{_tagReqForAll1Id, _tagReqForOther1Id}, 
                     new List<int>(), 
                     default);
                 Assert.IsTrue(result);
@@ -1343,7 +1347,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
                 var result = await dut.RequirementUsageWillCoverForOtherThanSuppliersAsync(
                     tag.Id, 
                     new List<int>(),
-                    new List<int>{_tagReqForAll1Id, _tagReqForOtherId}, 
+                    new List<int>{_tagReqForAll1Id, _tagReqForOther1Id}, 
                     new List<int>(), 
                     default);
                 Assert.IsFalse(result);
@@ -1360,7 +1364,7 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
                 var result = await dut.RequirementUsageWillCoverForOtherThanSuppliersAsync(
                     tag.Id, 
                     new List<int>(),
-                    new List<int>{_tagReqForAll1Id, _tagReqForOtherId}, 
+                    new List<int>{_tagReqForAll1Id, _tagReqForOther1Id}, 
                     new List<int>{_reqDefForAll2Id}, 
                     default);
                 Assert.IsTrue(result);
@@ -1391,6 +1395,57 @@ namespace Equinor.Procosys.Preservation.Command.Tests.Validators
                     new List<int>{reqId1},
                     new List<int>{reqId2}, 
                     new List<int>(), 
+                    default);
+                Assert.IsTrue(result);
+            }
+        }
+        
+        [TestMethod]
+        public async Task RequirementHasAnyForForOtherThanSuppliersUsageAsync_ShouldReturnTrue_WhenRequirementsCoversAll()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithAllReqsId);
+                var dut = new TagValidator(context, new RequirementDefinitionValidator(context));
+                var result = await dut.RequirementHasAnyForForOtherThanSuppliersUsageAsync(
+                    tag.Id,
+                    new List<int>(),
+                    new List<int>(),
+                    new List<int>(),
+                    default);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task RequirementHasAnyForForOtherThanSuppliersUsageAsync_ShouldReturnFalse_WhenVoidingRequirementsForOther()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithAllReqsId);
+                var dut = new TagValidator(context, new RequirementDefinitionValidator(context));
+                var result = await dut.RequirementHasAnyForForOtherThanSuppliersUsageAsync(
+                    tag.Id, 
+                    new List<int>(),
+                    new List<int>{_tagReqForOther1Id}, 
+                    new List<int>(), 
+                    default);
+                Assert.IsFalse(result);
+            }
+        }
+
+        [TestMethod]
+        public async Task RequirementHasAnyForForOtherThanSuppliersUsageAsync_ShouldReturnTrue_WhenVoidinOtherRequirementsAndAddingNew()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var tag = context.Tags.Include(t => t.Requirements).Single(t => t.Id == _tagWithAllReqsId);
+                var dut = new TagValidator(context, new RequirementDefinitionValidator(context));
+                var result = await dut.RequirementHasAnyForForOtherThanSuppliersUsageAsync(
+                    tag.Id, 
+                    new List<int>(),
+                    new List<int>{_tagReqForOther1Id}, 
+                    new List<int>{_reqDefForOther2Id}, 
                     default);
                 Assert.IsTrue(result);
             }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/ModeDto.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/ModeDto.cs
@@ -1,0 +1,12 @@
+﻿namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
+{
+    public class ModeDto
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public bool IsVoided { get; set; }
+        public bool ForSupplier { get; set; }
+        public bool IsInUse { get; set; }
+        public string RowVersion { get; set; }
+    }
+}

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/StepDto.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Journeys/StepDto.cs
@@ -8,6 +8,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Journeys
         public string Title { get; set; }
         public bool IsVoided { get; set; }
         public AutoTransferMethod AutoTransferMethod { get; set; }
+        public ModeDto Mode { get; set; }
         public string RowVersion { get; set; }
     }
 }

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/KnownTestData.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/KnownTestData.cs
@@ -7,7 +7,6 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
         public static string Plant => "PCS$PLANT1";
         public static string ProjectName => "TestProject";
         public static string ProjectDescription => "Test - Project";
-        public static string Mode => "TestMode";
         public static string ResponsibleCode => "TestResp";
         public static string ResponsibleDescription => "Test - Responsible";
         public static string ReqTypeA => "TestRT-A";
@@ -24,7 +23,6 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
         public static string StepInJourneyNotInUse => "TestStepB";
         public static string StandardTagNo => "Std-Test";
         public static string SiteTagNo => "#SITE-Test";
-        public static string SiteTagDescription => "Test - SiteTag";
         public static string Action => "TestAction";
         public static Guid ActionAttachmentBlobStorageId = new Guid("{11111111-1111-1111-1111-111111111111}");
         public static Guid TagAttachmentBlobStorageId = new Guid("{22222222-2222-2222-2222-222222222222}");

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/PreservationContextExtension.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/PreservationContextExtension.cs
@@ -45,8 +45,9 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
 
             var plant = plantProvider.Plant;
 
-            var mode = SeedMode(dbContext, plant);
-            knownTestData.ModeId = mode.Id;
+            var supplierMode = SeedMode(dbContext, plant, "SUP", true);
+            var otherMode = SeedMode(dbContext, plant, "FAB", false);
+            knownTestData.ModeId = otherMode.Id;
 
             var responsible = SeedResponsible(dbContext, plant);
 
@@ -66,11 +67,11 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
             SeedReqDef(dbContext, reqTypeB, KnownTestData.ReqDefInReqTypeB);
             
             var journeyWithTags = SeedJourney(dbContext, plant, KnownTestData.JourneyWithTags);
-            var stepInJourneyWithTags = SeedStep(dbContext, journeyWithTags, KnownTestData.StepAInJourneyWithTags, mode, responsible);
-            SeedStep(dbContext, journeyWithTags, KnownTestData.StepBInJourneyWithTags, mode, responsible);
+            var stepInJourneyWithTags = SeedStep(dbContext, journeyWithTags, KnownTestData.StepAInJourneyWithTags, supplierMode, responsible);
+            SeedStep(dbContext, journeyWithTags, KnownTestData.StepBInJourneyWithTags, otherMode, responsible);
             
             var journeyWithoutTags = SeedJourney(dbContext, plant, KnownTestData.JourneyNotInUse);
-            SeedStep(dbContext, journeyWithoutTags, KnownTestData.StepInJourneyNotInUse, mode, responsible);
+            SeedStep(dbContext, journeyWithoutTags, KnownTestData.StepInJourneyNotInUse, supplierMode, responsible);
 
             var project = SeedProject(dbContext, plant);
             var standardTagReadyForBulkPreserveNotStarted = SeedStandardTag(dbContext, project, stepInJourneyWithTags, reqDefANoField);
@@ -290,10 +291,10 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests
             return responsible;
         }
 
-        private static Mode SeedMode(PreservationContext dbContext, string plant)
+        private static Mode SeedMode(PreservationContext dbContext, string plant, string title, bool forSupplier)
         {
             var modeRepository = new ModeRepository(dbContext);
-            var mode = new Mode(plant, KnownTestData.Mode, false);
+            var mode = new Mode(plant, title, forSupplier);
             modeRepository.Add(mode);
             dbContext.SaveChangesAsync().Wait();
             return mode;

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerNegativeTests.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerNegativeTests.cs
@@ -1515,6 +1515,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
                 stepId,
                 "Desc",
                 null,
+                null,
                 null);
             await TagsControllerTestsHelper.StartPreservationAsync(UserType.Planner, TestFactory.PlantWithAccess, new List<int> {newTagId});
 
@@ -1603,6 +1604,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
                 "Desc",
                 null,
                 null,
+                null,
                 HttpStatusCode.Unauthorized);
 
         [TestMethod]
@@ -1617,6 +1619,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
                 null,
                 678,
                 "Desc",
+                null,
                 null,
                 null,
                 HttpStatusCode.BadRequest,
@@ -1636,6 +1639,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
                 "Desc",
                 null,
                 null,
+                null,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
 
@@ -1651,6 +1655,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
                 null,
                 678,
                 "Desc",
+                null,
                 null,
                 null,
                 HttpStatusCode.Forbidden);
@@ -1669,6 +1674,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
                 "Desc",
                 null,
                 null,
+                null,
                 HttpStatusCode.Forbidden);
 
         [TestMethod]
@@ -1683,6 +1689,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
                 null,
                 678,
                 "Desc",
+                null,
                 null,
                 null,
                 HttpStatusCode.Forbidden);

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTestsBase.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTestsBase.cs
@@ -12,6 +12,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
     [TestClass]
     public class TagsControllerTestsBase : TestBase
     {
+        protected readonly string KnownPOCode = "PO";
         protected readonly string KnownAreaCode = "A";
         protected readonly string KnownDisciplineCode = "D";
 

--- a/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTestsHelper.cs
+++ b/src/tests/Equinor.Procosys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTestsHelper.cs
@@ -548,6 +548,7 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
             string description,
             string remark,
             string storageArea,
+            string purchaseOrderCalloffCode,
             HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
             string expectedMessageOnBadRequest = null)
         {
@@ -562,7 +563,8 @@ namespace Equinor.Procosys.Preservation.WebApi.IntegrationTests.Tags
                 stepId,
                 description,
                 remark,
-                storageArea
+                storageArea,
+                purchaseOrderCalloffCode
             };
 
             var serializePayload = JsonConvert.SerializeObject(bodyPayload);


### PR DESCRIPTION
Changes in rules when creating / editing a PO Area tag. The BUG is that rules in current version of API, require that user add both requirement which is valid in an supplier step AND in a non supplier step. 

Since a PO Area tag has the characteristics that such tag MUST exist in a suppløier step (and can't be transferred), the requirement to add a requirement which is valid in an non supplier step is meaningless. 

Rules changed to ensure that for PO Area tag, it's OK with requirement valid in supplier step only

[AB#82120](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/82120)