### PR TITLE
87761 split edit - Better validations messages with TagNo

### DIFF
--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/BulkPreserve/BulkPreserveCommandValidator.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/BulkPreserve/BulkPreserveCommandValidator.cs
@@ -27,13 +27,13 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.BulkPreserve
             {
                 RuleForEach(command => command.TagIds)
                     .MustAsync((_, tagId, _, token) => BeAnExistingTagAsync(tagId, token))
-                    .WithMessage((_, tagId) => $"Tag doesn't exist! Tag={tagId}")
+                    .WithMessage((_, tagId) => $"Tag doesn't exist! TagId={tagId}")
                     .MustAsync((_, tagId, _, token) => NotBeAVoidedTagAsync(tagId, token))
-                    .WithMessage((_, tagId) => $"Tag is voided! Tag={tagId}")
+                    .WithMessage((_, tagId) => $"Tag is voided! Tag='{GetTagDetails(tagId)}'")
                     .MustAsync((_, tagId, _, token) => PreservationIsStartedAsync(tagId, token))
-                    .WithMessage((_, tagId) => $"Tag must have status {PreservationStatus.Active} to preserve! Tag={tagId}")
+                    .WithMessage((_, tagId) => $"Tag must have status {PreservationStatus.Active} to preserve! Tag='{GetTagDetails(tagId)}'")
                     .MustAsync((_, tagId, _, token) => BeReadyToBePreservedAsync(tagId, token))
-                    .WithMessage((_, tagId) => $"Tag is not ready to be bulk preserved! Tag={tagId}");
+                    .WithMessage((_, tagId) => $"Tag is not ready to be bulk preserved! Tag='{GetTagDetails(tagId)}'");
             });
 
             RuleFor(command => command.TagIds)
@@ -41,6 +41,8 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.BulkPreserve
                 .WithMessage("Tags must be in same project!")
                 .MustAsync(NotBeAClosedProjectForTagAsync)
                 .WithMessage("Project is closed!");
+
+            string GetTagDetails(int tagId) => tagValidator.GetTagDetailsAsync(tagId, default).Result;
 
             bool BeUniqueTags(IEnumerable<int> tagIds)
             {

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/CompletePreservation/CompletePreservationCommandValidator.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/CompletePreservation/CompletePreservationCommandValidator.cs
@@ -28,11 +28,11 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.CompletePreservation
             {
                 RuleForEach(command => command.Tags)
                     .MustAsync((_, tag, _, token) => BeAnExistingTagAsync(tag.Id, token))
-                    .WithMessage((_, tag) => $"Tag doesn't exist! Tag={tag.Id}")
+                    .WithMessage((_, tag) => $"Tag doesn't exist! TagId={tag.Id}")
                     .MustAsync((_, tag, _, token) => NotBeAVoidedTagAsync(tag.Id, token))
-                    .WithMessage((_, tag) => $"Tag is voided! Tag={tag.Id}")
+                    .WithMessage((_, tag) => $"Tag is voided! Tag='{GetTagDetails(tag.Id)}'")
                     .MustAsync((_, tag, _, token) => IsReadyToBeCompletedAsync(tag.Id, token))
-                    .WithMessage((_, tag) => $"Preservation on tag can not be completed! Tag={tag.Id}")
+                    .WithMessage((_, tag) => $"Preservation on tag can not be completed! Tag='{GetTagDetails(tag.Id)}'")
                     .Must(tag => HaveAValidRowVersion(tag.RowVersion))
                     .WithMessage((_, tag) => $"Not a valid row version! Row version={tag.RowVersion}");
             });
@@ -42,6 +42,8 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.CompletePreservation
                 .WithMessage("Tags must be in same project!")
                 .MustAsync(NotBeAClosedProjectForTagAsync)
                 .WithMessage("Project is closed!");
