### PR TITLE
Bug/87238 save preservation timeout

### DIFF
--- a/src/Equinor.ProCoSys.Preservation.Command/ActionAttachmentCommands/Delete/DeleteActionAttachmentCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/ActionAttachmentCommands/Delete/DeleteActionAttachmentCommandHandler.cs
@@ -31,7 +31,7 @@ namespace Equinor.ProCoSys.Preservation.Command.ActionAttachmentCommands.Delete
 
         public async Task<Result<Unit>> Handle(DeleteActionAttachmentCommand request, CancellationToken cancellationToken)
         {
-            var tag = await _projectRepository.GetTagByTagIdAsync(request.TagId);
+            var tag = await _projectRepository.GetTagWithActionsByTagIdAsync(request.TagId);
             var action = tag.Actions.Single(a => a.Id == request.ActionId);
             var attachment = action.Attachments.Single(a => a.Id == request.AttachmentId);
 

--- a/src/Equinor.ProCoSys.Preservation.Command/ActionAttachmentCommands/Upload/UploadActionAttachmentCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/ActionAttachmentCommands/Upload/UploadActionAttachmentCommandHandler.cs
@@ -34,7 +34,7 @@ namespace Equinor.ProCoSys.Preservation.Command.ActionAttachmentCommands.Upload
 
         public async Task<Result<int>> Handle(UploadActionAttachmentCommand request, CancellationToken cancellationToken)
         {
-            var tag = await _projectRepository.GetTagByTagIdAsync(request.TagId);
+            var tag = await _projectRepository.GetTagWithActionsByTagIdAsync(request.TagId);
             var action = tag.Actions.Single(a => a.Id == request.ActionId);
 
             var attachment = action.GetAttachmentByFileName(request.FileName);

--- a/src/Equinor.ProCoSys.Preservation.Command/ActionCommands/CloseAction/CloseActionCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/ActionCommands/CloseAction/CloseActionCommandHandler.cs
@@ -31,7 +31,7 @@ namespace Equinor.ProCoSys.Preservation.Command.ActionCommands.CloseAction
 
         public async Task<Result<string>> Handle(CloseActionCommand request, CancellationToken cancellationToken)
         {
-            var tag = await _projectRepository.GetTagByTagIdAsync(request.TagId);
+            var tag = await _projectRepository.GetTagWithActionsByTagIdAsync(request.TagId);
             var currentUser = await _personRepository.GetByOidAsync(_currentUserProvider.GetCurrentUserOid());
 
             var action = tag.CloseAction(request.ActionId, currentUser, TimeService.UtcNow, request.RowVersion);

--- a/src/Equinor.ProCoSys.Preservation.Command/ActionCommands/CreateAction/CreateActionCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/ActionCommands/CreateAction/CreateActionCommandHandler.cs
@@ -22,7 +22,7 @@ namespace Equinor.ProCoSys.Preservation.Command.ActionCommands.CreateAction
 
         public async Task<Result<int>> Handle(CreateActionCommand request, CancellationToken cancellationToken)
         {
-            var tag = await _projectRepository.GetTagByTagIdAsync(request.TagId);
+            var tag = await _projectRepository.GetTagWithActionsByTagIdAsync(request.TagId);
 
             var actionToAdd = new Action(
                  _plantProvider.Plant,

--- a/src/Equinor.ProCoSys.Preservation.Command/ActionCommands/UpdateAction/UpdateActionCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/ActionCommands/UpdateAction/UpdateActionCommandHandler.cs
@@ -21,7 +21,7 @@ namespace Equinor.ProCoSys.Preservation.Command.ActionCommands.UpdateAction
 
         public async Task<Result<string>> Handle(UpdateActionCommand request, CancellationToken cancellationToken)
         {
-            var tag = await _projectRepository.GetTagByTagIdAsync(request.TagId);
+            var tag = await _projectRepository.GetTagWithActionsByTagIdAsync(request.TagId);
             var action = tag.Actions.Single(a => a.Id == request.ActionId);
 
             action.Title = request.Title;

--- a/src/Equinor.ProCoSys.Preservation.Command/RequirementCommands/DeleteAttachment/DeleteFieldValueAttachmentCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/RequirementCommands/DeleteAttachment/DeleteFieldValueAttachmentCommandHandler.cs
@@ -34,7 +34,7 @@ namespace Equinor.ProCoSys.Preservation.Command.RequirementCommands.DeleteAttach
 
         public async Task<Result<Unit>> Handle(DeleteFieldValueAttachmentCommand request, CancellationToken cancellationToken)
         {
-            var tag = await _projectRepository.GetTagByTagIdAsync(request.TagId);
+            var tag = await _projectRepository.GetTagWithPreservationHistoryByTagIdAsync(request.TagId);
             var requirement = tag.Requirements.Single(r => r.Id == request.RequirementId);
 
             var requirementDefinition =

--- a/src/Equinor.ProCoSys.Preservation.Command/RequirementCommands/Preserve/PreserveCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/RequirementCommands/Preserve/PreserveCommandHandler.cs
@@ -29,7 +29,7 @@ namespace Equinor.ProCoSys.Preservation.Command.RequirementCommands.Preserve
 
         public async Task<Result<Unit>> Handle(PreserveCommand request, CancellationToken cancellationToken)
         {
-            var tag = await _projectRepository.GetTagByTagIdAsync(request.TagId);
+            var tag = await _projectRepository.GetTagWithPreservationHistoryByTagIdAsync(request.TagId);
             var currentUser = await _personRepository.GetByOidAsync(_currentUserProvider.GetCurrentUserOid());
 
             tag.Preserve(currentUser, request.RequirementId);

--- a/src/Equinor.ProCoSys.Preservation.Command/RequirementCommands/RecordValues/RecordValuesCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/RequirementCommands/RecordValues/RecordValuesCommandHandler.cs
@@ -28,7 +28,7 @@ namespace Equinor.ProCoSys.Preservation.Command.RequirementCommands.RecordValues
 
         public async Task<Result<Unit>> Handle(RecordValuesCommand request, CancellationToken cancellationToken)
         {
-            var tag = await _projectRepository.GetTagByTagIdAsync(request.TagId);
+            var tag = await _projectRepository.GetTagWithPreservationHistoryByTagIdAsync(request.TagId);
             var requirement = tag.Requirements.Single(r => r.Id == request.RequirementId);
 
             var requirementDefinition =

--- a/src/Equinor.ProCoSys.Preservation.Command/RequirementCommands/Upload/UploadFieldValueAttachmentCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/RequirementCommands/Upload/UploadFieldValueAttachmentCommandHandler.cs
@@ -39,7 +39,7 @@ namespace Equinor.ProCoSys.Preservation.Command.RequirementCommands.Upload
 
         public async Task<Result<int>> Handle(UploadFieldValueAttachmentCommand request, CancellationToken cancellationToken)
         {
-            var tag = await _projectRepository.GetTagByTagIdAsync(request.TagId);
+            var tag = await _projectRepository.GetTagWithPreservationHistoryByTagIdAsync(request.TagId);
             var requirement = tag.Requirements.Single(r => r.Id == request.RequirementId);
 
             var requirementDefinition =

--- a/src/Equinor.ProCoSys.Preservation.Command/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandHandler.cs
@@ -30,7 +30,7 @@ namespace Equinor.ProCoSys.Preservation.Command.TagAttachmentCommands.Delete
 
         public async Task<Result<Unit>> Handle(DeleteTagAttachmentCommand request, CancellationToken cancellationToken)
         {
-            var tag = await _projectRepository.GetTagByTagIdAsync(request.TagId);
+            var tag = await _projectRepository.GetTagWithAttachmentsHistoryByTagIdAsync(request.TagId);
 
             var attachment = tag.Attachments.Single(a => a.Id == request.AttachmentId);
             attachment.SetRowVersion(request.RowVersion);

--- a/src/Equinor.ProCoSys.Preservation.Command/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandHandler.cs
@@ -30,7 +30,7 @@ namespace Equinor.ProCoSys.Preservation.Command.TagAttachmentCommands.Delete
 
         public async Task<Result<Unit>> Handle(DeleteTagAttachmentCommand request, CancellationToken cancellationToken)
         {
-            var tag = await _projectRepository.GetTagWithAttachmentsHistoryByTagIdAsync(request.TagId);
+            var tag = await _projectRepository.GetTagWithAttachmentsByTagIdAsync(request.TagId);
 
             var attachment = tag.Attachments.Single(a => a.Id == request.AttachmentId);
             attachment.SetRowVersion(request.RowVersion);

--- a/src/Equinor.ProCoSys.Preservation.Command/TagAttachmentCommands/Upload/UploadTagAttachmentCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagAttachmentCommands/Upload/UploadTagAttachmentCommandHandler.cs
@@ -33,7 +33,7 @@ namespace Equinor.ProCoSys.Preservation.Command.TagAttachmentCommands.Upload
 
         public async Task<Result<int>> Handle(UploadTagAttachmentCommand request, CancellationToken cancellationToken)
         {
-            var tag = await _projectRepository.GetTagByTagIdAsync(request.TagId);
+            var tag = await _projectRepository.GetTagWithAttachmentsHistoryByTagIdAsync(request.TagId);
 
             var attachment = tag.GetAttachmentByFileName(request.FileName);
 

--- a/src/Equinor.ProCoSys.Preservation.Command/TagAttachmentCommands/Upload/UploadTagAttachmentCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagAttachmentCommands/Upload/UploadTagAttachmentCommandHandler.cs
@@ -33,7 +33,7 @@ namespace Equinor.ProCoSys.Preservation.Command.TagAttachmentCommands.Upload
 
         public async Task<Result<int>> Handle(UploadTagAttachmentCommand request, CancellationToken cancellationToken)
         {
-            var tag = await _projectRepository.GetTagWithAttachmentsHistoryByTagIdAsync(request.TagId);
+            var tag = await _projectRepository.GetTagWithAttachmentsByTagIdAsync(request.TagId);
 
             var attachment = tag.GetAttachmentByFileName(request.FileName);
 

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/BulkPreserve/BulkPreserveCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/BulkPreserve/BulkPreserveCommandHandler.cs
@@ -29,7 +29,7 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.BulkPreserve
 
         public async Task<Result<Unit>> Handle(BulkPreserveCommand request, CancellationToken cancellationToken)
         {
-            var tags = await _projectRepository.GetTagsByTagIdsAsync(request.TagIds);
+            var tags = await _projectRepository.GetTagsWithPreservationHistoryByTagIdsAsync(request.TagIds);
             var currentUser = await _personRepository.GetByOidAsync(_currentUserProvider.GetCurrentUserOid());
 
             foreach (var tag in tags)

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/CompletePreservation/CompletePreservationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/CompletePreservation/CompletePreservationCommandHandler.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Equinor.ProCoSys.Preservation.Command.TagCommands.Transfer;
 using Equinor.ProCoSys.Preservation.Domain;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.JourneyAggregate;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate;
@@ -26,8 +25,7 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.CompletePreservation
 
         public async Task<Result<IEnumerable<IdAndRowVersion>>> Handle(CompletePreservationCommand request, CancellationToken cancellationToken)
         {
-            var tags = await _projectRepository.GetTagsByTagIdsAsync(request.Tags.Select(x => x.Id));
-
+            var tags = await _projectRepository.GetTagsWithPreservationHistoryByTagIdsAsync(request.Tags.Select(x => x.Id));
             var stepIds = tags.Select(t => t.StepId).Distinct();
             var journeys = await _journeyRepository.GetJourneysByStepIdsAsync(stepIds);
 

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/DeleteTag/DeleteTagCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/DeleteTag/DeleteTagCommandHandler.cs
@@ -21,7 +21,7 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.DeleteTag
 
         public async Task<Result<Unit>> Handle(DeleteTagCommand request, CancellationToken cancellationToken)
         {
-            var project = await _projectRepository.GetProjectByTagIdAsync(request.TagId);
+            var project = await _projectRepository.GetProjectAndTagWithPreservationHistoryByTagIdAsync(request.TagId);
             var tag = project.Tags.Single(t => t.Id == request.TagId);
             
             tag.SetRowVersion(request.RowVersion);

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/DuplicateAreaTag/DuplicateAreaTagCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/DuplicateAreaTag/DuplicateAreaTagCommandHandler.cs
@@ -44,7 +44,7 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.DuplicateAreaTag
 
         public async Task<Result<int>> Handle(DuplicateAreaTagCommand request, CancellationToken cancellationToken)
         {
-            var sourceTag = await _projectRepository.GetTagByTagIdAsync(request.TagId);
+            var sourceTag = await _projectRepository.GetTagWithPreservationHistoryByTagIdAsync(request.TagId);
 
             var duplicatedTag = await DuplicateTagAsync(request, sourceTag);
 

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/Preserve/PreserveCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/Preserve/PreserveCommandHandler.cs
@@ -29,7 +29,7 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.Preserve
 
         public async Task<Result<Unit>> Handle(PreserveCommand request, CancellationToken cancellationToken)
         {
-            var tag = await _projectRepository.GetTagByTagIdAsync(request.TagId);
+            var tag = await _projectRepository.GetTagWithPreservationHistoryByTagIdAsync(request.TagId);
             var currentUser = await _personRepository.GetByOidAsync(_currentUserProvider.GetCurrentUserOid());
 
             tag.Preserve(currentUser);

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/Reschedule/RescheduleCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/Reschedule/RescheduleCommandHandler.cs
@@ -22,7 +22,7 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.Reschedule
 
         public async Task<Result<IEnumerable<IdAndRowVersion>>> Handle(RescheduleCommand request, CancellationToken cancellationToken)
         {
-            var tags = await _projectRepository.GetTagsByTagIdsAsync(request.Tags.Select(x => x.Id));
+            var tags = await _projectRepository.GetTagsWithPreservationHistoryByTagIdsAsync(request.Tags.Select(x => x.Id));
 
             foreach (var tag in tags)
             {

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/StartPreservation/StartPreservationCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/StartPreservation/StartPreservationCommandHandler.cs
@@ -20,7 +20,8 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.StartPreservation
 
         public async Task<Result<Unit>> Handle(StartPreservationCommand request, CancellationToken cancellationToken)
         {
-            var tags = await _projectRepository.GetTagsByTagIdsAsync(request.TagIds);
+            var tags = await _projectRepository.GetTagsWithPreservationHistoryByTagIdsAsync(request.TagIds);
+            
             foreach (var tag in tags)
             {
                 tag.StartPreservation();

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/Transfer/TransferCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/Transfer/TransferCommandHandler.cs
@@ -28,7 +28,7 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.Transfer
 
         public async Task<Result<IEnumerable<IdAndRowVersion>>> Handle(TransferCommand request, CancellationToken cancellationToken)
         {
-            var tags = await _projectRepository.GetTagsByTagIdsAsync(request.Tags.Select(x => x.Id));
+            var tags = await _projectRepository.GetTagsOnlyByTagIdsAsync(request.Tags.Select(x => x.Id));
 
             var stepIds = tags.Select(t => t.StepId).Distinct();
             var journeys = await _journeyRepository.GetJourneysByStepIdsAsync(stepIds);

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/UnvoidTag/UnvoidTagCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/UnvoidTag/UnvoidTagCommandHandler.cs
@@ -20,7 +20,7 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.UnvoidTag
 
         public async Task<Result<string>> Handle(UnvoidTagCommand request, CancellationToken cancellationToken)
         {
-            var tag = await _projectRepository.GetTagByTagIdAsync(request.TagId);
+            var tag = await _projectRepository.GetTagOnlyByTagIdAsync(request.TagId);
 
             tag.IsVoided = false;
             tag.SetRowVersion(request.RowVersion);

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/UpdateTag/UpdateTagCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/UpdateTag/UpdateTagCommandHandler.cs
@@ -21,7 +21,7 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.UpdateTag
 
         public async Task<Result<string>> Handle(UpdateTagCommand request, CancellationToken cancellationToken)
         {
-            var tag = await _projectRepository.GetTagByTagIdAsync(request.TagId);
+            var tag = await _projectRepository.GetTagOnlyByTagIdAsync(request.TagId);
 
             tag.StorageArea = request.StorageArea;
             tag.Remark = request.Remark;

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandHandler.cs
@@ -33,7 +33,7 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.UpdateTagStepAndRequ
 
         public async Task<Result<string>> Handle(UpdateTagStepAndRequirementsCommand request, CancellationToken cancellationToken)
         {
-            var tag = await _projectRepository.GetTagByTagIdAsync(request.TagId);
+            var tag = await _projectRepository.GetTagWithPreservationHistoryByTagIdAsync(request.TagId);
             var step = await _journeyRepository.GetStepByStepIdAsync(request.StepId);
 
             if (tag.IsAreaTag() && request.Description != null)

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/VoidTag/VoidTagCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/VoidTag/VoidTagCommandHandler.cs
@@ -20,7 +20,7 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.VoidTag
 
         public async Task<Result<string>> Handle(VoidTagCommand request, CancellationToken cancellationToken)
         {
-            var tag = await _projectRepository.GetTagByTagIdAsync(request.TagId);
+            var tag = await _projectRepository.GetTagOnlyByTagIdAsync(request.TagId);
 
             tag.IsVoided = true;
             tag.SetRowVersion(request.RowVersion);

--- a/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/ProjectAggregate/IProjectRepository.cs
+++ b/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/ProjectAggregate/IProjectRepository.cs
@@ -8,7 +8,6 @@ namespace Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate
         Task<Project> GetProjectOnlyByNameAsync(string projectName);
         Task<Tag> GetTagByTagIdAsync(int tagId);
         Task<List<Tag>> GetTagsByTagIdsAsync(IEnumerable<int> tagIds);
-        Task<List<Project>> GetAllProjectsOnlyAsync();
         Task<List<Tag>> GetStandardTagsInProjectOnlyAsync(string projectName);
         void RemoveTag(Tag tag);
         Task<List<Tag>> GetStandardTagsInProjectInStepsAsync(string projectName, IEnumerable<string> tagNos, IEnumerable<int> stepIds);

--- a/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/ProjectAggregate/IProjectRepository.cs
+++ b/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/ProjectAggregate/IProjectRepository.cs
@@ -7,6 +7,8 @@ namespace Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate
     {
         Task<Project> GetProjectOnlyByNameAsync(string projectName);
         Task<Tag> GetTagByTagIdAsync(int tagId);
+        Task<Tag> GetTagOnlyByTagIdAsync(int tagId);
+        Task<Tag> GetTagWithPreservationHistoryByTagIdAsync(int tagId);
         Task<List<Tag>> GetTagsByTagIdsAsync(IEnumerable<int> tagIds);
         Task<List<Tag>> GetStandardTagsInProjectOnlyAsync(string projectName);
         void RemoveTag(Tag tag);

--- a/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/ProjectAggregate/IProjectRepository.cs
+++ b/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/ProjectAggregate/IProjectRepository.cs
@@ -9,12 +9,13 @@ namespace Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate
         Task<Tag> GetTagOnlyByTagIdAsync(int tagId);
         Task<Tag> GetTagWithPreservationHistoryByTagIdAsync(int tagId);
         Task<Tag> GetTagWithActionsByTagIdAsync(int tagId);
-        Task<Tag> GetTagWithAttachmentsHistoryByTagIdAsync(int tagId);
-        Task<List<Tag>> GetTagsByTagIdsAsync(IEnumerable<int> tagIds);
+        Task<Tag> GetTagWithAttachmentsByTagIdAsync(int tagId);
+        Task<List<Tag>> GetTagsWithPreservationHistoryByTagIdsAsync(IEnumerable<int> tagIds);
+        Task<List<Tag>> GetTagsOnlyByTagIdsAsync(IEnumerable<int> tagIds);
         Task<List<Tag>> GetStandardTagsInProjectOnlyAsync(string projectName);
         void RemoveTag(Tag tag);
         Task<List<Tag>> GetStandardTagsInProjectInStepsAsync(string projectName, IEnumerable<string> tagNos, IEnumerable<int> stepIds);
-        Task<Project> GetProjectByTagIdAsync(int tagId);
+        Task<Project> GetProjectAndTagWithPreservationHistoryByTagIdAsync(int tagId);
         Task<Project> GetProjectOnlyByTagIdAsync(int tagId);
         Task<Project> GetProjectWithTagsByNameAsync(string projectName);
     }

--- a/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/ProjectAggregate/IProjectRepository.cs
+++ b/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/ProjectAggregate/IProjectRepository.cs
@@ -6,9 +6,10 @@ namespace Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate
     public interface IProjectRepository : IRepository<Project>
     {
         Task<Project> GetProjectOnlyByNameAsync(string projectName);
-        Task<Tag> GetTagByTagIdAsync(int tagId);
         Task<Tag> GetTagOnlyByTagIdAsync(int tagId);
         Task<Tag> GetTagWithPreservationHistoryByTagIdAsync(int tagId);
+        Task<Tag> GetTagWithActionsByTagIdAsync(int tagId);
+        Task<Tag> GetTagWithAttachmentsHistoryByTagIdAsync(int tagId);
         Task<List<Tag>> GetTagsByTagIdsAsync(IEnumerable<int> tagIds);
         Task<List<Tag>> GetStandardTagsInProjectOnlyAsync(string projectName);
         void RemoveTag(Tag tag);

--- a/src/Equinor.ProCoSys.Preservation.Infrastructure/Repositories/ProjectRepository.cs
+++ b/src/Equinor.ProCoSys.Preservation.Infrastructure/Repositories/ProjectRepository.cs
@@ -31,11 +31,6 @@ namespace Equinor.ProCoSys.Preservation.Infrastructure.Repositories
         public Task<Project> GetProjectWithTagsByNameAsync(string projectName)
             => Set.Include(p => p.Tags).SingleOrDefaultAsync(p => p.Name == projectName);
 
-        public Task<Tag> GetTagByTagIdAsync(int tagId)
-            => DefaultQuery
-                .SelectMany(project => project.Tags)
-                .SingleOrDefaultAsync(tag => tag.Id == tagId);
-
         public Task<Tag> GetTagOnlyByTagIdAsync(int tagId)
             => Set
                 .Include(p => p.Tags)
@@ -49,6 +44,21 @@ namespace Equinor.ProCoSys.Preservation.Infrastructure.Repositories
                     .ThenInclude(r => r.PreservationPeriods)
                     .ThenInclude(pp => pp.FieldValues)
                     .ThenInclude(fv => fv.FieldValueAttachment)
+                .SelectMany(project => project.Tags)
+                .SingleOrDefaultAsync(tag => tag.Id == tagId);
+
+        public Task<Tag> GetTagWithActionsByTagIdAsync(int tagId)
+            => Set
+                .Include(p => p.Tags)
+                    .ThenInclude(t => t.Actions)
+                    .ThenInclude(a => a.Attachments)
+                .SelectMany(project => project.Tags)
+                .SingleOrDefaultAsync(tag => tag.Id == tagId);
+
+        public Task<Tag> GetTagWithAttachmentsHistoryByTagIdAsync(int tagId)
+            => Set
+                .Include(p => p.Tags)
+                    .ThenInclude(t => t.Attachments)
                 .SelectMany(project => project.Tags)
                 .SingleOrDefaultAsync(tag => tag.Id == tagId);
 

--- a/src/Equinor.ProCoSys.Preservation.Infrastructure/Repositories/ProjectRepository.cs
+++ b/src/Equinor.ProCoSys.Preservation.Infrastructure/Repositories/ProjectRepository.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate;
@@ -34,6 +33,22 @@ namespace Equinor.ProCoSys.Preservation.Infrastructure.Repositories
 
         public Task<Tag> GetTagByTagIdAsync(int tagId)
             => DefaultQuery
+                .SelectMany(project => project.Tags)
+                .SingleOrDefaultAsync(tag => tag.Id == tagId);
+
+        public Task<Tag> GetTagOnlyByTagIdAsync(int tagId)
+            => Set
+                .Include(p => p.Tags)
+                .SelectMany(project => project.Tags)
+                .SingleOrDefaultAsync(tag => tag.Id == tagId);
+
+        public Task<Tag> GetTagWithPreservationHistoryByTagIdAsync(int tagId)
+            => Set
+                .Include(p => p.Tags)
+                    .ThenInclude(t => t.Requirements)
+                    .ThenInclude(r => r.PreservationPeriods)
+                    .ThenInclude(pp => pp.FieldValues)
+                    .ThenInclude(fv => fv.FieldValueAttachment)
                 .SelectMany(project => project.Tags)
                 .SingleOrDefaultAsync(tag => tag.Id == tagId);
 

--- a/src/Equinor.ProCoSys.Preservation.Infrastructure/Repositories/ProjectRepository.cs
+++ b/src/Equinor.ProCoSys.Preservation.Infrastructure/Repositories/ProjectRepository.cs
@@ -43,9 +43,6 @@ namespace Equinor.ProCoSys.Preservation.Infrastructure.Repositories
                 .Where(tag => tagIds.Contains(tag.Id))
                 .ToListAsync();
 
-        public Task<List<Project>> GetAllProjectsOnlyAsync()
-            => Set.ToListAsync();
-
         public Task<List<Tag>> GetStandardTagsInProjectOnlyAsync(string projectName)
             => Set.Where(project => project.Name == projectName)
                 .SelectMany(project => project.Tags)

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/ActionAttachmentCommands/Delete/DeleteActionAttachmentCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/ActionAttachmentCommands/Delete/DeleteActionAttachmentCommandHandlerTests.cs
@@ -22,7 +22,6 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.ActionAttachmentCommands.D
         private DeleteActionAttachmentCommand _command;
         private DeleteActionAttachmentCommandHandler _dut;
 
-        private Mock<IProjectRepository> _projectRepositoryMock;
         private Mock<IBlobStorage> _blobStorageMock;
         private Action _action;
 
@@ -31,7 +30,6 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.ActionAttachmentCommands.D
         {
             _command = new DeleteActionAttachmentCommand(1, 2, 3, _rowVersion);
 
-            _projectRepositoryMock = new Mock<IProjectRepository>();
             _blobStorageMock = new Mock<IBlobStorage>();
 
             var blobStorageOptionsMock = new Mock<IOptionsMonitor<BlobStorageOptions>>();
@@ -56,12 +54,13 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.ActionAttachmentCommands.D
             attachment.SetProtectedIdForTesting(_command.AttachmentId);
             _action.AddAttachment(attachment);
 
-            _projectRepositoryMock
-                .Setup(r => r.GetTagByTagIdAsync(_command.TagId))
+            var projectRepositoryMock = new Mock<IProjectRepository>();
+            projectRepositoryMock
+                .Setup(r => r.GetTagWithActionsByTagIdAsync(_command.TagId))
                 .Returns(Task.FromResult(tagMock.Object));
 
             _dut = new DeleteActionAttachmentCommandHandler(
-                _projectRepositoryMock.Object,
+                projectRepositoryMock.Object,
                 UnitOfWorkMock.Object,
                 _blobStorageMock.Object,
                 blobStorageOptionsMock.Object);

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/ActionAttachmentCommands/Upload/UploadActionAttachmentCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/ActionAttachmentCommands/Upload/UploadActionAttachmentCommandHandlerTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Preservation.BlobStorage;
 using Equinor.ProCoSys.Preservation.Command.ActionAttachmentCommands.Upload;
-using Equinor.ProCoSys.Preservation.Domain;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Equinor.ProCoSys.Preservation.Test.Common.ExtensionMethods;
 using Microsoft.Extensions.Options;
@@ -25,7 +24,6 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.ActionAttachmentCommands.U
         private UploadActionAttachmentCommand _commandWithoutOverwrite;
         private UploadActionAttachmentCommandHandler _dut;
 
-        private Mock<IProjectRepository> _projectRepositoryMock;
         private Mock<IBlobStorage> _blobStorageMock;
         private Action _action;
 
@@ -34,7 +32,6 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.ActionAttachmentCommands.U
         {
             _commandWithoutOverwrite = new UploadActionAttachmentCommand(_tagId, _actionId, _fileName, false, new MemoryStream());
 
-            _projectRepositoryMock = new Mock<IProjectRepository>();
             _blobStorageMock = new Mock<IBlobStorage>();
 
             var blobStorageOptionsMock = new Mock<IOptionsMonitor<BlobStorageOptions>>();
@@ -54,12 +51,13 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.ActionAttachmentCommands.U
             _action.SetProtectedIdForTesting(_commandWithoutOverwrite.ActionId);
             tagMock.Object.AddAction(_action);
 
-            _projectRepositoryMock
-                .Setup(r => r.GetTagByTagIdAsync(_tagId))
+            var projectRepositoryMock = new Mock<IProjectRepository>();
+            projectRepositoryMock
+                .Setup(r => r.GetTagWithActionsByTagIdAsync(_tagId))
                 .Returns(Task.FromResult(tagMock.Object));
 
             _dut = new UploadActionAttachmentCommandHandler(
-                _projectRepositoryMock.Object,
+                projectRepositoryMock.Object,
                 UnitOfWorkMock.Object,
                 PlantProviderMock.Object,
                 _blobStorageMock.Object,

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/ActionCommands/CloseAction/CloseActionCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/ActionCommands/CloseAction/CloseActionCommandHandlerTests.cs
@@ -20,17 +20,12 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.ActionCommands.CloseAction
         private CloseActionCommand _command;
         private CloseActionCommandHandler _dut;
 
-        private Mock<IProjectRepository> _projectRepositoryMock;
         private Action _action;
-        private Mock<IPersonRepository> _personRepositoryMock;
         private Mock<Person> _personMock;
 
         [TestInitialize]
         public void Setup()
         {
-            _projectRepositoryMock = new Mock<IProjectRepository>();
-            _personRepositoryMock = new Mock<IPersonRepository>();
-
             var tagId = 2;
             var tagMock = new Mock<Tag>();
             tagMock.SetupGet(t => t.Plant).Returns(TestPlant);
@@ -43,20 +38,22 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.ActionCommands.CloseAction
             _personMock = new Mock<Person>();
             _personMock.SetupGet(p => p.Id).Returns(_personId);
 
-            _projectRepositoryMock
-                .Setup(r => r.GetTagByTagIdAsync(tagId))
+            var projectRepositoryMock = new Mock<IProjectRepository>();
+            projectRepositoryMock
+                .Setup(r => r.GetTagWithActionsByTagIdAsync(tagId))
                 .Returns(Task.FromResult(tagMock.Object));
 
-            _personRepositoryMock
+            var personRepositoryMock = new Mock<IPersonRepository>();
+            personRepositoryMock
                 .Setup(p => p.GetByOidAsync(It.Is<Guid>(x => x == CurrentUserOid)))
                 .Returns(Task.FromResult(_personMock.Object));
 
             _command = new CloseActionCommand(tagId, actionId, _rowVersion);
 
             _dut = new CloseActionCommandHandler(
-                _projectRepositoryMock.Object,
+                projectRepositoryMock.Object,
                 UnitOfWorkMock.Object,
-                _personRepositoryMock.Object,
+                personRepositoryMock.Object,
                 CurrentUserProviderMock.Object
             );
         }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/ActionCommands/CreateAction/CreateActionCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/ActionCommands/CreateAction/CreateActionCommandHandlerTests.cs
@@ -22,15 +22,12 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.ActionCommands.CreateActio
         private CreateActionCommand _command;
         private CreateActionCommandHandler _dut;
 
-        private Mock<IProjectRepository> _projectRepositoryMock;
         private readonly int _rdId1 = 17;
         private readonly int _intervalWeeks = 2;
 
         [TestInitialize]
         public void Setup()
         {
-            _projectRepositoryMock = new Mock<IProjectRepository>();
-
             var stepMock = new Mock<Step>();
             stepMock.SetupGet(s => s.Plant).Returns(TestPlant);
 
@@ -41,14 +38,15 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.ActionCommands.CreateActio
             var requirement = new TagRequirement(TestPlant, _intervalWeeks, _rdMock.Object);
             _tag = new Tag(TestPlant, TagType.Standard, "", "", stepMock.Object, new List<TagRequirement> { requirement });
 
-            _projectRepositoryMock
-                .Setup(r => r.GetTagByTagIdAsync(_tagId))
+            var projectRepositoryMock = new Mock<IProjectRepository>();
+            projectRepositoryMock
+                .Setup(r => r.GetTagWithActionsByTagIdAsync(_tagId))
                 .Returns(Task.FromResult(_tag));
 
             _command = new CreateActionCommand(_tagId, _title, _description, _dueTimeUtc);
 
             _dut = new CreateActionCommandHandler(
-                _projectRepositoryMock.Object,
+                projectRepositoryMock.Object,
                 UnitOfWorkMock.Object,
                 PlantProviderMock.Object
                 );

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/ActionCommands/UpdateAction/UpdateActionCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/ActionCommands/UpdateAction/UpdateActionCommandHandlerTests.cs
@@ -24,14 +24,11 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.ActionCommands.UpdateActio
         private UpdateActionCommand _command;
         private UpdateActionCommandHandler _dut;
 
-        private Mock<IProjectRepository> _projectRepositoryMock;
         private Action _action;
 
         [TestInitialize]
         public void Setup()
         {
-            _projectRepositoryMock = new Mock<IProjectRepository>();
-
             var tagId = 2;
             var tagMock = new Mock<Tag>();
             tagMock.SetupGet(t => t.Plant).Returns(TestPlant);
@@ -41,14 +38,15 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.ActionCommands.UpdateActio
             _action.SetProtectedIdForTesting(actionId);
             tagMock.Object.AddAction(_action);
 
-            _projectRepositoryMock
-                .Setup(r => r.GetTagByTagIdAsync(tagId))
+            var projectRepositoryMock = new Mock<IProjectRepository>();
+            projectRepositoryMock
+                .Setup(r => r.GetTagWithActionsByTagIdAsync(tagId))
                 .Returns(Task.FromResult(tagMock.Object));
 
             _command = new UpdateActionCommand(tagId, actionId, _newTitle, _newDescription, _newDueTimeUtc, _rowVersion);
 
             _dut = new UpdateActionCommandHandler(
-                _projectRepositoryMock.Object,
+                projectRepositoryMock.Object,
                 UnitOfWorkMock.Object
             );
         }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/RequirementCommands/DeleteAttachment/DeleteFieldValueAttachmentCommandTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/RequirementCommands/DeleteAttachment/DeleteFieldValueAttachmentCommandTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Preservation.BlobStorage;
 using Equinor.ProCoSys.Preservation.Command.RequirementCommands.DeleteAttachment;
-using Equinor.ProCoSys.Preservation.Domain;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.JourneyAggregate;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
@@ -62,13 +61,13 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.RequirementCommands.Delete
             Assert.AreEqual(PreservationStatus.Active, tag.Status);
             Assert.IsTrue(_requirement.HasActivePeriod);
 
-            var _projectRepositoryMock = new Mock<IProjectRepository>();
-            _projectRepositoryMock
-                .Setup(r => r.GetTagByTagIdAsync(_tagId))
+            var projectRepositoryMock = new Mock<IProjectRepository>();
+            projectRepositoryMock
+                .Setup(r => r.GetTagWithPreservationHistoryByTagIdAsync(_tagId))
                 .Returns(Task.FromResult(tag));
 
-            var _rtRepositoryMock = new Mock<IRequirementTypeRepository>();
-            _rtRepositoryMock
+            var rtRepositoryMock = new Mock<IRequirementTypeRepository>();
+            rtRepositoryMock
                 .Setup(r => r.GetRequirementDefinitionByIdAsync(_reqId))
                 .Returns(Task.FromResult(_requirementDefinition.Object));
             
@@ -86,8 +85,8 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.RequirementCommands.Delete
                 .Returns(options);
 
             _dut = new DeleteFieldValueAttachmentCommandHandler(
-                _projectRepositoryMock.Object,
-                _rtRepositoryMock.Object,
+                projectRepositoryMock.Object,
+                rtRepositoryMock.Object,
                 UnitOfWorkMock.Object,
                 _blobStorageMock.Object,
                 blobStorageOptionsMock.Object);

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/RequirementCommands/Preserve/PreserveCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/RequirementCommands/Preserve/PreserveCommandHandlerTests.cs
@@ -29,8 +29,6 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.RequirementCommands.Preser
         private const int RequirementForOtherId = 72;
         private const int Interval = 2;
 
-        private Mock<IProjectRepository> _projectRepoMock;
-        private Mock<IPersonRepository> _personRepoMock;
         private PreserveCommand _commandForSupplierRequirement;
         private PreserveCommand _commandForOtherRequirement;
         private TagRequirement _requirementForSupplier;
@@ -79,11 +77,14 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.RequirementCommands.Preser
             });
             _tagInOtherStep.SetProtectedIdForTesting(TagInOtherStepId);
 
-            _projectRepoMock = new Mock<IProjectRepository>();
-            _projectRepoMock.Setup(r => r.GetTagByTagIdAsync(TagInSupplierStepId)).Returns(Task.FromResult(_tagInSupplierStep));
-            _projectRepoMock.Setup(r => r.GetTagByTagIdAsync(TagInOtherStepId)).Returns(Task.FromResult(_tagInOtherStep));
-            _personRepoMock = new Mock<IPersonRepository>();
-            _personRepoMock
+            var projectRepoMock = new Mock<IProjectRepository>();
+            projectRepoMock.Setup(r => r.GetTagWithPreservationHistoryByTagIdAsync(TagInSupplierStepId))
+                .Returns(Task.FromResult(_tagInSupplierStep));
+            projectRepoMock.Setup(r => r.GetTagWithPreservationHistoryByTagIdAsync(TagInOtherStepId))
+                .Returns(Task.FromResult(_tagInOtherStep));
+            
+            var personRepoMock = new Mock<IPersonRepository>();
+            personRepoMock
                 .Setup(p => p.GetByOidAsync(It.Is<Guid>(x => x == CurrentUserOid)))
                 .Returns(Task.FromResult(new Person(CurrentUserOid, "Test", "User")));
 
@@ -100,8 +101,8 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.RequirementCommands.Preser
             _initialPreservationPeriodForOtherRequirement = _requirementForOther.PreservationPeriods.Single();
 
             _dut = new PreserveCommandHandler(
-                _projectRepoMock.Object,
-                _personRepoMock.Object,
+                projectRepoMock.Object,
+                personRepoMock.Object,
                 UnitOfWorkMock.Object,
                 CurrentUserProviderMock.Object);
         }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/RequirementCommands/RecordValues/RecordValuesCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/RequirementCommands/RecordValues/RecordValuesCommandHandlerTests.cs
@@ -69,19 +69,19 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.RequirementCommands.Record
             Assert.AreEqual(PreservationStatus.Active, tag.Status);
             Assert.IsTrue(_requirement.HasActivePeriod);
 
-            var _projectRepositoryMock = new Mock<IProjectRepository>();
-            _projectRepositoryMock
-                .Setup(r => r.GetTagByTagIdAsync(_tagId))
+            var projectRepositoryMock = new Mock<IProjectRepository>();
+            projectRepositoryMock
+                .Setup(r => r.GetTagWithPreservationHistoryByTagIdAsync(_tagId))
                 .Returns(Task.FromResult(tag));
 
-            var _rtRepositoryMock = new Mock<IRequirementTypeRepository>();
-            _rtRepositoryMock
+            var rtRepositoryMock = new Mock<IRequirementTypeRepository>();
+            rtRepositoryMock
                 .Setup(r => r.GetRequirementDefinitionByIdAsync(_reqId))
                 .Returns(Task.FromResult(requirementDefinitionWith2FieldsMock.Object));
             
             _dut = new RecordValuesCommandHandler(
-                _projectRepositoryMock.Object,
-                _rtRepositoryMock.Object,
+                projectRepositoryMock.Object,
+                rtRepositoryMock.Object,
                 UnitOfWorkMock.Object);
         }
 

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/RequirementCommands/Upload/UploadFieldValueAttachmentCommandTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/RequirementCommands/Upload/UploadFieldValueAttachmentCommandTests.cs
@@ -65,13 +65,13 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.RequirementCommands.Upload
             Assert.AreEqual(PreservationStatus.Active, tag.Status);
             Assert.IsTrue(_requirement.HasActivePeriod);
 
-            var _projectRepositoryMock = new Mock<IProjectRepository>();
-            _projectRepositoryMock
-                .Setup(r => r.GetTagByTagIdAsync(_tagId))
+            var projectRepositoryMock = new Mock<IProjectRepository>();
+            projectRepositoryMock
+                .Setup(r => r.GetTagWithPreservationHistoryByTagIdAsync(_tagId))
                 .Returns(Task.FromResult(tag));
 
-            var _rtRepositoryMock = new Mock<IRequirementTypeRepository>();
-            _rtRepositoryMock
+            var rtRepositoryMock = new Mock<IRequirementTypeRepository>();
+            rtRepositoryMock
                 .Setup(r => r.GetRequirementDefinitionByIdAsync(_reqId))
                 .Returns(Task.FromResult(_requirementDefinition.Object));
             
@@ -89,8 +89,8 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.RequirementCommands.Upload
                 .Returns(options);
 
             _dut = new UploadFieldValueAttachmentCommandHandler(
-                _projectRepositoryMock.Object,
-                _rtRepositoryMock.Object,
+                projectRepositoryMock.Object,
+                rtRepositoryMock.Object,
                 UnitOfWorkMock.Object,
                 PlantProviderMock.Object,
                 _blobStorageMock.Object,

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandHandlerTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Preservation.BlobStorage;
 using Equinor.ProCoSys.Preservation.Command.TagAttachmentCommands.Delete;
-using Equinor.ProCoSys.Preservation.Domain;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.JourneyAggregate;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Equinor.ProCoSys.Preservation.Test.Common.ExtensionMethods;
@@ -24,7 +23,6 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagAttachmentCommands.Dele
         private DeleteTagAttachmentCommand _command;
         private DeleteTagAttachmentCommandHandler _dut;
 
-        private Mock<IProjectRepository> _projectRepositoryMock;
         private Mock<IBlobStorage> _blobStorageMock;
         private Tag _tag;
 
@@ -33,7 +31,6 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagAttachmentCommands.Dele
         {
             _command = new DeleteTagAttachmentCommand(1, 3, _rowVersion);
 
-            _projectRepositoryMock = new Mock<IProjectRepository>();
             _blobStorageMock = new Mock<IBlobStorage>();
 
             var blobStorageOptionsMock = new Mock<IOptionsMonitor<BlobStorageOptions>>();
@@ -59,12 +56,13 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagAttachmentCommands.Dele
             attachment.SetProtectedIdForTesting(_command.AttachmentId);
             _tag.AddAttachment(attachment);
 
-            _projectRepositoryMock
-                .Setup(r => r.GetTagByTagIdAsync(_command.TagId))
+            var projectRepositoryMock = new Mock<IProjectRepository>();
+            projectRepositoryMock
+                .Setup(r => r.GetTagWithAttachmentsHistoryByTagIdAsync(_command.TagId))
                 .Returns(Task.FromResult(_tag));
 
             _dut = new DeleteTagAttachmentCommandHandler(
-                _projectRepositoryMock.Object,
+                projectRepositoryMock.Object,
                 UnitOfWorkMock.Object,
                 _blobStorageMock.Object,
                 blobStorageOptionsMock.Object);

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagAttachmentCommands/Delete/DeleteTagAttachmentCommandHandlerTests.cs
@@ -58,7 +58,7 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagAttachmentCommands.Dele
 
             var projectRepositoryMock = new Mock<IProjectRepository>();
             projectRepositoryMock
-                .Setup(r => r.GetTagWithAttachmentsHistoryByTagIdAsync(_command.TagId))
+                .Setup(r => r.GetTagWithAttachmentsByTagIdAsync(_command.TagId))
                 .Returns(Task.FromResult(_tag));
 
             _dut = new DeleteTagAttachmentCommandHandler(

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagAttachmentCommands/Upload/UploadTagAttachmentCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagAttachmentCommands/Upload/UploadTagAttachmentCommandHandlerTests.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Preservation.BlobStorage;
 using Equinor.ProCoSys.Preservation.Command.TagAttachmentCommands.Upload;
-using Equinor.ProCoSys.Preservation.Domain;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.JourneyAggregate;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Microsoft.Extensions.Options;
@@ -23,7 +22,6 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagAttachmentCommands.Uplo
         private UploadTagAttachmentCommand _commandWithoutOverwrite;
         private UploadTagAttachmentCommandHandler _dut;
 
-        private Mock<IProjectRepository> _projectRepositoryMock;
         private Mock<IBlobStorage> _blobStorageMock;
         private Tag _tag;
         private readonly int _tagId = 2;
@@ -33,7 +31,6 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagAttachmentCommands.Uplo
         {
             _commandWithoutOverwrite = new UploadTagAttachmentCommand(_tagId, _fileName, false, new MemoryStream());
 
-            _projectRepositoryMock = new Mock<IProjectRepository>();
             _blobStorageMock = new Mock<IBlobStorage>();
 
             var blobStorageOptionsMock = new Mock<IOptionsMonitor<BlobStorageOptions>>();
@@ -55,12 +52,13 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagAttachmentCommands.Uplo
 
             _tag = new Tag(TestPlant, TagType.Standard, "", "", stepMock.Object, new List<TagRequirement> { reqMock.Object });
 
-            _projectRepositoryMock
-                .Setup(r => r.GetTagByTagIdAsync(_commandWithoutOverwrite.TagId))
+            var projectRepositoryMock = new Mock<IProjectRepository>();
+            projectRepositoryMock
+                .Setup(r => r.GetTagWithAttachmentsHistoryByTagIdAsync(_commandWithoutOverwrite.TagId))
                 .Returns(Task.FromResult(_tag));
 
             _dut = new UploadTagAttachmentCommandHandler(
-                _projectRepositoryMock.Object,
+                projectRepositoryMock.Object,
                 UnitOfWorkMock.Object,
                 PlantProviderMock.Object,
                 _blobStorageMock.Object,

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagAttachmentCommands/Upload/UploadTagAttachmentCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagAttachmentCommands/Upload/UploadTagAttachmentCommandHandlerTests.cs
@@ -54,7 +54,7 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagAttachmentCommands.Uplo
 
             var projectRepositoryMock = new Mock<IProjectRepository>();
             projectRepositoryMock
-                .Setup(r => r.GetTagWithAttachmentsHistoryByTagIdAsync(_commandWithoutOverwrite.TagId))
+                .Setup(r => r.GetTagWithAttachmentsByTagIdAsync(_commandWithoutOverwrite.TagId))
                 .Returns(Task.FromResult(_tag));
 
             _dut = new UploadTagAttachmentCommandHandler(

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/BulkPreserve/BulkPreserveCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/BulkPreserve/BulkPreserveCommandHandlerTests.cs
@@ -25,8 +25,6 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.BulkPreserve
         private const int TwoWeeksInterval = 2;
         private const int FourWeeksInterval = 4;
 
-        private Mock<IProjectRepository> _projectRepoMock;
-        private Mock<IPersonRepository> _personRepoMock;
         private BulkPreserveCommand _command;
         private Tag _tag1;
         private Tag _tag2;
@@ -64,10 +62,12 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.BulkPreserve
                 _tag1, _tag2
             };
             var tagIds = new List<int> {TagId1, TagId2};
-            _projectRepoMock = new Mock<IProjectRepository>();
-            _projectRepoMock.Setup(r => r.GetTagsByTagIdsAsync(tagIds)).Returns(Task.FromResult(tags));
-            _personRepoMock = new Mock<IPersonRepository>();
-            _personRepoMock
+            var projectRepoMock = new Mock<IProjectRepository>();
+            projectRepoMock.Setup(r => r.GetTagsWithPreservationHistoryByTagIdsAsync(tagIds))
+                .Returns(Task.FromResult(tags));
+            
+            var personRepoMock = new Mock<IPersonRepository>();
+            personRepoMock
                 .Setup(p => p.GetByOidAsync(It.Is<Guid>(x => x == CurrentUserOid)))
                 .Returns(Task.FromResult(new Person(CurrentUserOid, "Test", "User")));
             _command = new BulkPreserveCommand(tagIds);
@@ -76,8 +76,8 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.BulkPreserve
             _tag2.StartPreservation();
 
             _dut = new BulkPreserveCommandHandler(
-                _projectRepoMock.Object,
-                _personRepoMock.Object,
+                projectRepoMock.Object,
+                personRepoMock.Object,
                 UnitOfWorkMock.Object,
                 CurrentUserProviderMock.Object);
         }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/CompletePreservation/CompletePreservationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/CompletePreservation/CompletePreservationCommandHandlerTests.cs
@@ -15,7 +15,6 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.CompletePreser
     [TestClass]
     public class CompletePreservationCommandHandlerTests : CommandHandlerTestsBase
     {
-        private Mock<IProjectRepository> _projectRepoMock;
         private CompletePreservationCommand _command;
         private Tag _tag1;
         private Tag _tag2;
@@ -86,8 +85,9 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.CompletePreser
             var tagIds = new List<int> { tagId1, tagId2 };
             var tagIdsWithRowVersion = new List<IdAndRowVersion> { new IdAndRowVersion(tagId1, _rowVersion1), new IdAndRowVersion(tagId2, _rowVersion2) };
 
-            _projectRepoMock = new Mock<IProjectRepository>();
-            _projectRepoMock.Setup(r => r.GetTagsByTagIdsAsync(tagIds)).Returns(Task.FromResult(tags));
+            var projectRepoMock = new Mock<IProjectRepository>();
+            projectRepoMock.Setup(r => r.GetTagsWithPreservationHistoryByTagIdsAsync(tagIds))
+                .Returns(Task.FromResult(tags));
 
             var journeyRepoMock = new Mock<IJourneyRepository>();
             journeyRepoMock
@@ -96,7 +96,7 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.CompletePreser
             
             _command = new CompletePreservationCommand(tagIdsWithRowVersion);
 
-            _dut = new CompletePreservationCommandHandler(_projectRepoMock.Object, journeyRepoMock.Object, UnitOfWorkMock.Object);
+            _dut = new CompletePreservationCommandHandler(projectRepoMock.Object, journeyRepoMock.Object, UnitOfWorkMock.Object);
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/DeleteTag/DeleteTagCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/DeleteTag/DeleteTagCommandHandlerTests.cs
@@ -16,7 +16,6 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.DeleteTag
         private int _tagId = 2;
         private const string _projectName = "ProjectName";
         private const string _rowVersion = "AAAAAAAAABA=";
-        private Mock<IProjectRepository> _projectRepositoryMock;
         private DeleteTagCommand _command;
         private DeleteTagCommandHandler _dut;
         private Tag _tag;
@@ -33,8 +32,6 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.DeleteTag
             _rdMock.SetupGet(rd => rd.Id).Returns(2);
             _rdMock.SetupGet(rd => rd.Plant).Returns(TestPlant);
 
-            _projectRepositoryMock = new Mock<IProjectRepository>();
-
             var requirement = new TagRequirement(TestPlant, 2, _rdMock.Object);
             _tag = new Tag(TestPlant, TagType.Standard, "", "", _stepMock.Object, new List<TagRequirement> { requirement });
             _tag.SetProtectedIdForTesting(2);
@@ -43,12 +40,13 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.DeleteTag
             _project = new Project(TestPlant, _projectName, "");
             _project.AddTag(_tag);
             
-            _projectRepositoryMock
-                .Setup(x => x.GetProjectByTagIdAsync(_tag.Id))
+            var projectRepositoryMock = new Mock<IProjectRepository>();
+            projectRepositoryMock
+                .Setup(x => x.GetProjectAndTagWithPreservationHistoryByTagIdAsync(_tag.Id))
                 .Returns(Task.FromResult(_project));
             _command = new DeleteTagCommand(_tagId, _rowVersion);
 
-            _dut = new DeleteTagCommandHandler(_projectRepositoryMock.Object, UnitOfWorkMock.Object);
+            _dut = new DeleteTagCommandHandler(projectRepositoryMock.Object, UnitOfWorkMock.Object);
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/DuplicateAreaTag/DuplicateAreaTagCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/DuplicateAreaTag/DuplicateAreaTagCommandHandlerTests.cs
@@ -16,11 +16,6 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.DuplicateAreaT
     [TestClass]
     public class DuplicateAreaTagCommandHandlerTests : CommandHandlerTestsBase
     {
-        private Mock<IProjectRepository> _projectRepoMock;
-        private Mock<IJourneyRepository> _journeyRepositoryMock;
-        private Mock<IRequirementTypeRepository> _rtRepositoryMock;
-        private Mock<IDisciplineApiService> _disciplineApiServiceMock;
-        private Mock<IAreaApiService> _areaApiServiceMock;
         private DuplicateAreaTagCommand _command;
         private Tag _sourceTag;
         private TagRequirement _req1;
@@ -48,8 +43,8 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.DuplicateAreaT
             stepMock.SetupGet(s => s.Plant).Returns(TestPlant);
             stepMock.SetupGet(s => s.Id).Returns(_stepId);
                         
-            _journeyRepositoryMock = new Mock<IJourneyRepository>();
-            _journeyRepositoryMock
+            var journeyRepositoryMock = new Mock<IJourneyRepository>();
+            journeyRepositoryMock
                 .Setup(x => x.GetStepByStepIdAsync(_stepId))
                 .Returns(Task.FromResult(stepMock.Object));
 
@@ -60,8 +55,8 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.DuplicateAreaT
             _rd2Mock.SetupGet(rd => rd.Id).Returns(_rdId2);
             _rd2Mock.SetupGet(rd => rd.Plant).Returns(TestPlant);
             
-            _rtRepositoryMock = new Mock<IRequirementTypeRepository>();
-            _rtRepositoryMock
+            var rtRepositoryMock = new Mock<IRequirementTypeRepository>();
+            rtRepositoryMock
                 .Setup(r => r.GetRequirementDefinitionsByIdsAsync(new List<int> {_rdId1, _rdId2}))
                 .Returns(Task.FromResult(new List<RequirementDefinition> {_rd1Mock.Object, _rd2Mock.Object}));
 
@@ -82,14 +77,14 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.DuplicateAreaT
             _sourceTag.SetProtectedIdForTesting(_sourceTagId);
             _project.AddTag(_sourceTag);
 
-            _projectRepoMock = new Mock<IProjectRepository>();
-            _projectRepoMock.Setup(r => r.GetTagByTagIdAsync(_sourceTagId)).Returns(Task.FromResult(_sourceTag));
-            _projectRepoMock
+            var projectRepoMock = new Mock<IProjectRepository>();
+            projectRepoMock.Setup(r => r.GetTagWithPreservationHistoryByTagIdAsync(_sourceTagId)).Returns(Task.FromResult(_sourceTag));
+            projectRepoMock
                 .Setup(r => r.GetProjectOnlyByTagIdAsync(_sourceTagId)).Returns(Task.FromResult(_project));
             
             var disciplineCode = "D";
-            _disciplineApiServiceMock = new Mock<IDisciplineApiService>();
-            _disciplineApiServiceMock.Setup(s => s.TryGetDisciplineAsync(TestPlant, disciplineCode))
+            var disciplineApiServiceMock = new Mock<IDisciplineApiService>();
+            disciplineApiServiceMock.Setup(s => s.TryGetDisciplineAsync(TestPlant, disciplineCode))
                 .Returns(Task.FromResult(new PCSDiscipline
                 {
                     Code = disciplineCode,
@@ -97,8 +92,8 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.DuplicateAreaT
                 }));
 
             var areaCode = "A";
-            _areaApiServiceMock = new Mock<IAreaApiService>();
-            _areaApiServiceMock.Setup(s => s.TryGetAreaAsync(TestPlant, areaCode))
+            var areaApiServiceMock = new Mock<IAreaApiService>();
+            areaApiServiceMock.Setup(s => s.TryGetAreaAsync(TestPlant, areaCode))
                 .Returns(Task.FromResult(new PCSArea
                 {
                     Code = areaCode,
@@ -108,13 +103,13 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.DuplicateAreaT
             _command = new DuplicateAreaTagCommand(_sourceTagId,TagType.SiteArea, disciplineCode, areaCode, "-01", "Desc", "Rem", "SA");
 
             _dut = new DuplicateAreaTagCommandHandler(
-                _projectRepoMock.Object,
-                _journeyRepositoryMock.Object,
-                _rtRepositoryMock.Object,
+                projectRepoMock.Object,
+                journeyRepositoryMock.Object,
+                rtRepositoryMock.Object,
                 UnitOfWorkMock.Object,
                 PlantProviderMock.Object,
-                _disciplineApiServiceMock.Object,
-                _areaApiServiceMock.Object);
+                disciplineApiServiceMock.Object,
+                areaApiServiceMock.Object);
         }
         
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/Preserve/PreserveCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/Preserve/PreserveCommandHandlerTests.cs
@@ -28,8 +28,6 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.Preserve
         private const int TwoWeeksInterval = 2;
         private const int FourWeeksInterval = 4;
 
-        private Mock<IProjectRepository> _projectRepoMock;
-        private Mock<IPersonRepository> _personRepoMock;
         private PreserveCommand _commandForTagWithForAllRequirements;
         private PreserveCommand _commandForTagInSupplierStep;
         private PreserveCommand _commandForTagInOtherStep;
@@ -91,13 +89,16 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.Preserve
                 _reqForOtherInOtherStep
             });
 
-            _projectRepoMock = new Mock<IProjectRepository>();
-            _projectRepoMock.Setup(r => r.GetTagByTagIdAsync(TagWithForAllRequirementsId)).Returns(Task.FromResult(_tagWithForAllRequirements));
-            _projectRepoMock.Setup(r => r.GetTagByTagIdAsync(TagInOtherStepId)).Returns(Task.FromResult(_tagWithSupplierAndOtherRequirementsInOtherStep));
-            _projectRepoMock.Setup(r => r.GetTagByTagIdAsync(TagInSupplierStepId)).Returns(Task.FromResult(_tagWithSupplierAndOtherRequirementsInSupplierStep));
+            var projectRepoMock = new Mock<IProjectRepository>();
+            projectRepoMock.Setup(r => r.GetTagWithPreservationHistoryByTagIdAsync(TagWithForAllRequirementsId))
+                .Returns(Task.FromResult(_tagWithForAllRequirements));
+            projectRepoMock.Setup(r => r.GetTagWithPreservationHistoryByTagIdAsync(TagInOtherStepId))
+                .Returns(Task.FromResult(_tagWithSupplierAndOtherRequirementsInOtherStep));
+            projectRepoMock.Setup(r => r.GetTagWithPreservationHistoryByTagIdAsync(TagInSupplierStepId))
+                .Returns(Task.FromResult(_tagWithSupplierAndOtherRequirementsInSupplierStep));
             
-            _personRepoMock = new Mock<IPersonRepository>();
-            _personRepoMock
+            var personRepoMock = new Mock<IPersonRepository>();
+            personRepoMock
                 .Setup(p => p.GetByOidAsync(It.Is<Guid>(x => x == CurrentUserOid)))
                 .Returns(Task.FromResult(new Person(CurrentUserOid, "Test", "User")));
             _commandForTagWithForAllRequirements = new PreserveCommand(TagWithForAllRequirementsId);
@@ -109,8 +110,8 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.Preserve
             _tagWithSupplierAndOtherRequirementsInSupplierStep.StartPreservation();
 
             _dut = new PreserveCommandHandler(
-                _projectRepoMock.Object,
-                _personRepoMock.Object,
+                projectRepoMock.Object,
+                personRepoMock.Object,
                 UnitOfWorkMock.Object,
                 CurrentUserProviderMock.Object);
         }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/Reschedule/RescheduleCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/Reschedule/RescheduleCommandHandlerTests.cs
@@ -16,7 +16,6 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.Reschedule
     [TestClass]
     public class RescheduleCommandHandlerTests : CommandHandlerTestsBase
     {
-        private Mock<IProjectRepository> _projectRepoMock;
         private RescheduleCommand _rescheduleOneWeekLaterCommand;
         private RescheduleCommand _rescheduleFourWeeksEarlierCommand;
         private const string _rowVersion1 = "AAAAAAAAABA=";
@@ -71,12 +70,14 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.Reschedule
             {
                 new IdAndRowVersion(_tagId1, _rowVersion1), new IdAndRowVersion(_tagId2, _rowVersion2)
             };
-            _projectRepoMock = new Mock<IProjectRepository>();
-            _projectRepoMock.Setup(r => r.GetTagsByTagIdsAsync(tagIds)).Returns(Task.FromResult(tags));
+            
+            var projectRepoMock = new Mock<IProjectRepository>();
+            projectRepoMock.Setup(r => r.GetTagsWithPreservationHistoryByTagIdsAsync(tagIds))
+                .Returns(Task.FromResult(tags));
             _rescheduleOneWeekLaterCommand = new RescheduleCommand(tagIdsWithRowVersion, 1, RescheduledDirection.Later, "Comment");
             _rescheduleFourWeeksEarlierCommand = new RescheduleCommand(tagIdsWithRowVersion, 4, RescheduledDirection.Earlier, "Comment");
 
-            _dut = new RescheduleCommandHandler(_projectRepoMock.Object, UnitOfWorkMock.Object);
+            _dut = new RescheduleCommandHandler(projectRepoMock.Object, UnitOfWorkMock.Object);
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/StartPreservation/StartPreservationCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/StartPreservation/StartPreservationCommandHandlerTests.cs
@@ -14,7 +14,6 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.StartPreservat
     [TestClass]
     public class StartPreservationCommandHandlerTests : CommandHandlerTestsBase
     {
-        private Mock<IProjectRepository> _projectRepoMock;
         private StartPreservationCommand _command;
         private Tag _tag1;
         private Tag _tag2;
@@ -63,11 +62,12 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.StartPreservat
             };
 
             var tagIds = new List<int> {_tagId1, _tagId2};
-            _projectRepoMock = new Mock<IProjectRepository>();
-            _projectRepoMock.Setup(r => r.GetTagsByTagIdsAsync(tagIds)).Returns(Task.FromResult(tags));
+            var projectRepoMock = new Mock<IProjectRepository>();
+            projectRepoMock.Setup(r => r.GetTagsWithPreservationHistoryByTagIdsAsync(tagIds))
+                .Returns(Task.FromResult(tags));
             _command = new StartPreservationCommand(tagIds);
 
-            _dut = new StartPreservationCommandHandler(_projectRepoMock.Object, UnitOfWorkMock.Object);
+            _dut = new StartPreservationCommandHandler(projectRepoMock.Object, UnitOfWorkMock.Object);
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/Transfer/TransferCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/Transfer/TransferCommandHandlerTests.cs
@@ -82,7 +82,7 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.Transfer
             var tagIds = new List<int> {tagId1, tagId2};
             var tagIdsWithRowVersion = new List<IdAndRowVersion> {new IdAndRowVersion(tagId1, _rowVersion1), new IdAndRowVersion(tagId2, _rowVersion2)};
             projectRepoMock
-                .Setup(r => r.GetTagsByTagIdsAsync(tagIds))
+                .Setup(r => r.GetTagsOnlyByTagIdsAsync(tagIds))
                 .Returns(Task.FromResult(new List<Tag> {_tag1, _tag2}));
 
             _command = new TransferCommand(tagIdsWithRowVersion);

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/UnvoidTag/UnvoidTagCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/UnvoidTag/UnvoidTagCommandHandlerTests.cs
@@ -22,7 +22,6 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.UnvoidTag
         public void Setup()
         {
             var tagId = 2;
-            var projectRepositoryMock = new Mock<IProjectRepository>();
 
             var stepMock = new Mock<Step>();
             stepMock.SetupGet(s => s.Plant).Returns(TestPlant);
@@ -34,8 +33,9 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.UnvoidTag
             _tag = new Tag(TestPlant, TagType.Standard, "", "", stepMock.Object,
                 new List<TagRequirement> {requirement});
 
+            var projectRepositoryMock = new Mock<IProjectRepository>();
             projectRepositoryMock
-                .Setup(r => r.GetTagByTagIdAsync(tagId))
+                .Setup(r => r.GetTagOnlyByTagIdAsync(tagId))
                 .Returns(Task.FromResult(_tag));
 
             _command = new UnvoidTagCommand(tagId, _rowVersion);

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandHandlerTests.cs
@@ -26,13 +26,9 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.UpdateTag
         private UpdateTagCommand _command;
         private UpdateTagCommandHandler _dut;
 
-        private Mock<IProjectRepository> _projectRepositoryMock;
-
         [TestInitialize]
         public void Setup()
         {
-            _projectRepositoryMock = new Mock<IProjectRepository>();
-
             var stepMock = new Mock<Step>();
             stepMock.SetupGet(s => s.Plant).Returns(TestPlant);
 
@@ -48,14 +44,15 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.UpdateTag
             };
 
             var tagId = 2;
-            _projectRepositoryMock
-                .Setup(r => r.GetTagByTagIdAsync(tagId))
+            var projectRepositoryMock = new Mock<IProjectRepository>();
+            projectRepositoryMock
+                .Setup(r => r.GetTagOnlyByTagIdAsync(tagId))
                 .Returns(Task.FromResult(_tag));
 
             _command = new UpdateTagCommand(tagId, _newRemark, _newStorageArea, _rowVersion);
 
             _dut = new UpdateTagCommandHandler(
-                _projectRepositoryMock.Object,
+                projectRepositoryMock.Object,
                 UnitOfWorkMock.Object);
         }
 

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/UpdateTagStepAndRequirements/UpdateTagStepAndRequirementsCommandHandlerTests.cs
@@ -28,9 +28,6 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
 
         private Mock<Step> _stepMock1;
         private Mock<Step> _stepMock2;
-        private Mock<IJourneyRepository> _journeyRepositoryMock;
-        private Mock<IProjectRepository> _projectRepositoryMock;
-        private Mock<IRequirementTypeRepository> _rtRepositoryMock;
         private Tag _areaTagWithOneRequirement;
         private Tag _standardTagWithOneRequirement;
         private Tag _standardTagWithTwoRequirements;
@@ -52,14 +49,14 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
             _stepMock2.SetupGet(s => s.Id).Returns(StepId2);
             _stepMock2.SetupGet(s => s.Plant).Returns(TestPlant);
 
-            _rtRepositoryMock = new Mock<IRequirementTypeRepository>();
+            var rtRepositoryMock = new Mock<IRequirementTypeRepository>();
             var rdMock1 = new Mock<RequirementDefinition>();
             rdMock1.SetupGet(x => x.Id).Returns(ReqDefId1);
             rdMock1.SetupGet(x => x.Plant).Returns(TestPlant);
             var rdMock2 = new Mock<RequirementDefinition>();
             rdMock2.SetupGet(x => x.Id).Returns(ReqDefId2);
             rdMock2.SetupGet(x => x.Plant).Returns(TestPlant);
-            _rtRepositoryMock
+            rtRepositoryMock
                 .Setup(r => r.GetRequirementDefinitionByIdAsync(ReqDefId2))
                 .Returns(Task.FromResult(rdMock2.Object));
 
@@ -86,23 +83,26 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.UpdateTagStepA
                 _tagRequirement1OnAreaTag
             });
 
-            _journeyRepositoryMock = new Mock<IJourneyRepository>();
-            _journeyRepositoryMock
+            var journeyRepositoryMock = new Mock<IJourneyRepository>();
+            journeyRepositoryMock
                 .Setup(x => x.GetStepByStepIdAsync(StepId1))
                 .Returns(Task.FromResult(_stepMock1.Object));
-            _journeyRepositoryMock
+            journeyRepositoryMock
                 .Setup(x => x.GetStepByStepIdAsync(StepId2))
                 .Returns(Task.FromResult(_stepMock2.Object));
 
-            _projectRepositoryMock = new Mock<IProjectRepository>();
-            _projectRepositoryMock.Setup(p => p.GetTagByTagIdAsync(StandardTagId1)).Returns(Task.FromResult(_standardTagWithOneRequirement));
-            _projectRepositoryMock.Setup(p => p.GetTagByTagIdAsync(StandardTagId2)).Returns(Task.FromResult(_standardTagWithTwoRequirements));
-            _projectRepositoryMock.Setup(p => p.GetTagByTagIdAsync(AreaTagId)).Returns(Task.FromResult(_areaTagWithOneRequirement));
+            var projectRepositoryMock = new Mock<IProjectRepository>();
+            projectRepositoryMock.Setup(p => p.GetTagWithPreservationHistoryByTagIdAsync(StandardTagId1))
+                .Returns(Task.FromResult(_standardTagWithOneRequirement));
+            projectRepositoryMock.Setup(p => p.GetTagWithPreservationHistoryByTagIdAsync(StandardTagId2))
+                .Returns(Task.FromResult(_standardTagWithTwoRequirements));
+            projectRepositoryMock.Setup(p => p.GetTagWithPreservationHistoryByTagIdAsync(AreaTagId))
+                .Returns(Task.FromResult(_areaTagWithOneRequirement));
 
             _dut = new UpdateTagStepAndRequirementsCommandHandler(
-                _projectRepositoryMock.Object,
-                _journeyRepositoryMock.Object,
-                _rtRepositoryMock.Object,
+                projectRepositoryMock.Object,
+                journeyRepositoryMock.Object,
+                rtRepositoryMock.Object,
                 UnitOfWorkMock.Object,
                 PlantProviderMock.Object);
 

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/VoidTag/VoidTagCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/VoidTag/VoidTagCommandHandlerTests.cs
@@ -22,7 +22,6 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.VoidTag
         public void Setup()
         {
             var tagId = 2;
-            var projectRepositoryMock = new Mock<IProjectRepository>();
 
             var stepMock = new Mock<Step>();
             stepMock.SetupGet(s => s.Plant).Returns(TestPlant);
@@ -34,8 +33,9 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.VoidTag
             _tag = new Tag(TestPlant, TagType.Standard, "", "", stepMock.Object,
                 new List<TagRequirement> {requirement});
 
+            var projectRepositoryMock = new Mock<IProjectRepository>();
             projectRepositoryMock
-                .Setup(r => r.GetTagByTagIdAsync(tagId))
+                .Setup(r => r.GetTagOnlyByTagIdAsync(tagId))
                 .Returns(Task.FromResult(_tag));
 
             _command = new VoidTagCommand(tagId, _rowVersion);

--- a/src/tests/Equinor.ProCoSys.Preservation.Infrastructure.Tests/Repositories/ProjectRepositoryTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Infrastructure.Tests/Repositories/ProjectRepositoryTests.cs
@@ -127,16 +127,6 @@ namespace Equinor.ProCoSys.Preservation.Infrastructure.Tests.Repositories
         }
 
         [TestMethod]
-        public async Task GetAllProjectsOnlyAsync_ShouldReturnProjectsWithoutTags()
-        {
-            var result = await _dut.GetAllProjectsOnlyAsync();
-
-            Assert.AreEqual(2, result.Count);
-            // Not able to test that Projects don't have Tag as children. BuildMockDbSet seem to build Set as a graph with all children
-            //Assert.IsTrue(result.All(p => p.Tags.Count == 0));
-        }
-
-        [TestMethod]
         public async Task GetProjectOnlyByNameAsync_UnknownProject_ShouldReturnNull()
         {
             var result = await _dut.GetProjectOnlyByNameAsync("XYZ");

--- a/src/tests/Equinor.ProCoSys.Preservation.Infrastructure.Tests/Repositories/ProjectRepositoryTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Infrastructure.Tests/Repositories/ProjectRepositoryTests.cs
@@ -142,9 +142,9 @@ namespace Equinor.ProCoSys.Preservation.Infrastructure.Tests.Repositories
         }
 
         [TestMethod]
-        public async Task GetTagWithAttachmentsHistoryByTagId_ShouldReturnTag()
+        public async Task GetTagWithAttachmentsByTagId_ShouldReturnTag()
         {
-            var result = await _dut.GetTagWithAttachmentsHistoryByTagIdAsync(StandardTagId1);
+            var result = await _dut.GetTagWithAttachmentsByTagIdAsync(StandardTagId1);
 
             Assert.AreEqual(StandardTagId1, result.Id);
         }
@@ -166,18 +166,35 @@ namespace Equinor.ProCoSys.Preservation.Infrastructure.Tests.Repositories
         }
 
         [TestMethod]
-        public async Task GetTagsByTagIdsAsync_KnownTag_ShouldReturnTag()
+        public async Task GetTagsOnlyByTagIdsAsync_KnownTag_ShouldReturnTag()
         {
-            var result = await _dut.GetTagsByTagIdsAsync(new List<int> {StandardTagId1});
+            var result = await _dut.GetTagsOnlyByTagIdsAsync(new List<int> {StandardTagId1});
 
             Assert.AreEqual(1, result.Count);
             Assert.AreEqual(StandardTagId1, result.First().Id);
         }
 
         [TestMethod]
-        public async Task GetTagsByTagIdsAsync_UnknownTag_ShouldReturnEmptyList()
+        public async Task GetTagsOnlyByTagIdsAsync_UnknownTag_ShouldReturnEmptyList()
         {
-            var result = await _dut.GetTagsByTagIdsAsync(new List<int> {9187});
+            var result = await _dut.GetTagsOnlyByTagIdsAsync(new List<int> {9187});
+
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [TestMethod]
+        public async Task GetTagsWithPreservationHistoryByTagIdsAsync_KnownTag_ShouldReturnTag()
+        {
+            var result = await _dut.GetTagsWithPreservationHistoryByTagIdsAsync(new List<int> {StandardTagId1});
+
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(StandardTagId1, result.First().Id);
+        }
+
+        [TestMethod]
+        public async Task GetTagsWithPreservationHistoryByTagIdsAsync_UnknownTag_ShouldReturnEmptyList()
+        {
+            var result = await _dut.GetTagsWithPreservationHistoryByTagIdsAsync(new List<int> {9187});
 
             Assert.AreEqual(0, result.Count);
         }
@@ -216,10 +233,10 @@ namespace Equinor.ProCoSys.Preservation.Infrastructure.Tests.Repositories
         }
 
         [TestMethod]
-        public async Task GetProjectByTagIdAsync_KnownTag_ShouldReturnProjectIncludingTheTag()
+        public async Task GetProjectAndTagWithPreservationHistoryByTagIdAsync_KnownTag_ShouldReturnProjectIncludingTheTag()
         {
             // Act
-            var project = await _dut.GetProjectByTagIdAsync(StandardTagId1);
+            var project = await _dut.GetProjectAndTagWithPreservationHistoryByTagIdAsync(StandardTagId1);
 
             // Assert
             Assert.IsNotNull(project);
@@ -230,10 +247,10 @@ namespace Equinor.ProCoSys.Preservation.Infrastructure.Tests.Repositories
         }
 
         [TestMethod]
-        public async Task GetProjectByTagIdAsync_UnknownTag_ShouldReturnNull()
+        public async Task GetProjectAndTagWithPreservationHistoryByTagIdAsync_UnknownTag_ShouldReturnNull()
         {
             // Act
-            var project = await _dut.GetProjectByTagIdAsync(234234);
+            var project = await _dut.GetProjectAndTagWithPreservationHistoryByTagIdAsync(234234);
 
             // Assert
             Assert.IsNull(project);

--- a/src/tests/Equinor.ProCoSys.Preservation.Infrastructure.Tests/Repositories/ProjectRepositoryTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Infrastructure.Tests/Repositories/ProjectRepositoryTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.JourneyAggregate;
@@ -138,6 +137,22 @@ namespace Equinor.ProCoSys.Preservation.Infrastructure.Tests.Repositories
         public async Task GetTagByTagId_ShouldReturnTag()
         {
             var result = await _dut.GetTagByTagIdAsync(StandardTagId1);
+
+            Assert.AreEqual(StandardTagId1, result.Id);
+        }
+
+        [TestMethod]
+        public async Task GetTagOnlyByTagId_ShouldReturnTag()
+        {
+            var result = await _dut.GetTagOnlyByTagIdAsync(StandardTagId1);
+
+            Assert.AreEqual(StandardTagId1, result.Id);
+        }
+
+        [TestMethod]
+        public async Task GetTagWithPreservationHistoryByTagId_ShouldReturnTag()
+        {
+            var result = await _dut.GetTagWithPreservationHistoryByTagIdAsync(StandardTagId1);
 
             Assert.AreEqual(StandardTagId1, result.Id);
         }

--- a/src/tests/Equinor.ProCoSys.Preservation.Infrastructure.Tests/Repositories/ProjectRepositoryTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Infrastructure.Tests/Repositories/ProjectRepositoryTests.cs
@@ -134,9 +134,17 @@ namespace Equinor.ProCoSys.Preservation.Infrastructure.Tests.Repositories
         }
 
         [TestMethod]
-        public async Task GetTagByTagId_ShouldReturnTag()
+        public async Task GetTagWithActionsByTagId_ShouldReturnTag()
         {
-            var result = await _dut.GetTagByTagIdAsync(StandardTagId1);
+            var result = await _dut.GetTagWithActionsByTagIdAsync(StandardTagId1);
+
+            Assert.AreEqual(StandardTagId1, result.Id);
+        }
+
+        [TestMethod]
+        public async Task GetTagWithAttachmentsHistoryByTagId_ShouldReturnTag()
+        {
+            var result = await _dut.GetTagWithAttachmentsHistoryByTagIdAsync(StandardTagId1);
 
             Assert.AreEqual(StandardTagId1, result.Id);
         }

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerNegativeTests.cs
@@ -64,39 +64,39 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
 
         }
 
-        #region GetAllTags
+        #region GetPageOfTags
         [TestMethod]
-        public async Task GetAllTags_AsAnonymous_ShouldReturnUnauthorized()
-            => await TagsControllerTestsHelper.GetAllTagsAsync(
+        public async Task GetPageOfTags_AsAnonymous_ShouldReturnUnauthorized()
+            => await TagsControllerTestsHelper.GetPageOfTagsAsync(
                 UserType.Anonymous, TestFactory.UnknownPlant,
                 TestFactory.ProjectWithAccess,
                 HttpStatusCode.Unauthorized);
 
         [TestMethod]
-        public async Task GetAllTags_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
-            => await TagsControllerTestsHelper.GetAllTagsAsync(
+        public async Task GetPageOfTags_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await TagsControllerTestsHelper.GetPageOfTagsAsync(
                 UserType.Hacker, TestFactory.UnknownPlant,
                 TestFactory.ProjectWithAccess,
                 HttpStatusCode.Forbidden);
 
         [TestMethod]
-        public async Task GetAllTags_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
-            => await TagsControllerTestsHelper.GetAllTagsAsync(
+        public async Task GetPageOfTags_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await TagsControllerTestsHelper.GetPageOfTagsAsync(
                 UserType.LibraryAdmin, TestFactory.UnknownPlant,
                 TestFactory.ProjectWithAccess,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
 
         [TestMethod]
-        public async Task GetAllTags_AsHacker_ShouldReturnForbidden_WhenPermissionMissing()
-            => await TagsControllerTestsHelper.GetAllTagsAsync(
+        public async Task GetPageOfTags_AsHacker_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.GetPageOfTagsAsync(
                 UserType.Hacker, TestFactory.PlantWithAccess,
                 TestFactory.ProjectWithAccess,
                 HttpStatusCode.Forbidden);
 
         [TestMethod]
-        public async Task GetAllTags_AsAdmin_ShouldReturnForbidden_WhenPermissionMissing()
-            => await TagsControllerTestsHelper.GetAllTagsAsync(
+        public async Task GetPageOfTags_AsAdmin_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.GetPageOfTagsAsync(
                 UserType.LibraryAdmin, TestFactory.PlantWithAccess,
                 TestFactory.ProjectWithAccess,
                 HttpStatusCode.Forbidden);
@@ -1454,7 +1454,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         public async Task Transfer_AsPlanner_ShouldReturnBadRequest_WhenIllegalRowVersion()
         {
             // Arrange 
-            var tagResultDto = await TagsControllerTestsHelper.GetAllTagsAsync(
+            var tagResultDto = await TagsControllerTestsHelper.GetPageOfTagsAsync(
                 UserType.Planner, TestFactory.PlantWithAccess,
                 TestFactory.ProjectWithAccess);
             var tagToTransfer = tagResultDto.Tags.FirstOrDefault(t => t.ReadyToBeTransferred);
@@ -1550,7 +1550,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
                 null);
             await TagsControllerTestsHelper.StartPreservationAsync(UserType.Planner, TestFactory.PlantWithAccess, new List<int> {newTagId});
 
-            var tagsResult = await TagsControllerTestsHelper.GetAllTagsAsync(
+            var tagsResult = await TagsControllerTestsHelper.GetPageOfTagsAsync(
                 UserType.Planner, TestFactory.PlantWithAccess,
                 TestFactory.ProjectWithAccess);
             var tagToCompletedPreservation = tagsResult.Tags.Single(t => t.Id == newTagId);
@@ -1853,6 +1853,108 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
                 9999,
                 HttpStatusCode.NotFound);
 
+        #endregion
+        
+        #region VoidTag
+        [TestMethod]
+        public async Task VoidTag_AsAnonymous_ShouldReturnUnauthorized()
+            => await TagsControllerTestsHelper.VoidTagAsync(
+                UserType.Anonymous, TestFactory.UnknownPlant,
+                9999,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task VoidTag_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await TagsControllerTestsHelper.VoidTagAsync(
+                UserType.Hacker, TestFactory.UnknownPlant,
+                9999,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidTag_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await TagsControllerTestsHelper.VoidTagAsync(
+                UserType.LibraryAdmin, TestFactory.UnknownPlant,
+                9999,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                expectedMessageOnBadRequest:"is not a valid plant");
+
+        [TestMethod]
+        public async Task VoidTag_AsHacker_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.VoidTagAsync(
+                UserType.Hacker, TestFactory.PlantWithAccess,
+                9999,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidTag_AsAdmin_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.VoidTagAsync(
+                UserType.LibraryAdmin, TestFactory.PlantWithAccess,
+                9999,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidTag_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.VoidTagAsync(
+                UserType.Preserver, TestFactory.PlantWithAccess,
+                9999,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+        #endregion
+        
+        #region UnvoidTag
+        [TestMethod]
+        public async Task UnvoidTag_AsAnonymous_ShouldReturnUnauthorized()
+            => await TagsControllerTestsHelper.UnvoidTagAsync(
+                UserType.Anonymous, TestFactory.UnknownPlant,
+                9999,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task UnvoidTag_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await TagsControllerTestsHelper.UnvoidTagAsync(
+                UserType.Hacker, TestFactory.UnknownPlant,
+                9999,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidTag_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await TagsControllerTestsHelper.UnvoidTagAsync(
+                UserType.LibraryAdmin, TestFactory.UnknownPlant,
+                9999,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                expectedMessageOnBadRequest:"is not a valid plant");
+
+        [TestMethod]
+        public async Task UnvoidTag_AsHacker_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.UnvoidTagAsync(
+                UserType.Hacker, TestFactory.PlantWithAccess,
+                9999,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidTag_AsAdmin_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.UnvoidTagAsync(
+                UserType.LibraryAdmin, TestFactory.PlantWithAccess,
+                9999,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidTag_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.UnvoidTagAsync(
+                UserType.Preserver, TestFactory.PlantWithAccess,
+                9999,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
         #endregion
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerNegativeTests.cs
@@ -363,6 +363,59 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
                 expectedMessageOnBadRequest:"Tag must be an area tag to update description!");
         }
         #endregion
+        
+        #region UpdateTag
+        [TestMethod]
+        public async Task UpdateTag_AsAnonymous_ShouldReturnUnauthorized()
+            => await TagsControllerTestsHelper.UpdateTagAsync(
+                UserType.Anonymous, TestFactory.UnknownPlant,
+                9999,
+                null,
+                null,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task UpdateTag_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await TagsControllerTestsHelper.UpdateTagAsync(
+                UserType.Hacker, TestFactory.UnknownPlant,
+                9999,
+                null,
+                null,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateTag_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await TagsControllerTestsHelper.UpdateTagAsync(
+                UserType.LibraryAdmin, TestFactory.UnknownPlant,
+                9999,
+                null,
+                null,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task UpdateTag_AsHacker_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.UpdateTagAsync(
+                UserType.Hacker, TestFactory.PlantWithAccess,
+                9999,
+                null,
+                null,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateTag_AsAdmin_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.UpdateTagAsync(
+                UserType.LibraryAdmin, TestFactory.PlantWithAccess,
+                9999,
+                null,
+                null,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+        #endregion
 
         #region GetAllTagAttachments
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTests.cs
@@ -321,7 +321,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
 
             // Act
             var newRowVersion = await TagsControllerTestsHelper.UpdateTagAsync(
-                UserType.Planner, TestFactory.PlantWithAccess,
+                UserType.Preserver, TestFactory.PlantWithAccess,
                 tag.Id,
                 newRemark,
                 newStorageArea,

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTests.cs
@@ -15,10 +15,10 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
     public class TagsControllerTests : TagsControllerTestsBase
     {
         [TestMethod]
-        public async Task GetAllTags_AsPreserver_ShouldGetTags()
+        public async Task GetPageOfTags_AsPreserver_ShouldGetTags()
         {
             // Act
-            var tagsResult = await TagsControllerTestsHelper.GetAllTagsAsync(
+            var tagsResult = await TagsControllerTestsHelper.GetPageOfTagsAsync(
                 UserType.Preserver, TestFactory.PlantWithAccess,
                 TestFactory.ProjectWithAccess);
 
@@ -62,7 +62,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         public async Task DuplicateAreaTag_AsPlanner_ShouldDuplicateTag()
         {
             // Arrange
-            var tagsResult = await TagsControllerTestsHelper.GetAllTagsAsync(
+            var tagsResult = await TagsControllerTestsHelper.GetPageOfTagsAsync(
                 UserType.Planner, TestFactory.PlantWithAccess,
                 TestFactory.ProjectWithAccess);
             var initialTagsCount = tagsResult.Tags.Count;
@@ -707,7 +707,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
                 null,
                 true);
 
-            var tagsResult = await TagsControllerTestsHelper.GetAllTagsAsync(
+            var tagsResult = await TagsControllerTestsHelper.GetPageOfTagsAsync(
                 UserType.Planner, TestFactory.PlantWithAccess,
                 TestFactory.ProjectWithAccess);
             var tagToTransfer = tagsResult.Tags.Single(t => t.Id == tagIdUnderTest);
@@ -739,7 +739,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         public async Task CreateStandardTag_AsPlanner_ShouldCreateStandardTag()
         {
             // Arrange
-            var tagsResult = await TagsControllerTestsHelper.GetAllTagsAsync(
+            var tagsResult = await TagsControllerTestsHelper.GetPageOfTagsAsync(
                 UserType.Planner, TestFactory.PlantWithAccess,
                 TestFactory.ProjectWithAccess);
             var initialTagsCount = tagsResult.Tags.Count;
@@ -755,7 +755,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         public async Task CreatePreAreaTag_AsPlanner_ShouldCreatePreAreaTag()
         {
             // Arrange
-            var tagsResult = await TagsControllerTestsHelper.GetAllTagsAsync(
+            var tagsResult = await TagsControllerTestsHelper.GetPageOfTagsAsync(
                 UserType.Planner, TestFactory.PlantWithAccess,
                 TestFactory.ProjectWithAccess);
             var initialTagsCount = tagsResult.Tags.Count;
@@ -775,7 +775,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         public async Task CreatePoAreaTag_AsPlanner_ShouldCreatePoAreaTag()
         {
             // Arrange
-            var tagsResult = await TagsControllerTestsHelper.GetAllTagsAsync(
+            var tagsResult = await TagsControllerTestsHelper.GetPageOfTagsAsync(
                 UserType.Planner, TestFactory.PlantWithAccess,
                 TestFactory.ProjectWithAccess);
             var initialTagsCount = tagsResult.Tags.Count;
@@ -831,7 +831,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
                 null,
                 true);
 
-            var tagsResult = await TagsControllerTestsHelper.GetAllTagsAsync(
+            var tagsResult = await TagsControllerTestsHelper.GetPageOfTagsAsync(
                 UserType.Planner, TestFactory.PlantWithAccess,
                 TestFactory.ProjectWithAccess);
             var tagToReschedule = tagsResult.Tags.Single(t => t.Id == tagIdUnderTest);
@@ -860,6 +860,58 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
             AssertRowVersionChange(currentRowVersion, requirementDetailDto.RowVersion);
             await AssertInHistoryAsLatestEventAsync(tagToReschedule.Id, UserType.Planner, EventType.Rescheduled);
         }
+        
+        [TestMethod]
+        public async Task VoidTag_AsAdmin_ShouldVoidTag()
+        {
+            // Arrange
+            var tagIdUnderTest = await CreateAreaTagAsync(
+                AreaTagType.PreArea,
+                TwoStepJourneyWithTags.Steps.First().Id,
+                null,
+                true);
+            var tag = await TagsControllerTestsHelper.GetTagAsync(UserType.Planner, TestFactory.PlantWithAccess, tagIdUnderTest);
+            var currentRowVersion = tag.RowVersion;
+            Assert.IsFalse(tag.IsVoided);
+
+            // Act
+            var newRowVersion = await TagsControllerTestsHelper.VoidTagAsync(
+                UserType.Planner, TestFactory.PlantWithAccess,
+                tag.Id,
+                currentRowVersion);
+
+            // Assert
+            tag = await TagsControllerTestsHelper.GetTagAsync(UserType.Planner, TestFactory.PlantWithAccess, tagIdUnderTest);
+            AssertRowVersionChange(currentRowVersion, newRowVersion);
+            Assert.IsTrue(tag.IsVoided);
+        }
+
+        [TestMethod]
+        public async Task UnvoidTag_AsAdmin_ShouldUnvoidTag()
+        {
+            // Arrange
+            var tagIdUnderTest = await CreateAreaTagAsync(
+                AreaTagType.PreArea,
+                TwoStepJourneyWithTags.Steps.First().Id,
+                null,
+                true);
+            var mode = await TagsControllerTestsHelper.GetTagAsync(UserType.Planner, TestFactory.PlantWithAccess, tagIdUnderTest);
+            var currentRowVersion = await TagsControllerTestsHelper.VoidTagAsync(
+                UserType.Planner, TestFactory.PlantWithAccess,
+                mode.Id,
+                mode.RowVersion);
+
+            // Act
+            var newRowVersion = await TagsControllerTestsHelper.UnvoidTagAsync(
+                UserType.Planner, TestFactory.PlantWithAccess,
+                mode.Id,
+                currentRowVersion);
+
+            // Assert
+            mode = await TagsControllerTestsHelper.GetTagAsync(UserType.Planner, TestFactory.PlantWithAccess, tagIdUnderTest);
+            AssertRowVersionChange(currentRowVersion, newRowVersion);
+            Assert.IsFalse(mode.IsVoided);
+        }
 
         private void AssertUser(TokenProfile profile, PersonDto personDto)
         {
@@ -881,7 +933,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
             int initialTagsCount)
         {
             Assert.IsTrue(id > 0);
-            var tagsResult = await TagsControllerTestsHelper.GetAllTagsAsync(
+            var tagsResult = await TagsControllerTestsHelper.GetPageOfTagsAsync(
                 userType,
                 plant,
                 TestFactory.ProjectWithAccess);

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTests.cs
@@ -862,7 +862,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         }
         
         [TestMethod]
-        public async Task VoidTag_AsAdmin_ShouldVoidTag()
+        public async Task VoidTag_AsPlanner_ShouldVoidTag()
         {
             // Arrange
             var tagIdUnderTest = await CreateAreaTagAsync(
@@ -887,7 +887,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         }
 
         [TestMethod]
-        public async Task UnvoidTag_AsAdmin_ShouldUnvoidTag()
+        public async Task UnvoidTag_AsPlanner_ShouldUnvoidTag()
         {
             // Arrange
             var tagIdUnderTest = await CreateAreaTagAsync(

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTests.cs
@@ -298,6 +298,43 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
             tag = await TagsControllerTestsHelper.GetTagAsync(UserType.Planner, TestFactory.PlantWithAccess, tagIdUnderTest);
             Assert.AreEqual(otherStepId, tag.Step.Id);
         }
+        
+        [TestMethod]
+        public async Task UpdateTag_AsPreserver_ShouldChangeTag()
+        {
+            // Arrange
+            var tagIdUnderTest = await CreateAreaTagAsync(
+                AreaTagType.SiteArea, 
+                TwoStepJourneyWithTags.Steps.Last().Id,
+                null,
+                false);
+            var tag = await TagsControllerTestsHelper.GetTagAsync(
+                UserType.Planner, TestFactory.PlantWithAccess, 
+                tagIdUnderTest);
+            var oldRemark = tag.Remark;
+            var newRemark = Guid.NewGuid().ToString();
+            Assert.AreNotEqual(oldRemark, newRemark);
+            var oldStorageArea = tag.StorageArea;
+            var newStorageArea = Guid.NewGuid().ToString();
+            Assert.AreNotEqual(oldStorageArea, newStorageArea);
+            var currentRowVersion = tag.RowVersion;
+
+            // Act
+            var newRowVersion = await TagsControllerTestsHelper.UpdateTagAsync(
+                UserType.Planner, TestFactory.PlantWithAccess,
+                tag.Id,
+                newRemark,
+                newStorageArea,
+                tag.RowVersion);
+
+            // Assert
+            AssertRowVersionChange(currentRowVersion, newRowVersion);
+            tag = await TagsControllerTestsHelper.GetTagAsync(
+                UserType.Planner, TestFactory.PlantWithAccess, 
+                tagIdUnderTest);
+            Assert.AreEqual(newRemark, tag.Remark);
+            Assert.AreEqual(newStorageArea, tag.StorageArea);
+        }
 
         [TestMethod]
         public async Task GetAllTagAttachments_AsPreserver_ShouldGetAttachments()

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTestsBase.cs
@@ -33,7 +33,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         [TestInitialize]
         public async Task TestInitialize()
         {
-            var result = await TagsControllerTestsHelper.GetAllTagsAsync(
+            var result = await TagsControllerTestsHelper.GetPageOfTagsAsync(
                 UserType.Preserver, TestFactory.PlantWithAccess,
                 TestFactory.ProjectWithAccess);
 

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTestsHelper.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTestsHelper.cs
@@ -167,6 +167,36 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
             return await response.Content.ReadAsStringAsync();
         }
 
+        public static async Task<string> UpdateTagAsync(
+            UserType userType, 
+            string plant,
+            int tagId,
+            string remark,
+            string storageArea,
+            string rowVersion,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                remark,
+                storageArea,
+                rowVersion
+            };
+
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response = await TestFactory.Instance.GetHttpClient(userType, plant).PutAsync($"{_route}/{tagId}", content);
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            return await response.Content.ReadAsStringAsync();
+        }
+
         public static async Task<List<TagAttachmentDto>> GetAllTagAttachmentsAsync(
             UserType userType, string plant,
             int tagId,

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTestsHelper.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTestsHelper.cs
@@ -16,7 +16,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
     {
         private const string _route = "Tags";
 
-        public static async Task<TagResultDto> GetAllTagsAsync(
+        public static async Task<TagResultDto> GetPageOfTagsAsync(
             UserType userType,
             string plant,
             string projectName,
@@ -25,7 +25,10 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         {
             var parameters = new ParameterCollection
             {
-                {"ProjectName", projectName}
+                {"ProjectName", projectName},
+                // use big page size. Default if not given is 20. 
+                // Positive tags tests create tags -> number of tags grows
+                {"Size", "1000"}
             };
             var url = $"{_route}{parameters}";
             var response = await TestFactory.Instance.GetHttpClient(userType, plant).GetAsync(url);
@@ -697,6 +700,58 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
 
             var jsonString = await response.Content.ReadAsStringAsync();
             return JsonConvert.DeserializeObject<List<IdAndRowVersion>>(jsonString);
+        }
+
+        public static async Task<string> VoidTagAsync(
+            UserType userType, 
+            string plant,
+            int tagId,
+            string rowVersion,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                rowVersion
+            };
+
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response = await TestFactory.Instance.GetHttpClient(userType, plant).PutAsync($"{_route}/{tagId}/Void", content);
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            return await response.Content.ReadAsStringAsync();
+        }
+
+        public static async Task<string> UnvoidTagAsync(
+            UserType userType, 
+            string plant,
+            int tagId,
+            string rowVersion,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                rowVersion
+            };
+
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response = await TestFactory.Instance.GetHttpClient(userType, plant).PutAsync($"{_route}/{tagId}/Unvoid", content);
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            return await response.Content.ReadAsStringAsync();
         }
     }
 }


### PR DESCRIPTION
[AB#87238](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/87238) 

Had to change methods in project repo how to get tags. The DefaultQuery included the whole Tag "graph", which was to generous and didn't respond when tag got many preservations together with many actions/attachments.

Made targeted repio methods, getting either:
 - tag with preservation history (now DefaultQuery )
 - tag with actions
 - tag with attachments