### PR TITLE
83491 Voided tags active after a week bugfix

### DIFF
--- a/src/Equinor.ProCoSys.Preservation.WebApi/Synchronization/BusReceiverService.cs
+++ b/src/Equinor.ProCoSys.Preservation.WebApi/Synchronization/BusReceiverService.cs
@@ -150,7 +150,6 @@ namespace Equinor.ProCoSys.Preservation.WebApi.Synchronization
                 tagToUpdate.Description = tagEvent.Description;
                 tagToUpdate.McPkgNo = tagEvent.McPkgNo;
                 tagToUpdate.TagFunctionCode = tagEvent.TagFunctionCode;
-                tagToUpdate.IsVoided = tagEvent.IsVoided;
             }
         }
 

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.Tests/Synchronization/BusReceiverServiceTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.Tests/Synchronization/BusReceiverServiceTests.cs
@@ -600,7 +600,6 @@ namespace Equinor.ProCoSys.Preservation.WebApi.Tests.Synchronization
             // Act
             await _dut.ProcessMessageAsync(PcsTopic.Tag, message, new CancellationToken(false));
 
-
             // Assert
             Assert.AreEqual(area, _tag1.AreaCode);
             Assert.AreEqual(areaDescription, _tag1.AreaDescription);
@@ -608,7 +607,6 @@ namespace Equinor.ProCoSys.Preservation.WebApi.Tests.Synchronization
             Assert.AreEqual(disciplineDescription, _tag1.DisciplineDescription);
             Assert.AreEqual(callOffNo, _tag1.Calloff);
             Assert.AreEqual(poNo, _tag1.PurchaseOrderNo);
-            Assert.IsTrue(_tag1.IsVoided);
             Assert.AreEqual(tagFunctionCodeNew, _tag1.TagFunctionCode);
         }
 
@@ -638,8 +636,28 @@ namespace Equinor.ProCoSys.Preservation.WebApi.Tests.Synchronization
             Assert.AreEqual(disciplineDescription, _tag1.DisciplineDescription);
             Assert.AreEqual(callOffNo, _tag1.Calloff);
             Assert.AreEqual(poNo, _tag1.PurchaseOrderNo);
-            Assert.IsTrue(_tag1.IsVoided);
             Assert.AreEqual(tagFunctionCodeNew, _tag1.TagFunctionCode);
+        }
+
+        [TestMethod]
+        public async Task HandleTagTopic_ShouldNotUpdateIsVoidedProperty()
+        {
+            // Arrange
+            var area = "Area69";
+            var areaDescription = "Area69 Description";
+            var discipline = "ABC";
+            var disciplineDescription = "ABC Desc";
+            var callOffNo = "123";
+            var poNo = "321";
+            var tagFunctionCodeNew = "FCS123";
+            var message =
+                $"{{\"TagNo\" : \"{TagNo1}\",\"Description\" : \"Test 123\",\"ProjectName\" : \"{Project1Name}\",\"McPkgNo\" : \"{McPkg1}\",\"CommPkgNo\" : \"{CommPkg1}\",\"AreaCode\" : \"{area}\",\"AreaDescription\" : \"{areaDescription}\",\"DisciplineCode\" : \"{discipline}\",\"DisciplineDescription\" : \"{disciplineDescription}\",\"CallOffNo\" : \"{callOffNo}\",\"PurchaseOrderNo\" : \"{poNo}\",\"TagFunctionCode\" : \"{tagFunctionCodeNew}\",\"IsVoided\" : true,\"Plant\" : \"{Plant}\"}}";
+
+            // Act
+            await _dut.ProcessMessageAsync(PcsTopic.Tag, message, new CancellationToken(false));
+
+            // Assert
+            Assert.IsFalse(_tag1.IsVoided);
         }
 
         [TestMethod]
@@ -672,7 +690,6 @@ namespace Equinor.ProCoSys.Preservation.WebApi.Tests.Synchronization
             Assert.AreEqual(disciplineDescription, _tag1.DisciplineDescription);
             Assert.AreEqual(callOffNo, _tag1.Calloff);
             Assert.AreEqual(poNo, _tag1.PurchaseOrderNo);
-            Assert.IsTrue(_tag1.IsVoided);
             Assert.AreEqual(tagFunctionCodeNew, _tag1.TagFunctionCode);
             Assert.IsTrue( _project2.Tags.Contains(_tag1));
         }
@@ -708,7 +725,6 @@ namespace Equinor.ProCoSys.Preservation.WebApi.Tests.Synchronization
             Assert.AreEqual(disciplineDescription, _tag1.DisciplineDescription);
             Assert.AreEqual(callOffNo, _tag1.Calloff);
             Assert.AreEqual(poNo, _tag1.PurchaseOrderNo);
-            Assert.IsTrue(_tag1.IsVoided);
             Assert.AreEqual(tagFunctionCodeNew, _tag1.TagFunctionCode);
             Assert.IsNotNull(_newProjectCreated);
             Assert.IsTrue(_newProjectCreated.Tags.Contains(_tag1));

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.Tests/Synchronization/BusReceiverServiceTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.Tests/Synchronization/BusReceiverServiceTests.cs
@@ -653,6 +653,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.Tests.Synchronization
             var message =
                 $"{{\"TagNo\" : \"{TagNo1}\",\"Description\" : \"Test 123\",\"ProjectName\" : \"{Project1Name}\",\"McPkgNo\" : \"{McPkg1}\",\"CommPkgNo\" : \"{CommPkg1}\",\"AreaCode\" : \"{area}\",\"AreaDescription\" : \"{areaDescription}\",\"DisciplineCode\" : \"{discipline}\",\"DisciplineDescription\" : \"{disciplineDescription}\",\"CallOffNo\" : \"{callOffNo}\",\"PurchaseOrderNo\" : \"{poNo}\",\"TagFunctionCode\" : \"{tagFunctionCodeNew}\",\"IsVoided\" : true,\"Plant\" : \"{Plant}\"}}";
 
+            Assert.IsFalse(_tag1.IsVoided);
+
             // Act
             await _dut.ProcessMessageAsync(PcsTopic.Tag, message, new CancellationToken(false));
 


### PR DESCRIPTION
[AB#83491](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/83491)

Bug was: Any tag which had been voided showed up in the unvoided list a week later. 

Solution: Sync bus wrongfully set tag isvoided, this was not done in the prior sync solution. 'Voiding' a tag in preservation is not the same thing as voiding a tag in main, so this property will be ignored in preservation. 