+
+            string GetTagDetails(int tagId) => tagValidator.GetTagDetailsAsync(tagId, default).Result;
 
             bool BeUniqueTags(IEnumerable<IdAndRowVersion> tags)
             {

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/DeleteTag/DeleteTagCommandValidator.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/DeleteTag/DeleteTagCommandValidator.cs
@@ -17,20 +17,25 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.DeleteTag
 
             RuleFor(command => command)
                 .MustAsync((command, token) => BeAnExistingTagAsync(command.TagId, token))
-                .WithMessage(command => $"Tag doesn't exist! Tag={command.TagId}")
+                .WithMessage(command => $"Tag doesn't exist! TagId={command.TagId}")
                 .MustAsync((command, token) => BeAVoidedTagAsync(command.TagId, token))
-                .WithMessage(command => $"Tag is not voided! Tag={command.TagId}")
+                .WithMessage(command => $"Tag is not voided! Tag='{GetTagDetails(command.TagId)}'")
                 .MustAsync((command, token) => NotBeInUse(command.TagId, token))
-                .WithMessage(command => $"Tag is in use! Tag={command.TagId}")
+                .WithMessage(command => $"Tag is in use! Tag='{GetTagDetails(command.TagId)}'")
                 .Must(command => HaveAValidRowVersion(command.RowVersion))
                 .WithMessage(command => $"Not a valid row version! Row version={command.RowVersion}");
 
+            string GetTagDetails(int tagId) => tagValidator.GetTagDetailsAsync(tagId, default).Result;
+
             async Task<bool> BeAnExistingTagAsync(int tagId, CancellationToken token)
                 => await tagValidator.ExistsAsync(tagId, token);
+            
             async Task<bool> BeAVoidedTagAsync(int tagId, CancellationToken token)
                 => await tagValidator.IsVoidedAsync(tagId, token);
+            
             async Task<bool> NotBeInUse(int tagId, CancellationToken token)
                 => !await tagValidator.IsInUseAsync(tagId, token);
+            
             bool HaveAValidRowVersion(string rowVersion)
                 => rowVersionValidator.IsValid(rowVersion);
         }

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/DuplicateAreaTag/DuplicateAreaTagCommandValidator.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/DuplicateAreaTag/DuplicateAreaTagCommandValidator.cs
@@ -14,13 +14,15 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.DuplicateAreaTag
 
             RuleFor(command => command)
                 .MustAsync((command, token) => NotBeAClosedProjectForTagAsync(command.TagId, token))
-                .WithMessage(command => $"Project is closed! Tag={command.TagId}")
+                .WithMessage(command => $"Project is closed! Tag='{GetTagDetails(command.TagId)}'")
                 .MustAsync((command, token) => BeAnExistingSourceTagAsync(command.TagId, token))
-                .WithMessage(command => $"Tag doesn't exist! Tag={command.TagId}")
+                .WithMessage(command => $"Source tag doesn't exist! TagId={command.TagId}")
                 .MustAsync((command, token) => NotBeAnExistingTagWithinProjectAsync(command.GetTagNo(), command.TagId, token))
                 .WithMessage(command => $"Tag already exists in scope for project! Tag={command.GetTagNo()}")
                 .MustAsync((command, token) => IsReadyToBeDuplicatedAsync(command.TagId, token))
-                .WithMessage(command => $"Tag can not be duplicated! Tag={command.TagId}");
+                .WithMessage(command => $"Source tag can not be duplicated! Tag='{GetTagDetails(command.TagId)}'");
+
+            string GetTagDetails(int tagId) => tagValidator.GetTagDetailsAsync(tagId, default).Result;
 
             async Task<bool> NotBeAClosedProjectForTagAsync(int tagId, CancellationToken token)
                 => !await projectValidator.IsClosedForTagAsync(tagId, token);

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/Preserve/PreserveCommandValidator.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/Preserve/PreserveCommandValidator.cs
@@ -17,16 +17,18 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.Preserve
             
             RuleFor(command => command)
                 .MustAsync((command, token) => NotBeAClosedProjectForTagAsync(command.TagId, token))
-                .WithMessage(command => $"Project for tag is closed! Tag={command.TagId}")
+                .WithMessage(command => $"Project for tag is closed! Tag='{GetTagDetails(command.TagId)}'")
                 .MustAsync((command, token) => BeAnExistingTagAsync(command.TagId, token))
-                .WithMessage(command => $"Tag doesn't exist! Tag={command.TagId}")
+                .WithMessage(command => $"Tag doesn't exist! TagId={command.TagId}")
                 .MustAsync((command, token) => NotBeAVoidedTag(command.TagId, token))
-                .WithMessage(command => $"Tag is voided! Tag={command.TagId}")
+                .WithMessage(command => $"Tag is voided! Tag='{GetTagDetails(command.TagId)}'")
                 .MustAsync((command, token) => PreservationIsStartedAsync(command.TagId, token))
-                .WithMessage(command => $"Tag must have status {PreservationStatus.Active} to preserve! Tag={command.TagId}")
+                .WithMessage(command => $"Tag must have status {PreservationStatus.Active} to preserve! Tag='{GetTagDetails(command.TagId)}'")
                 .MustAsync((command, token) => BeReadyToBePreservedAsync(command.TagId, token))
