### PR TITLE
85750 - bad performance getting tag w many actions and/or attachments

### DIFF
--- a/src/Equinor.ProCoSys.Preservation.Query/GetTagDetails/GetTagDetailsQueryHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Query/GetTagDetails/GetTagDetailsQueryHandler.cs
@@ -9,6 +9,7 @@ using Equinor.ProCoSys.Preservation.Domain.AggregateModels.ResponsibleAggregate;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using ServiceResult;
+using PreservationAction = Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate.Action;
 
 namespace Equinor.ProCoSys.Preservation.Query.GetTagDetails
 {
@@ -22,19 +23,21 @@ namespace Equinor.ProCoSys.Preservation.Query.GetTagDetails
         {
             // Requirements and it's PreservationPeriods needs to be included so tag.IsReadyToBePreserved calculates as it should
             var tagDetails = await (from tag in _context.QuerySet<Tag>()
-                                                .Include(t => t.Actions)
-                                                .Include(t => t.Attachments)
                                                 .Include(t => t.Requirements)
                                                     .ThenInclude(r => r.PreservationPeriods)
                                     join step in _context.QuerySet<Step>() on tag.StepId equals step.Id
                                     join journey in _context.QuerySet<Journey>() on EF.Property<int>(step, "JourneyId") equals journey.Id
                                     join mode in _context.QuerySet<Mode>() on step.ModeId equals mode.Id
                                     join responsible in _context.QuerySet<Responsible>() on step.ResponsibleId equals responsible.Id
+                                    let anyActions = (from a in _context.QuerySet<PreservationAction>()
+                                        where EF.Property<int>(a, "TagId") == tag.Id select a.Id).Any()
+                                    let anyAttachments = (from a in _context.QuerySet<TagAttachment>()
+                                        where EF.Property<int>(a, "TagId") == tag.Id select a.Id).Any()
                                     where tag.Id == request.TagId
                                     select new TagDetailsDto(
                                         tag.Id,
                                         tag.TagNo,
-                                        tag.Status != PreservationStatus.NotStarted || tag.Actions.Any() || tag.Attachments.Any(),
+                                        tag.Status != PreservationStatus.NotStarted || anyActions || anyAttachments,
                                         tag.IsVoided,
                                         tag.Description,
                                         tag.Status.GetDisplayValue(),

--- a/src/Equinor.ProCoSys.Preservation.WebApi/Properties/launchSettings.json
+++ b/src/Equinor.ProCoSys.Preservation.WebApi/Properties/launchSettings.json
@@ -1,0 +1,28 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:47400/",
+      "sslPort": 44369
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Equinor.ProCoSys.Preservation.WebApi": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:47401/;http://localhost:47400/"
+    }
+  }
+}


### PR DESCRIPTION
Improve generated sql due to bad performance when tag has many actions and/or attachments. The generated sql with existing code, produced over 30000 rows to get 1 tag!

[AB#85750](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/85750)