-                .WithMessage(command => $"Tag is not ready to be preserved! Tag={command.TagId}");
-            
+                .WithMessage(command => $"Tag is not ready to be preserved! Tag='{GetTagDetails(command.TagId)}'");
+
+            string GetTagDetails(int tagId) => tagValidator.GetTagDetailsAsync(tagId, default).Result;
+
             async Task<bool> NotBeAClosedProjectForTagAsync(int tagId, CancellationToken token)
                 => !await projectValidator.IsClosedForTagAsync(tagId, token);
 

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/Reschedule/RescheduleCommandValidator.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/Reschedule/RescheduleCommandValidator.cs
@@ -34,11 +34,11 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.Reschedule
             {
                 RuleForEach(command => command.Tags)
                     .MustAsync((_, tag, _, token) => BeAnExistingTagAsync(tag.Id, token))
-                    .WithMessage((_, tag) => $"Tag doesn't exist! Tag={tag.Id}")
+                    .WithMessage((_, tag) => $"Tag doesn't exist! TagId={tag.Id}")
                     .MustAsync((_, tag, _, token) => NotBeAVoidedTagAsync(tag.Id, token))
-                    .WithMessage((_, tag) => $"Tag is voided! Tag={tag.Id}")
+                    .WithMessage((_, tag) => $"Tag is voided! Tag='{GetTagDetails(tag.Id)}'")
                     .MustAsync((_, tag, _, token) => IsReadyToBeRescheduledAsync(tag.Id, token))
-                    .WithMessage((_, tag) => $"Tag can not be rescheduled! Tag={tag.Id}")
+                    .WithMessage((_, tag) => $"Tag can not be rescheduled! Tag='{GetTagDetails(tag.Id)}'")
                     .Must(tag => HaveAValidRowVersion(tag.RowVersion))
                     .WithMessage((_, tag) => $"Not a valid row version! Row version={tag.RowVersion}");
             });
@@ -48,6 +48,8 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.Reschedule
                 .WithMessage("Tags must be in same project!")
                 .MustAsync(NotBeAClosedProjectForTagAsync)
                 .WithMessage("Project is closed!");
+
+            string GetTagDetails(int tagId) => tagValidator.GetTagDetailsAsync(tagId, default).Result;
 
             bool BeUniqueTags(IEnumerable<IdAndRowVersion> tags)
             {

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/StartPreservation/StartPreservationCommandValidator.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/StartPreservation/StartPreservationCommandValidator.cs
@@ -26,13 +26,13 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.StartPreservation
             {
                 RuleForEach(command => command.TagIds)
                     .MustAsync((_, tagId, _, token) => BeAnExistingTagAsync(tagId, token))
-                    .WithMessage((_, tagId) => $"Tag doesn't exist! Tag={tagId}")
+                    .WithMessage((_, tagId) => $"Tag doesn't exist! TagId={tagId}")
                     .MustAsync((_, tagId, _, token) => NotBeAVoidedTagAsync(tagId, token))
-                    .WithMessage((_, tagId) => $"Tag is voided! Tag={tagId}")
+                    .WithMessage((_, tagId) => $"Tag is voided! Tag='{GetTagDetails(tagId)}'")
                     .MustAsync((_, tagId, _, token) => IsReadyToBeStartedAsync(tagId, token))
-                    .WithMessage((_, tagId) => $"Preservation on tag can not be started! Tag={tagId}")
+                    .WithMessage((_, tagId) => $"Preservation on tag can not be started! Tag='{GetTagDetails(tagId)}'")
                     .MustAsync((_, tagId, _, token) => HaveAtLeastOneNonVoidedRequirementAsync(tagId, token))
-                    .WithMessage((_, tagId) => $"Tag do not have any non voided requirement! Tag={tagId}");
+                    .WithMessage((_, tagId) => $"Tag do not have any non voided requirement! Tag='{GetTagDetails(tagId)}'");
             });
 
             RuleFor(command => command.TagIds)
@@ -40,6 +40,8 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.StartPreservation
                 .WithMessage("Tags must be in same project!")
                 .MustAsync(NotBeAClosedProjectForTagAsync)
                 .WithMessage("Project is closed!");
+
+            string GetTagDetails(int tagId) => tagValidator.GetTagDetailsAsync(tagId, default).Result;
 
             bool BeUniqueTags(IEnumerable<int> tagIds)
             {

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/Transfer/TransferCommandValidator.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/Transfer/TransferCommandValidator.cs
@@ -28,13 +28,13 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.Transfer
             {
                 RuleForEach(command => command.Tags)
                     .MustAsync((_, tag, _, token) => BeAnExistingTagAsync(tag.Id, token))
-                    .WithMessage((_, tag) => $"Tag doesn't exist! Tag={tag.Id}")
+                    .WithMessage((_, tag) => $"Tag doesn't exist! TagId={tag.Id}")
                     .MustAsync((_, tag, _, token) => NotBeAVoidedTagAsync(tag.Id, token))
-                    .WithMessage((_, tag) => $"Tag is voided! Tag={tag.Id}")
+                    .WithMessage((_, tag) => $"Tag is voided! Tag='{GetTagDetails(tag.Id)}'")
                     .MustAsync((_, tag, _, token) => IsReadyToBeTransferredAsync(tag.Id, token))
-                    .WithMessage((_, tag) => $"Tag can not be transferred! Tag={tag.Id}")
+                    .WithMessage((_, tag) => $"Tag can not be transferred! Tag='{GetTagDetails(tag.Id)}'")
                     .MustAsync((_, tag, _, token) => TagHasRequirementInNextStepAsync(tag.Id, token))
-                    .WithMessage((_, tag) => $"Tag doesn't have any requirement in next step! Tag={tag.Id}")
+                    .WithMessage((_, tag) => $"Tag doesn't have any requirement in next step! Tag='{GetTagDetails(tag.Id)}'")
                     .Must(tag => HaveAValidRowVersion(tag.RowVersion))
                     .WithMessage((_, tag) => $"Not a valid row version! Row version={tag.RowVersion}");
             });
@@ -44,6 +44,8 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.Transfer
                 .WithMessage("Tags must be in same project!")
                 .MustAsync(NotBeAClosedProjectForTagAsync)
                 .WithMessage("Project is closed!");
+
+            string GetTagDetails(int tagId) => tagValidator.GetTagDetailsAsync(tagId, default).Result;
 
             bool BeUniqueTags(IEnumerable<IdAndRowVersion> tags)
             {

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/UndoStartPreservation/UndoStartPreservationCommandValidator.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/UndoStartPreservation/UndoStartPreservationCommandValidator.cs
@@ -28,11 +28,11 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.UndoStartPreservatio
             {
                 RuleForEach(command => command.Tags)
                     .MustAsync((_, tag, _, token) => BeAnExistingTagAsync(tag.Id, token))
-                    .WithMessage((_, tag) => $"Tag doesn't exist! Tag={tag.Id}")
+                    .WithMessage((_, tag) => $"Tag doesn't exist! TagId={tag.Id}")
                     .MustAsync((_, tag, _, token) => NotBeAVoidedTagAsync(tag.Id, token))
-                    .WithMessage((_, tag) => $"Tag is voided! Tag={tag.Id}")
+                    .WithMessage((_, tag) => $"Tag is voided! Tag='{GetTagDetails(tag.Id)}'")
                     .MustAsync((_, tag, _, token) => IsReadyToUndoStartedAsync(tag.Id, token))
-                    .WithMessage((_, tag) => $"Undo preservation start on tag can not be done! Tag={tag.Id}")
+                    .WithMessage((_, tag) => $"Undo preservation start on tag can not be done! Tag='{GetTagDetails(tag.Id)}'")
                     .Must(tag => HaveAValidRowVersion(tag.RowVersion))
                     .WithMessage((_, tag) => $"Not a valid row version! Row version={tag.RowVersion}");
             });
@@ -42,6 +42,8 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.UndoStartPreservatio
                 .WithMessage("Tags must be in same project!")
                 .MustAsync(NotBeAClosedProjectForTagAsync)
                 .WithMessage("Project is closed!");
+
+            string GetTagDetails(int tagId) => tagValidator.GetTagDetailsAsync(tagId, default).Result;
 
             bool BeUniqueTags(IEnumerable<IdAndRowVersion> tags)
             {

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/UnvoidTag/UnvoidTagCommandValidator.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/UnvoidTag/UnvoidTagCommandValidator.cs
@@ -18,20 +18,25 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.UnvoidTag
 
             RuleFor(command => command)
                 .MustAsync((command, token) => NotBeAClosedProjectForTagAsync(command.TagId, token))
-                .WithMessage(command => $"Project for tag is closed! Tag={command.TagId}")
+                .WithMessage(command => $"Project for tag is closed! Tag='{GetTagDetails(command.TagId)}'")
                 .MustAsync((command, token) => BeAnExistingTagAsync(command.TagId, token))
-                .WithMessage(command => $"Tag doesn't exist! Tag={command.TagId}")
+                .WithMessage(command => $"Tag doesn't exist! TagId={command.TagId}")
                 .MustAsync((command, token) => BeAVoidedTagAsync(command.TagId, token))
-                .WithMessage(command => $"Tag is not voided! Tag={command.TagId}")
+                .WithMessage(command => $"Tag is not voided! Tag='{GetTagDetails(command.TagId)}'")
                 .Must(command => HaveAValidRowVersion(command.RowVersion))
                 .WithMessage(command => $"Not a valid row version! Row version={command.RowVersion}");
 
+            string GetTagDetails(int tagId) => tagValidator.GetTagDetailsAsync(tagId, default).Result;
+
             async Task<bool> NotBeAClosedProjectForTagAsync(int tagId, CancellationToken token)
                 => !await projectValidator.IsClosedForTagAsync(tagId, token);
+
             async Task<bool> BeAnExistingTagAsync(int tagId, CancellationToken token)
                 => await tagValidator.ExistsAsync(tagId, token);
+
             async Task<bool> BeAVoidedTagAsync(int tagId, CancellationToken token)
                 => await tagValidator.IsVoidedAsync(tagId, token);
+
             bool HaveAValidRowVersion(string rowVersion)
                 => rowVersionValidator.IsValid(rowVersion);
         }

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/UpdateTag/UpdateTagCommandValidator.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/UpdateTag/UpdateTagCommandValidator.cs
@@ -18,24 +18,30 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.UpdateTag
 
             RuleFor(command => command)
                 .MustAsync((command, token) => NotBeAClosedProjectForTagAsync(command.TagId, token))
-                .WithMessage(command => $"Project for tag is closed! Tag={command.TagId}")
+                .WithMessage(command => $"Project for tag is closed! Tag='{GetTagDetails(command.TagId)}'")
                 .MustAsync((command, token) => BeAnExistingTagAsync(command.TagId, token))
-                .WithMessage(command => $"Tag doesn't exist! Tag={command.TagId}")
+                .WithMessage(command => $"Tag doesn't exist! TagId={command.TagId}")
                 .MustAsync((command, token) => BeReadyForEditingAsync(command.TagId, token))
-                .WithMessage(command => $"Tag can't be edited! Tag={command.TagId}")
+                .WithMessage(command => $"Tag can't be edited! Tag='{GetTagDetails(command.TagId)}'")
                 .MustAsync((command, token) => NotBeAVoidedTagAsync(command.TagId, token))
-                .WithMessage(command => $"Tag is voided! Tag={command.TagId}")
+                .WithMessage(command => $"Tag is voided! Tag='{GetTagDetails(command.TagId)}'")
                 .Must(command => HaveAValidRowVersion(command.RowVersion))
                 .WithMessage(command => $"Not a valid row version! Row version={command.RowVersion}");
 
+            string GetTagDetails(int tagId) => tagValidator.GetTagDetailsAsync(tagId, default).Result;
+
             async Task<bool> NotBeAClosedProjectForTagAsync(int tagId, CancellationToken token)
                 => !await projectValidator.IsClosedForTagAsync(tagId, token);
+
             async Task<bool> BeReadyForEditingAsync(int tagId, CancellationToken token)
                 => await tagValidator.IsReadyToBeEditedAsync(tagId, token);
+
             async Task<bool> BeAnExistingTagAsync(int tagId, CancellationToken token)
                 => await tagValidator.ExistsAsync(tagId, token);
+
             async Task<bool> NotBeAVoidedTagAsync(int tagId, CancellationToken token)
                 => !await tagValidator.IsVoidedAsync(tagId, token);
+
             bool HaveAValidRowVersion(string rowVersion)
                 => rowVersionValidator.IsValid(rowVersion);
         }

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/UpdateTagRequirements/UpdateTagRequirementsCommandValidator.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/UpdateTagRequirements/UpdateTagRequirementsCommandValidator.cs
@@ -89,13 +89,13 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.UpdateTagRequirement
                         token))
                 .WithMessage(_ => "Requirements must be unique!")
                 .MustAsync((command, token) => NotBeAClosedProjectForTagAsync(command.TagId, token))
-                .WithMessage(command => $"Project for tag is closed! Tag={command.TagId}")
+                .WithMessage(command => $"Project for tag is closed! Tag='{GetTagDetails(command.TagId)}'")
                 .MustAsync((command, token) => BeAnExistingTagAsync(command.TagId, token))
-                .WithMessage(command => $"Tag doesn't exist! Tag={command.TagId}")
+                .WithMessage(command => $"Tag doesn't exist! TagId={command.TagId}")
                 .MustAsync((command, token) => BeReadyForEditingAsync(command.TagId, token))
-                .WithMessage(command => $"Tag can't be edited! Tag={command.TagId}")
+                .WithMessage(command => $"Tag can't be edited! Tag='{GetTagDetails(command.TagId)}'")
                 .MustAsync((command, token) => NotBeAVoidedTagAsync(command.TagId, token))
-                .WithMessage(command => $"Tag is voided! Tag={command.TagId}")
+                .WithMessage(command => $"Tag is voided! Tag='{GetTagDetails(command.TagId)}'")
                 .Must(command => HaveAValidRowVersion(command.RowVersion))
                 .WithMessage(command => $"Not a valid row version! Row version={command.RowVersion}");
 
@@ -120,6 +120,8 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.UpdateTagRequirement
                 .MustAsync((_, req, _, token) => NotBeAVoidedRequirementDefinitionAsync(req.RequirementDefinitionId, token))
                 .WithMessage((_, req) =>
                     $"Requirement definition is voided! Requirement definition={req.RequirementDefinitionId}");
+
+            string GetTagDetails(int tagId) => tagValidator.GetTagDetailsAsync(tagId, default).Result;
 
             async Task<bool> RequirementsMustBeUniqueAfterUpdateAsync(
                 int tagId,
@@ -179,7 +181,7 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.UpdateTagRequirement
                     tagRequirementIdsToBeVoided, 
                     requirementDefinitionIdsToBeAdded, 
                     token);
-            
+
             async Task<bool> TagIsInASupplierStepAsync(int tagId, CancellationToken token)
                 => await tagValidator.IsInASupplierStepAsync(tagId, token);
             

--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/VoidTag/VoidTagCommandValidator.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/VoidTag/VoidTagCommandValidator.cs
@@ -18,20 +18,25 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.VoidTag
 
             RuleFor(command => command)
                 .MustAsync((command, token) => NotBeAClosedProjectForTagAsync(command.TagId, token))
-                .WithMessage(command => $"Project for tag is closed! Tag={command.TagId}")
+                .WithMessage(command => $"Project for tag is closed! Tag='{GetTagDetails(command.TagId)}'")
                 .MustAsync((command, token) => BeAnExistingTagAsync(command.TagId, token))
-                .WithMessage(command => $"Tag doesn't exist! Tag={command.TagId}")
+                .WithMessage(command => $"Tag doesn't exist! TagId={command.TagId}")
                 .MustAsync((command, token) => NotBeAVoidedTagAsync(command.TagId, token))
-                .WithMessage(command => $"Tag is voided! Tag={command.TagId}")
+                .WithMessage(command => $"Tag is voided! Tag='{GetTagDetails(command.TagId)}'")
                 .Must(command => HaveAValidRowVersion(command.RowVersion))
                 .WithMessage(command => $"Not a valid row version! Row version={command.RowVersion}");
 
+            string GetTagDetails(int tagId) => tagValidator.GetTagDetailsAsync(tagId, default).Result;
+
             async Task<bool> NotBeAClosedProjectForTagAsync(int tagId, CancellationToken token)
                 => !await projectValidator.IsClosedForTagAsync(tagId, token);
+
             async Task<bool> BeAnExistingTagAsync(int tagId, CancellationToken token)
                 => await tagValidator.ExistsAsync(tagId, token);
+
             async Task<bool> NotBeAVoidedTagAsync(int tagId, CancellationToken token)
                 => !await tagValidator.IsVoidedAsync(tagId, token);
+
             bool HaveAValidRowVersion(string rowVersion)
                 => rowVersionValidator.IsValid(rowVersion);
         }

--- a/src/Equinor.ProCoSys.Preservation.Command/Validators/TagValidators/ITagValidator.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/Validators/TagValidators/ITagValidator.cs
@@ -106,5 +106,7 @@ namespace Equinor.ProCoSys.Preservation.Command.Validators.TagValidators
         Task<bool> HasRequirementCoverageInNextStepAsync(int tagId, CancellationToken token);
         
         Task<bool> IsInASupplierStepAsync(int tagId, CancellationToken token);
+        
+        Task<string> GetTagDetailsAsync(int tagId, CancellationToken token);
     }
 }

--- a/src/Equinor.ProCoSys.Preservation.Command/Validators/TagValidators/TagValidator.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/Validators/TagValidators/TagValidator.cs
@@ -494,6 +494,12 @@ namespace Equinor.ProCoSys.Preservation.Command.Validators.TagValidators
             return step != null && step.IsSupplierStep;
         }
 
+        public async Task<string> GetTagDetailsAsync(int tagId, CancellationToken token)
+        {
+            var tag = await GetTagWithoutIncludesAsync(tagId, token);
+            return tag != null ? tag.TagNo : string.Empty;
+        }
+
         private async Task<Tag> GetTagWithoutIncludesAsync(int tagId, CancellationToken token)
         {
             var tag = await (from t in _context.QuerySet<Tag>()

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/BulkPreserve/BulkPreserveCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/BulkPreserve/BulkPreserveCommandValidatorTests.cs
@@ -170,5 +170,19 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.BulkPreserve
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
         }
+
+        [TestMethod]
+        public void Validate_ShouldIncludeTagNoInMessage()
+        {
+            _tagValidatorMock.Setup(r => r.IsVoidedAsync(TagId1, default)).Returns(Task.FromResult(true));
+            var tagNo = "Tag X";
+            _tagValidatorMock.Setup(r => r.GetTagDetailsAsync(TagId1, default)).Returns(Task.FromResult(tagNo));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.Contains(tagNo));
+        }
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/CompletePreservation/CompletePreservationCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/CompletePreservation/CompletePreservationCommandValidatorTests.cs
@@ -183,5 +183,19 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.CompletePreser
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid row version!"));
         }
+
+        [TestMethod]
+        public void Validate_ShouldIncludeTagNoInMessage()
+        {
+            _tagValidatorMock.Setup(r => r.IsVoidedAsync(TagId1, default)).Returns(Task.FromResult(true));
+            var tagNo = "Tag X";
+            _tagValidatorMock.Setup(r => r.GetTagDetailsAsync(TagId1, default)).Returns(Task.FromResult(tagNo));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.Contains(tagNo));
+        }
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/DeleteTag/DeleteTagCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/DeleteTag/DeleteTagCommandValidatorTests.cs
@@ -93,5 +93,19 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.DeleteTag
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid row version!"));
         }
+
+        [TestMethod]
+        public void Validate_ShouldIncludeTagNoInMessage()
+        {
+            _tagValidatorMock.Setup(r => r.IsVoidedAsync(_tagId, default)).Returns(Task.FromResult(false));
+            var tagNo = "Tag X";
+            _tagValidatorMock.Setup(r => r.GetTagDetailsAsync(_tagId, default)).Returns(Task.FromResult(tagNo));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.Contains(tagNo));
+        }
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/DuplicateAreaTag/DuplicateAreaTagCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/DuplicateAreaTag/DuplicateAreaTagCommandValidatorTests.cs
@@ -47,7 +47,7 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.DuplicateAreaT
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Tag doesn't exist!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Source tag doesn't exist!"));
         }
         
         [TestMethod]
@@ -83,7 +83,7 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.DuplicateAreaT
 
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
-            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Tag can not be duplicated!"));
+            Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Source tag can not be duplicated!"));
         }
 
         [TestMethod]
@@ -97,6 +97,20 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.DuplicateAreaT
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Project is closed!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldIncludeTagNoInMessage()
+        {
+            _tagValidatorMock.Setup(r => r.IsReadyToBeDuplicatedAsync(TagId, default)).Returns(Task.FromResult(false));
+            var tagNo = "Tag X";
+            _tagValidatorMock.Setup(r => r.GetTagDetailsAsync(TagId, default)).Returns(Task.FromResult(tagNo));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.Contains(tagNo));
         }
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/Preserve/PreserveCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/Preserve/PreserveCommandValidatorTests.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Equinor.ProCoSys.Preservation.Command.TagCommands.Preserve;
 using Equinor.ProCoSys.Preservation.Command.Validators.ProjectValidators;
 using Equinor.ProCoSys.Preservation.Command.Validators.TagValidators;
-using Equinor.ProCoSys.Preservation.Domain;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -114,6 +113,20 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.Preserve
             Assert.IsFalse(result.IsValid);
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Project for tag is closed!"));
+        }
+
+        [TestMethod]
+        public void Validate_ShouldIncludeTagNoInMessage()
+        {
+            _tagValidatorMock.Setup(r => r.IsVoidedAsync(TagId, default)).Returns(Task.FromResult(true));
+            var tagNo = "Tag X";
+            _tagValidatorMock.Setup(r => r.GetTagDetailsAsync(TagId, default)).Returns(Task.FromResult(tagNo));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.Contains(tagNo));
         }
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/Reschedule/RescheduleCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/Reschedule/RescheduleCommandValidatorTests.cs
@@ -204,5 +204,19 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.Reschedule
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid row version!"));
         }
+
+        [TestMethod]
+        public void Validate_ShouldIncludeTagNoInMessage()
+        {
+            _tagValidatorMock.Setup(r => r.IsVoidedAsync(TagId1, default)).Returns(Task.FromResult(true));
+            var tagNo = "Tag X";
+            _tagValidatorMock.Setup(r => r.GetTagDetailsAsync(TagId1, default)).Returns(Task.FromResult(tagNo));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.Contains(tagNo));
+        }
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/StartPreservation/StartPreservationCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/StartPreservation/StartPreservationCommandValidatorTests.cs
@@ -168,5 +168,19 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.StartPreservat
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Tags must be unique!"));
         }
+
+        [TestMethod]
+        public void Validate_ShouldIncludeTagNoInMessage()
+        {
+            _tagValidatorMock.Setup(r => r.IsVoidedAsync(TagId1, default)).Returns(Task.FromResult(true));
+            var tagNo = "Tag X";
+            _tagValidatorMock.Setup(r => r.GetTagDetailsAsync(TagId1, default)).Returns(Task.FromResult(tagNo));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.Contains(tagNo));
+        }
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/Transfer/TransferCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/Transfer/TransferCommandValidatorTests.cs
@@ -171,5 +171,19 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.Transfer
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid row version!"));
         }
+
+        [TestMethod]
+        public void Validate_ShouldIncludeTagNoInMessage()
+        {
+            _tagValidatorMock.Setup(r => r.IsVoidedAsync(TagId1, default)).Returns(Task.FromResult(true));
+            var tagNo = "Tag X";
+            _tagValidatorMock.Setup(r => r.GetTagDetailsAsync(TagId1, default)).Returns(Task.FromResult(tagNo));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.Contains(tagNo));
+        }
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/UndoStartPreservation/UndoStartPreservationCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/UndoStartPreservation/UndoStartPreservationCommandValidatorTests.cs
@@ -188,5 +188,19 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.UndoStartPrese
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid row version!"));
         }
+
+        [TestMethod]
+        public void Validate_ShouldIncludeTagNoInMessage()
+        {
+            _tagValidatorMock.Setup(r => r.IsVoidedAsync(TagId1, default)).Returns(Task.FromResult(true));
+            var tagNo = "Tag X";
+            _tagValidatorMock.Setup(r => r.GetTagDetailsAsync(TagId1, default)).Returns(Task.FromResult(tagNo));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.Contains(tagNo));
+        }
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/UnvoidTag/UnvoidTagCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/UnvoidTag/UnvoidTagCommandValidatorTests.cs
@@ -94,5 +94,19 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.UnvoidTag
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid row version!"));
         }
+
+        [TestMethod]
+        public void Validate_ShouldIncludeTagNoInMessage()
+        {
+            _tagValidatorMock.Setup(r => r.IsVoidedAsync(_tagId, default)).Returns(Task.FromResult(false));
+            var tagNo = "Tag X";
+            _tagValidatorMock.Setup(r => r.GetTagDetailsAsync(_tagId, default)).Returns(Task.FromResult(tagNo));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.Contains(tagNo));
+        }
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/UpdateTag/UpdateTagCommandValidatorTests.cs
@@ -109,5 +109,19 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.UpdateTag
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid row version!"));
         }
+
+        [TestMethod]
+        public void Validate_ShouldIncludeTagNoInMessage()
+        {
+            _tagValidatorMock.Setup(r => r.IsVoidedAsync(_tagId, default)).Returns(Task.FromResult(true));
+            var tagNo = "Tag X";
+            _tagValidatorMock.Setup(r => r.GetTagDetailsAsync(_tagId, default)).Returns(Task.FromResult(tagNo));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.Contains(tagNo));
+        }
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/UpdateTagRequirements/UpdateTagRequirementsCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/UpdateTagRequirements/UpdateTagRequirementsCommandValidatorTests.cs
@@ -640,5 +640,19 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.UpdateTagRequi
 
             Assert.IsTrue(result.IsValid);
         }
+
+        [TestMethod]
+        public void Validate_ShouldIncludeTagNoInMessage()
+        {
+            _tagValidatorMock.Setup(r => r.IsVoidedAsync(_tagId, default)).Returns(Task.FromResult(true));
+            var tagNo = "Tag X";
+            _tagValidatorMock.Setup(r => r.GetTagDetailsAsync(_tagId, default)).Returns(Task.FromResult(tagNo));
+
+            var result = _dut.Validate(_addTwoReqsCommand);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.Contains(tagNo));
+        }
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/UpdateTagStep/UpdateTagStepCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/UpdateTagStep/UpdateTagStepCommandValidatorTests.cs
@@ -332,5 +332,19 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.UpdateTagStep
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Tags must be in same project!"));
         }
+
+        [TestMethod]
+        public void Validate_ShouldIncludeTagNoInMessage()
+        {
+            _tagValidatorMock.Setup(r => r.IsVoidedAsync(TagId1, default)).Returns(Task.FromResult(true));
+            var tagNo = "Tag X";
+            _tagValidatorMock.Setup(r => r.GetTagDetailsAsync(TagId1, default)).Returns(Task.FromResult(tagNo));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.Contains(tagNo));
+        }
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/VoidTag/VoidTagCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagCommands/VoidTag/VoidTagCommandValidatorTests.cs
@@ -92,5 +92,19 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagCommands.VoidTag
             Assert.AreEqual(1, result.Errors.Count);
             Assert.IsTrue(result.Errors[0].ErrorMessage.StartsWith("Not a valid row version!"));
         }
+
+        [TestMethod]
+        public void Validate_ShouldIncludeTagNoInMessage()
+        {
+            _tagValidatorMock.Setup(r => r.IsVoidedAsync(_tagId, default)).Returns(Task.FromResult(true));
+            var tagNo = "Tag X";
+            _tagValidatorMock.Setup(r => r.GetTagDetailsAsync(_tagId, default)).Returns(Task.FromResult(tagNo));
+
+            var result = _dut.Validate(_command);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(1, result.Errors.Count);
+            Assert.IsTrue(result.Errors[0].ErrorMessage.Contains(tagNo));
+        }
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/Validators/TagValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/Validators/TagValidatorTests.cs
@@ -2020,5 +2020,27 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.Validators
                 Assert.IsFalse(result);
             }
         }
+
+        [TestMethod]
+        public async Task GetTagDetailsAsync_KnownTag_ShouldReturnTagNo()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new TagValidator(context, null);
+                var result = await dut.GetTagDetailsAsync(_standardTagNotStartedInFirstStepId, default);
+                Assert.AreEqual(TagNo, result);
+            }
+        }
+
+        [TestMethod]
+        public async Task GetTagDetailsAsync_UnknownTag_ShouldReturnEmptyString()
+        {
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new TagValidator(context, null);
+                var result = await dut.GetTagDetailsAsync(0, default);
+                Assert.AreEqual(string.Empty, result);
+            }
+        }
     }
 }


### PR DESCRIPTION
Changed validation messages to show TagNo instead of TagId. Handy when validating multiple tags, and one of many has a problem

[AB#87761](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/87761)