### PR TITLE
88576 optimistic concurrency integration tests

### DIFF
--- a/src/Equinor.ProCoSys.Preservation.Command/TagFunctionCommands/UnvoidTagFunction/UnvoidTagFunctionCommandValidator.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagFunctionCommands/UnvoidTagFunction/UnvoidTagFunctionCommandValidator.cs
@@ -15,17 +15,17 @@ namespace Equinor.ProCoSys.Preservation.Command.TagFunctionCommands.UnvoidTagFun
             CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
-                .MustAsync((command, token) => BeAnExistingTagFunctionAsync(command.TagFunctionCode, token))
-                .WithMessage(command => $"Tag function doesn't exist! Tag function={command.TagFunctionCode}")
-                .MustAsync((command, token) => BeAVoidedTagFunctionAsync(command.TagFunctionCode, token))
-                .WithMessage(command => $"Tag function is not voided! Tag function={command.TagFunctionCode}")
+                .MustAsync((command, token) => BeAnExistingTagFunctionAsync(command.TagFunctionCode, command.RegisterCode, token))
+                .WithMessage(command => $"Tag function doesn't exist! Tag function={command.RegisterCode}/{command.TagFunctionCode}")
+                .MustAsync((command, token) => BeAVoidedTagFunctionAsync(command.TagFunctionCode, command.RegisterCode, token))
+                .WithMessage(command => $"Tag function is not voided! Tag function={command.RegisterCode}/{command.TagFunctionCode}")
                 .Must(command => HaveAValidRowVersion(command.RowVersion))
                 .WithMessage(command => $"Not a valid row version! Row version={command.RowVersion}");
 
-            async Task<bool> BeAnExistingTagFunctionAsync(string tagFunctionCode, CancellationToken token)
-                => await tagFunctionValidator.ExistsAsync(tagFunctionCode, token);
-            async Task<bool> BeAVoidedTagFunctionAsync(string tagFunctionCode, CancellationToken token)
-                => await tagFunctionValidator.IsVoidedAsync(tagFunctionCode, token);
+            async Task<bool> BeAnExistingTagFunctionAsync(string tagFunctionCode, string registerCode, CancellationToken token)
+                => await tagFunctionValidator.ExistsAsync(tagFunctionCode, registerCode, token);
+            async Task<bool> BeAVoidedTagFunctionAsync(string tagFunctionCode, string registerCode, CancellationToken token)
+                => await tagFunctionValidator.IsVoidedAsync(tagFunctionCode, registerCode, token);
             bool HaveAValidRowVersion(string rowVersion)
                 => rowVersionValidator.IsValid(rowVersion);
         }

--- a/src/Equinor.ProCoSys.Preservation.Command/TagFunctionCommands/VoidTagFunction/VoidTagFunctionCommandValidator.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagFunctionCommands/VoidTagFunction/VoidTagFunctionCommandValidator.cs
@@ -15,17 +15,17 @@ namespace Equinor.ProCoSys.Preservation.Command.TagFunctionCommands.VoidTagFunct
             CascadeMode = CascadeMode.Stop;
 
             RuleFor(command => command)
-                .MustAsync((command, token) => BeAnExistingTagFunctionAsync(command.TagFunctionCode, token))
-                .WithMessage(command => $"Tag function doesn't exist! Tag function={command.TagFunctionCode}")
-                .MustAsync((command, token) => NotBeAVoidedTagFunctionAsync(command.TagFunctionCode, token))
-                .WithMessage(command => $"Tag function is already voided! Tag function={command.TagFunctionCode}")
+                .MustAsync((command, token) => BeAnExistingTagFunctionAsync(command.TagFunctionCode, command.RegisterCode, token))
+                .WithMessage(command => $"Tag function doesn't exist! Tag function={command.RegisterCode}/{command.TagFunctionCode}")
+                .MustAsync((command, token) => NotBeAVoidedTagFunctionAsync(command.TagFunctionCode, command.RegisterCode, token))
+                .WithMessage(command => $"Tag function is already voided! Tag function={command.RegisterCode}/{command.TagFunctionCode}")
                 .Must(command => HaveAValidRowVersion(command.RowVersion))
                 .WithMessage(command => $"Not a valid row version! Row version={command.RowVersion}");
 
-            async Task<bool> BeAnExistingTagFunctionAsync(string tagFunctionCode, CancellationToken token)
-                => await tagFunctionValidator.ExistsAsync(tagFunctionCode, token);
-            async Task<bool> NotBeAVoidedTagFunctionAsync(string tagFunctionCode, CancellationToken token)
-                => !await tagFunctionValidator.IsVoidedAsync(tagFunctionCode, token);
+            async Task<bool> BeAnExistingTagFunctionAsync(string tagFunctionCode, string registerCode, CancellationToken token)
+                => await tagFunctionValidator.ExistsAsync(tagFunctionCode, registerCode, token);
+            async Task<bool> NotBeAVoidedTagFunctionAsync(string tagFunctionCode, string registerCode, CancellationToken token)
+                => !await tagFunctionValidator.IsVoidedAsync(tagFunctionCode, registerCode, token);
             bool HaveAValidRowVersion(string rowVersion)
                 => rowVersionValidator.IsValid(rowVersion);
         }

--- a/src/Equinor.ProCoSys.Preservation.Command/Validators/TagFunctionValidators/ITagFunctionValidator.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/Validators/TagFunctionValidators/ITagFunctionValidator.cs
@@ -5,7 +5,7 @@ namespace Equinor.ProCoSys.Preservation.Command.Validators.TagFunctionValidators
 {
     public interface ITagFunctionValidator
     {
-        Task<bool> ExistsAsync(string tagFunctionCode, CancellationToken token);
-        Task<bool> IsVoidedAsync(string tagFunctionCode, CancellationToken token);
+        Task<bool> ExistsAsync(string tagFunctionCode, string registerCode, CancellationToken token);
+        Task<bool> IsVoidedAsync(string tagFunctionCode, string registerCode, CancellationToken token);
     }
 }

--- a/src/Equinor.ProCoSys.Preservation.Command/Validators/TagFunctionValidators/TagFunctionValidator.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/Validators/TagFunctionValidators/TagFunctionValidator.cs
@@ -13,16 +13,16 @@ namespace Equinor.ProCoSys.Preservation.Command.Validators.TagFunctionValidators
 
         public TagFunctionValidator(IReadOnlyContext context) => _context = context;
 
-        public async Task<bool> ExistsAsync(string tagFunctionCode, CancellationToken token) =>
+        public async Task<bool> ExistsAsync(string tagFunctionCode, string registerCode, CancellationToken token) =>
             await (from tf in _context.QuerySet<TagFunction>()
-                where tf.Code == tagFunctionCode
+                where tf.Code == tagFunctionCode && tf.RegisterCode == registerCode
                    select tf).AnyAsync(token);
 
-        public async Task<bool> IsVoidedAsync(string tagFunctionCode, CancellationToken token)
+        public async Task<bool> IsVoidedAsync(string tagFunctionCode, string registerCode, CancellationToken token)
         {
             var tagFunction = await (from tf in _context.QuerySet<TagFunction>()
-                where tf.Code == tagFunctionCode
-                select tf).SingleOrDefaultAsync(token);
+                where tf.Code == tagFunctionCode && tf.RegisterCode == registerCode
+                    select tf).SingleOrDefaultAsync(token);
             return tagFunction != null && tagFunction.IsVoided;
         }
     }

--- a/src/Equinor.ProCoSys.Preservation.Domain/EntityBase.cs
+++ b/src/Equinor.ProCoSys.Preservation.Domain/EntityBase.cs
@@ -23,9 +23,13 @@ namespace Equinor.ProCoSys.Preservation.Domain
             _domainEvents.Add(eventItem);
         }
 
-        public virtual void SetRowVersion(string value)
+        public virtual void SetRowVersion(string rowVersion)
         {
-            var newRowVersion = Convert.FromBase64String(value);
+            if (string.IsNullOrEmpty(rowVersion))
+            {
+                throw new ArgumentNullException(nameof(rowVersion));
+            }
+            var newRowVersion = Convert.FromBase64String(rowVersion);
             for (var index = 0; index < newRowVersion.Length; index++)
             {
                 RowVersion[index] = newRowVersion[index];

--- a/src/Equinor.ProCoSys.Preservation.WebApi/Controllers/Tags/TagsController.cs
+++ b/src/Equinor.ProCoSys.Preservation.WebApi/Controllers/Tags/TagsController.cs
@@ -639,21 +639,6 @@ namespace Equinor.ProCoSys.Preservation.WebApi.Controllers.Tags
         }
 
         [Authorize(Roles = Permissions.PRESERVATION_PLAN_WRITE)]
-        [HttpPut("{id}/CompletePreservation")]
-        public async Task<IActionResult> CompletePreservation(
-            [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
-            [Required]
-            string plant,
-            [FromRoute] int id,
-            [FromBody] CompletePreservationDto dto)
-        {
-            var command = new CompletePreservationCommand(new List<IdAndRowVersion> { new IdAndRowVersion(id, dto.RowVersion) });
-
-            var result = await _mediator.Send(command);
-            return this.FromResult(result);
-        }
-
-        [Authorize(Roles = Permissions.PRESERVATION_PLAN_WRITE)]
         [HttpPut("CompletePreservation")]
         public async Task<ActionResult<List<IdAndRowVersion>>> CompletePreservation(
             [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
@@ -891,7 +876,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.Controllers.Tags
 
         [AuthorizeAny(Permissions.PRESERVATION_READ, Permissions.PRESERVATION_PLAN_READ)]
         [HttpGet("{id}/Requirements/{tagRequirementId}/PreservationRecord/{preservationRecordGuid}")]
-        public async Task<ActionResult<PreservationRecordDto>>GetPreservationRecord(
+        public async Task<ActionResult<PreservationRecordDto>> GetPreservationRecord(
             [FromHeader(Name = CurrentPlantMiddleware.PlantHeader)]
             [Required]
             string plant,

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagFunctionCommands/UnvoidTagFunction/UnvoidTagFunctionCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagFunctionCommands/UnvoidTagFunction/UnvoidTagFunctionCommandValidatorTests.cs
@@ -23,8 +23,8 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagFunctionCommands.Unvoid
         public void Setup_OkState()
         {
             _tagFunctionValidatorMock = new Mock<ITagFunctionValidator>();
-            _tagFunctionValidatorMock.Setup(r => r.ExistsAsync(_tagFunctionCode, default)).Returns(Task.FromResult(true));
-            _tagFunctionValidatorMock.Setup(r => r.IsVoidedAsync(_tagFunctionCode, default))
+            _tagFunctionValidatorMock.Setup(r => r.ExistsAsync(_tagFunctionCode, _registerCode, default)).Returns(Task.FromResult(true));
+            _tagFunctionValidatorMock.Setup(r => r.IsVoidedAsync(_tagFunctionCode, _registerCode, default))
                 .Returns(Task.FromResult(true));
 
             _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
@@ -45,7 +45,7 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagFunctionCommands.Unvoid
         [TestMethod]
         public void Validate_ShouldFail_WhenTagFunctionNotExists()
         {
-            _tagFunctionValidatorMock.Setup(r => r.ExistsAsync(_tagFunctionCode, default)).Returns(Task.FromResult(false));
+            _tagFunctionValidatorMock.Setup(r => r.ExistsAsync(_tagFunctionCode, _registerCode, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 
@@ -57,7 +57,7 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagFunctionCommands.Unvoid
         [TestMethod]
         public void Validate_ShouldFail_WhenTagFunctionIsNotVoided()
         {
-            _tagFunctionValidatorMock.Setup(r => r.IsVoidedAsync(_tagFunctionCode, default)).Returns(Task.FromResult(false));
+            _tagFunctionValidatorMock.Setup(r => r.IsVoidedAsync(_tagFunctionCode, _registerCode, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagFunctionCommands/VoidTagFunction/VoidTagFunctionCommandValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagFunctionCommands/VoidTagFunction/VoidTagFunctionCommandValidatorTests.cs
@@ -23,7 +23,7 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagFunctionCommands.VoidTa
         public void Setup_OkState()
         {
             _tagFunctionValidatorMock = new Mock<ITagFunctionValidator>();
-            _tagFunctionValidatorMock.Setup(r => r.ExistsAsync(_tagFunctionCode, default)).Returns(Task.FromResult(true));
+            _tagFunctionValidatorMock.Setup(r => r.ExistsAsync(_tagFunctionCode, _registerCode, default)).Returns(Task.FromResult(true));
 
             _rowVersionValidatorMock = new Mock<IRowVersionValidator>();
             _rowVersionValidatorMock.Setup(r => r.IsValid(_rowVersion)).Returns(true);
@@ -43,7 +43,7 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagFunctionCommands.VoidTa
         [TestMethod]
         public void Validate_ShouldFail_WhenTagFunctionNotExists()
         {
-            _tagFunctionValidatorMock.Setup(r => r.ExistsAsync(_tagFunctionCode, default)).Returns(Task.FromResult(false));
+            _tagFunctionValidatorMock.Setup(r => r.ExistsAsync(_tagFunctionCode, _registerCode, default)).Returns(Task.FromResult(false));
 
             var result = _dut.Validate(_command);
 
@@ -55,7 +55,7 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagFunctionCommands.VoidTa
         [TestMethod]
         public void Validate_ShouldFail_WhenTagFunctionIsVoided()
         {
-            _tagFunctionValidatorMock.Setup(r => r.IsVoidedAsync(_tagFunctionCode, default)).Returns(Task.FromResult(true));
+            _tagFunctionValidatorMock.Setup(r => r.IsVoidedAsync(_tagFunctionCode, _registerCode, default)).Returns(Task.FromResult(true));
 
             var result = _dut.Validate(_command);
 

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerNegativeTests.cs
@@ -13,21 +13,21 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task CreateJourney_AsAnonymous_ShouldReturnUnauthorized()
             => await JourneysControllerTestsHelper.CreateJourneyAsync(
                 UserType.Anonymous, TestFactory.UnknownPlant,
-                "Journey1",
+                Guid.NewGuid().ToString(),
                 HttpStatusCode.Unauthorized);
 
         [TestMethod]
         public async Task CreateJourney_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
             => await JourneysControllerTestsHelper.CreateJourneyAsync(
                 UserType.Hacker, TestFactory.UnknownPlant,
-                "Journey1",
+                Guid.NewGuid().ToString(),
                 HttpStatusCode.Forbidden);
 
         [TestMethod]
         public async Task CreateJourney_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
             => await JourneysControllerTestsHelper.CreateJourneyAsync(
                 UserType.LibraryAdmin, TestFactory.UnknownPlant,
-                "Journey1",
+                Guid.NewGuid().ToString(),
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
 
@@ -35,28 +35,28 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task CreateJourney_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
             => await JourneysControllerTestsHelper.CreateJourneyAsync(
                 UserType.Hacker, TestFactory.PlantWithoutAccess,
-                "Journey1",
+                Guid.NewGuid().ToString(),
                 HttpStatusCode.Forbidden);
 
         [TestMethod]
         public async Task CreateJourney_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
             => await JourneysControllerTestsHelper.CreateJourneyAsync(
                 UserType.LibraryAdmin, TestFactory.PlantWithoutAccess,
-                "Journey1",
+                Guid.NewGuid().ToString(),
                 HttpStatusCode.Forbidden);
 
         [TestMethod]
         public async Task CreateJourney_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
             => await JourneysControllerTestsHelper.CreateJourneyAsync(
                 UserType.Planner, TestFactory.PlantWithAccess,
-                "Journey1",
+                Guid.NewGuid().ToString(),
                 HttpStatusCode.Forbidden);
 
         [TestMethod]
         public async Task CreateJourney_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
             => await JourneysControllerTestsHelper.CreateJourneyAsync(
                 UserType.Preserver, TestFactory.PlantWithAccess,
-                "Journey1",
+                Guid.NewGuid().ToString(),
                 HttpStatusCode.Forbidden);
         #endregion
 
@@ -110,21 +110,21 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task GetJourney_AsAnonymous_ShouldReturnUnauthorized()
             => await JourneysControllerTestsHelper.GetJourneyAsync(
                 UserType.Anonymous, TestFactory.UnknownPlant,
-                9999,
+                JourneyId1UnderTest,
                 HttpStatusCode.Unauthorized);
 
         [TestMethod]
         public async Task GetJourney_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
             => await JourneysControllerTestsHelper.GetJourneyAsync(
                 UserType.Hacker, TestFactory.UnknownPlant,
-                9999,
+                JourneyId1UnderTest,
                 HttpStatusCode.Forbidden);
 
         [TestMethod]
         public async Task GetJourney_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
             => await JourneysControllerTestsHelper.GetJourneyAsync(
                 UserType.LibraryAdmin, TestFactory.UnknownPlant,
-                9999,
+                JourneyId1UnderTest,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
 
@@ -132,29 +132,285 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task GetJourney_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
             => await JourneysControllerTestsHelper.GetJourneyAsync(
                 UserType.Hacker, TestFactory.PlantWithoutAccess,
-                9999,
+                JourneyId1UnderTest,
                 HttpStatusCode.Forbidden);
 
         [TestMethod]
         public async Task GetJourney_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
             => await JourneysControllerTestsHelper.GetJourneyAsync(
                 UserType.LibraryAdmin, TestFactory.PlantWithoutAccess,
-                9999,
+                JourneyId1UnderTest,
                 HttpStatusCode.Forbidden);
 
         [TestMethod]
         public async Task GetJourney_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
             => await JourneysControllerTestsHelper.GetJourneyAsync(
                 UserType.Planner, TestFactory.PlantWithAccess,
-                9999,
+                JourneyId1UnderTest,
                 HttpStatusCode.Forbidden);
 
         [TestMethod]
         public async Task GetJourney_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
             => await JourneysControllerTestsHelper.GetJourneyAsync(
                 UserType.Preserver, TestFactory.PlantWithAccess,
-                9999,
+                JourneyId1UnderTest,
                 HttpStatusCode.Forbidden);
+        #endregion
+
+        #region UpdateJourney
+        [TestMethod]
+        public async Task UpdateJourney_AsAnonymous_ShouldReturnUnauthorized()
+            => await JourneysControllerTestsHelper.UpdateJourneyAsync(
+                UserType.Anonymous,
+                TestFactory.UnknownPlant,
+                JourneyId1UnderTest,
+                Guid.NewGuid().ToString(),
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task UpdateJourney_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await JourneysControllerTestsHelper.UpdateJourneyAsync(
+                UserType.Hacker,
+                TestFactory.UnknownPlant,
+                JourneyId1UnderTest,
+                Guid.NewGuid().ToString(),
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateJourney_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await JourneysControllerTestsHelper.UpdateJourneyAsync(
+                UserType.LibraryAdmin,
+                TestFactory.UnknownPlant,
+                JourneyId1UnderTest,
+                Guid.NewGuid().ToString(),
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task UpdateJourney_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await JourneysControllerTestsHelper.UpdateJourneyAsync(
+                UserType.Hacker,
+                TestFactory.PlantWithoutAccess,
+                JourneyId1UnderTest,
+                Guid.NewGuid().ToString(),
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateJourney_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await JourneysControllerTestsHelper.UpdateJourneyAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithoutAccess,
+                JourneyId1UnderTest,
+                Guid.NewGuid().ToString(),
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateJourney_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await JourneysControllerTestsHelper.UpdateJourneyAsync(
+                UserType.Planner, TestFactory.PlantWithAccess,
+                JourneyId1UnderTest,
+                Guid.NewGuid().ToString(),
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateJourney_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await JourneysControllerTestsHelper.UpdateJourneyAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                JourneyId1UnderTest,
+                Guid.NewGuid().ToString(),
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateJourney_AsAdmin_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            // Arrange
+            var journeyId = await JourneysControllerTestsHelper.CreateJourneyAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                Guid.NewGuid().ToString());
+
+            // Act
+            await JourneysControllerTestsHelper.UpdateJourneyAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                journeyId,
+                Guid.NewGuid().ToString(),
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
+        #endregion
+
+        #region VoidJourney
+        [TestMethod]
+        public async Task VoidJourney_AsAnonymous_ShouldReturnUnauthorized()
+            => await JourneysControllerTestsHelper.VoidJourneyAsync(
+                UserType.Anonymous, TestFactory.UnknownPlant,
+                JourneyId1UnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task VoidJourney_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await JourneysControllerTestsHelper.VoidJourneyAsync(
+                UserType.Hacker, TestFactory.UnknownPlant,
+                JourneyId1UnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidJourney_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await JourneysControllerTestsHelper.VoidJourneyAsync(
+                UserType.LibraryAdmin, TestFactory.UnknownPlant,
+                JourneyId1UnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task VoidJourney_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await JourneysControllerTestsHelper.VoidJourneyAsync(
+                UserType.Hacker, TestFactory.PlantWithoutAccess,
+                JourneyId1UnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidJourney_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await JourneysControllerTestsHelper.VoidJourneyAsync(
+                UserType.LibraryAdmin, TestFactory.PlantWithoutAccess,
+                JourneyId1UnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidJourney_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await JourneysControllerTestsHelper.VoidJourneyAsync(
+                UserType.Planner, TestFactory.PlantWithAccess,
+                JourneyId1UnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidJourney_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await JourneysControllerTestsHelper.VoidJourneyAsync(
+                UserType.Preserver, TestFactory.PlantWithAccess,
+                JourneyId1UnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidJourney_AsAdmin_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            // Arrange
+            var journeyId = await JourneysControllerTestsHelper.CreateJourneyAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                Guid.NewGuid().ToString());
+
+            // Act
+            await JourneysControllerTestsHelper.VoidJourneyAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                journeyId,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
+
+        #endregion
+
+        #region UnvoidJourney
+        [TestMethod]
+        public async Task UnvoidJourney_AsAnonymous_ShouldReturnUnauthorized()
+            => await JourneysControllerTestsHelper.UnvoidJourneyAsync(
+                UserType.Anonymous, TestFactory.UnknownPlant,
+                JourneyId1UnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task UnvoidJourney_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await JourneysControllerTestsHelper.UnvoidJourneyAsync(
+                UserType.Hacker, TestFactory.UnknownPlant,
+                JourneyId1UnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidJourney_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await JourneysControllerTestsHelper.UnvoidJourneyAsync(
+                UserType.LibraryAdmin, TestFactory.UnknownPlant,
+                JourneyId1UnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task UnvoidJourney_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await JourneysControllerTestsHelper.UnvoidJourneyAsync(
+                UserType.Hacker, TestFactory.PlantWithoutAccess,
+                JourneyId1UnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidJourney_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await JourneysControllerTestsHelper.UnvoidJourneyAsync(
+                UserType.LibraryAdmin, TestFactory.PlantWithoutAccess,
+                JourneyId1UnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidJourney_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await JourneysControllerTestsHelper.UnvoidJourneyAsync(
+                UserType.Planner, TestFactory.PlantWithAccess,
+                JourneyId1UnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidJourney_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await JourneysControllerTestsHelper.UnvoidJourneyAsync(
+                UserType.Preserver, TestFactory.PlantWithAccess,
+                JourneyId1UnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidJourney_AsAdmin_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            // Arrange
+            var journeyId = await JourneysControllerTestsHelper.CreateJourneyAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                Guid.NewGuid().ToString());
+            var journey = await JourneysControllerTestsHelper.GetJourneyAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                journeyId);
+
+            await JourneysControllerTestsHelper.VoidJourneyAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                journeyId,
+                journey.RowVersion);
+
+            // Act
+            await JourneysControllerTestsHelper.UnvoidJourneyAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                journeyId,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
         #endregion
 
         #region CreateStep
@@ -162,30 +418,30 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task CreateStep_AsAnonymous_ShouldReturnUnauthorized()
             => await JourneysControllerTestsHelper.CreateStepAsync(
                 UserType.Anonymous, TestFactory.UnknownPlant,
-                9999,
-                "Step1",
-                7777,
-                "RC",
+                JourneyId1UnderTest,
+                Guid.NewGuid().ToString(),
+                OtherModeIdUnderTest,
+                KnownTestData.ResponsibleCode,
                 HttpStatusCode.Unauthorized);
 
         [TestMethod]
         public async Task CreateStep_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
             => await JourneysControllerTestsHelper.CreateStepAsync(
                 UserType.Hacker, TestFactory.UnknownPlant,
-                9999,
-                "Step1",
-                7777,
-                "RC",
+                JourneyId1UnderTest,
+                Guid.NewGuid().ToString(),
+                OtherModeIdUnderTest,
+                KnownTestData.ResponsibleCode,
                 HttpStatusCode.Forbidden);
 
         [TestMethod]
         public async Task CreateStep_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
             => await JourneysControllerTestsHelper.CreateStepAsync(
                 UserType.LibraryAdmin, TestFactory.UnknownPlant,
-                9999,
-                "Step1",
-                7777,
-                "RC",
+                JourneyId1UnderTest,
+                Guid.NewGuid().ToString(),
+                OtherModeIdUnderTest,
+                KnownTestData.ResponsibleCode,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
 
@@ -193,40 +449,40 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task CreateStep_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
             => await JourneysControllerTestsHelper.CreateStepAsync(
                 UserType.Hacker, TestFactory.PlantWithoutAccess,
-                9999,
-                "Step1",
-                7777,
-                "RC",
+                JourneyId1UnderTest,
+                Guid.NewGuid().ToString(),
+                OtherModeIdUnderTest,
+                KnownTestData.ResponsibleCode,
                 HttpStatusCode.Forbidden);
 
         [TestMethod]
         public async Task CreateStep_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
             => await JourneysControllerTestsHelper.CreateStepAsync(
                 UserType.LibraryAdmin, TestFactory.PlantWithoutAccess,
-                9999,
-                "Step1",
-                7777,
-                "RC",
+                JourneyId1UnderTest,
+                Guid.NewGuid().ToString(),
+                OtherModeIdUnderTest,
+                KnownTestData.ResponsibleCode,
                 HttpStatusCode.Forbidden);
 
         [TestMethod]
         public async Task CreateStep_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
             => await JourneysControllerTestsHelper.CreateStepAsync(
                 UserType.Planner, TestFactory.PlantWithAccess,
-                9999,
-                "Step1",
-                7777,
-                "RC",
+                JourneyId1UnderTest,
+                Guid.NewGuid().ToString(),
+                OtherModeIdUnderTest,
+                KnownTestData.ResponsibleCode,
                 HttpStatusCode.Forbidden);
 
         [TestMethod]
         public async Task CreateStep_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
             => await JourneysControllerTestsHelper.CreateStepAsync(
                 UserType.Preserver, TestFactory.PlantWithAccess,
-                9999,
-                "Step1",
-                7777,
-                "RC",
+                JourneyId1UnderTest,
+                Guid.NewGuid().ToString(),
+                OtherModeIdUnderTest,
+                KnownTestData.ResponsibleCode,
                 HttpStatusCode.Forbidden);
         #endregion
 
@@ -235,11 +491,11 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task UpdateStep_AsAnonymous_ShouldReturnUnauthorized()
             => await JourneysControllerTestsHelper.UpdateStepAsync(
                 UserType.Anonymous, TestFactory.UnknownPlant,
-                9999,
-                8888,
-                "Step1",
-                7777,
-                "RC",
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
+                Guid.NewGuid().ToString(),
+                OtherModeIdUnderTest,
+                KnownTestData.ResponsibleCode,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Unauthorized);
 
@@ -247,11 +503,11 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task UpdateStep_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
             => await JourneysControllerTestsHelper.UpdateStepAsync(
                 UserType.Hacker, TestFactory.UnknownPlant,
-                9999,
-                8888,
-                "Step1",
-                7777,
-                "RC",
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
+                Guid.NewGuid().ToString(),
+                OtherModeIdUnderTest,
+                KnownTestData.ResponsibleCode,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -259,11 +515,11 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task UpdateStep_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
             => await JourneysControllerTestsHelper.UpdateStepAsync(
                 UserType.LibraryAdmin, TestFactory.UnknownPlant,
-                9999,
-                8888,
-                "Step1",
-                7777,
-                "RC",
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
+                Guid.NewGuid().ToString(),
+                OtherModeIdUnderTest,
+                KnownTestData.ResponsibleCode,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
@@ -272,11 +528,11 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task UpdateStep_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
             => await JourneysControllerTestsHelper.UpdateStepAsync(
                 UserType.Hacker, TestFactory.PlantWithoutAccess,
-                9999,
-                8888,
-                "Step1",
-                7777,
-                "RC",
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
+                Guid.NewGuid().ToString(),
+                OtherModeIdUnderTest,
+                KnownTestData.ResponsibleCode,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -284,11 +540,11 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task UpdateStep_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
             => await JourneysControllerTestsHelper.UpdateStepAsync(
                 UserType.LibraryAdmin, TestFactory.PlantWithoutAccess,
-                9999,
-                8888,
-                "Step1",
-                7777,
-                "RC",
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
+                Guid.NewGuid().ToString(),
+                OtherModeIdUnderTest,
+                KnownTestData.ResponsibleCode,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -296,11 +552,11 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task UpdateStep_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
             => await JourneysControllerTestsHelper.UpdateStepAsync(
                 UserType.Planner, TestFactory.PlantWithAccess,
-                9999,
-                8888,
-                "Step1",
-                7777,
-                "RC",
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
+                Guid.NewGuid().ToString(),
+                OtherModeIdUnderTest,
+                KnownTestData.ResponsibleCode,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -308,11 +564,11 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task UpdateStep_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
             => await JourneysControllerTestsHelper.UpdateStepAsync(
                 UserType.Preserver, TestFactory.PlantWithAccess,
-                9999,
-                8888,
-                "Step1",
-                7777,
-                "RC",
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
+                Guid.NewGuid().ToString(),
+                OtherModeIdUnderTest,
+                KnownTestData.ResponsibleCode,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -329,6 +585,24 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
                 HttpStatusCode.BadRequest,
                 "Journey and/or step doesn't exist!");
 
+        [TestMethod]
+        public async Task UpdateStep_AsAdmin_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            // Arrange
+            var (journeyIdUnderTest, step) = await CreateStepAsync(Guid.NewGuid().ToString(), OtherModeIdUnderTest);
+           
+            // Act
+            await JourneysControllerTestsHelper.UpdateStepAsync(
+                           UserType.LibraryAdmin,
+                           TestFactory.PlantWithAccess,
+                           journeyIdUnderTest,
+                           step.Id,
+                           Guid.NewGuid().ToString(),
+                           OtherModeIdUnderTest,
+                           KnownTestData.ResponsibleCode,
+                           TestFactory.WrongButValidRowVersion,
+                           HttpStatusCode.Conflict);
+        }
         #endregion
 
         #region VoidStep
@@ -336,8 +610,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task VoidStep_AsAnonymous_ShouldReturnUnauthorized()
             => await JourneysControllerTestsHelper.VoidStepAsync(
                 UserType.Anonymous, TestFactory.UnknownPlant,
-                9999,
-                8888,
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Unauthorized);
 
@@ -345,8 +619,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task VoidStep_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
             => await JourneysControllerTestsHelper.VoidStepAsync(
                 UserType.Hacker, TestFactory.UnknownPlant,
-                9999,
-                8888,
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -354,8 +628,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task VoidStep_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
             => await JourneysControllerTestsHelper.VoidStepAsync(
                 UserType.LibraryAdmin, TestFactory.UnknownPlant,
-                9999,
-                8888,
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
@@ -364,8 +638,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task VoidStep_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
             => await JourneysControllerTestsHelper.VoidStepAsync(
                 UserType.Hacker, TestFactory.PlantWithoutAccess,
-                9999,
-                8888,
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -373,8 +647,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task VoidStep_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
             => await JourneysControllerTestsHelper.VoidStepAsync(
                 UserType.LibraryAdmin, TestFactory.PlantWithoutAccess,
-                9999,
-                8888,
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -382,8 +656,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task VoidStep_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
             => await JourneysControllerTestsHelper.VoidStepAsync(
                 UserType.Planner, TestFactory.PlantWithAccess,
-                9999,
-                8888,
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -391,8 +665,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task VoidStep_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
             => await JourneysControllerTestsHelper.VoidStepAsync(
                 UserType.Preserver, TestFactory.PlantWithAccess,
-                9999,
-                8888,
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -405,6 +679,23 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "Journey and/or step doesn't exist!");
+
+        [TestMethod]
+        public async Task VoidStep_AsAdmin_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            // Arrange
+            var (journeyIdUnderTest, step) = await CreateStepAsync(Guid.NewGuid().ToString(), OtherModeIdUnderTest);
+
+            // Act
+            await JourneysControllerTestsHelper.VoidStepAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                journeyIdUnderTest,
+                step.Id,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
+         
         #endregion
 
         #region UnvoidStep
@@ -412,8 +703,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task UnvoidStep_AsAnonymous_ShouldReturnUnauthorized()
             => await JourneysControllerTestsHelper.UnvoidStepAsync(
                 UserType.Anonymous, TestFactory.UnknownPlant,
-                9999,
-                8888,
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Unauthorized);
 
@@ -421,8 +712,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task UnvoidStep_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
             => await JourneysControllerTestsHelper.UnvoidStepAsync(
                 UserType.Hacker, TestFactory.UnknownPlant,
-                9999,
-                8888,
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -430,8 +721,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task UnvoidStep_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
             => await JourneysControllerTestsHelper.UnvoidStepAsync(
                 UserType.LibraryAdmin, TestFactory.UnknownPlant,
-                9999,
-                8888,
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
@@ -440,8 +731,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task UnvoidStep_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
             => await JourneysControllerTestsHelper.UnvoidStepAsync(
                 UserType.Hacker, TestFactory.PlantWithoutAccess,
-                9999,
-                8888,
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -449,8 +740,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task UnvoidStep_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
             => await JourneysControllerTestsHelper.UnvoidStepAsync(
                 UserType.LibraryAdmin, TestFactory.PlantWithoutAccess,
-                9999,
-                8888,
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -458,8 +749,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task UnvoidStep_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
             => await JourneysControllerTestsHelper.UnvoidStepAsync(
                 UserType.Planner, TestFactory.PlantWithAccess,
-                9999,
-                8888,
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -467,8 +758,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task UnvoidStep_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
             => await JourneysControllerTestsHelper.UnvoidStepAsync(
                 UserType.Preserver, TestFactory.PlantWithAccess,
-                9999,
-                8888,
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -481,6 +772,114 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "Journey and/or step doesn't exist!");
+
+        [TestMethod]
+        public async Task UnvoidStep_AsAdmin_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            // Arrange
+            var (journeyIdUnderTest, step) = await CreateStepAsync(Guid.NewGuid().ToString(), OtherModeIdUnderTest);
+            await JourneysControllerTestsHelper.VoidStepAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                journeyIdUnderTest,
+                step.Id,
+                step.RowVersion);
+            
+            // Act
+            await JourneysControllerTestsHelper.UnvoidStepAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                journeyIdUnderTest,
+                step.Id,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
+        #endregion
+
+        #region DeleteJourney
+        [TestMethod]
+        public async Task DeleteJourney_AsAnonymous_ShouldReturnUnauthorized()
+            => await JourneysControllerTestsHelper.DeleteJourneyAsync(
+                UserType.Anonymous, TestFactory.UnknownPlant,
+                JourneyId1UnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task DeleteJourney_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await JourneysControllerTestsHelper.DeleteJourneyAsync(
+                UserType.Hacker, TestFactory.UnknownPlant,
+                JourneyId1UnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task DeleteJourney_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await JourneysControllerTestsHelper.DeleteJourneyAsync(
+                UserType.LibraryAdmin, TestFactory.UnknownPlant,
+                JourneyId1UnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task DeleteJourney_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await JourneysControllerTestsHelper.DeleteJourneyAsync(
+                UserType.Hacker, TestFactory.PlantWithoutAccess,
+                JourneyId1UnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task DeleteJourney_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await JourneysControllerTestsHelper.DeleteJourneyAsync(
+                UserType.LibraryAdmin, TestFactory.PlantWithoutAccess,
+                JourneyId1UnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task DeleteJourney_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await JourneysControllerTestsHelper.DeleteJourneyAsync(
+                UserType.Planner, TestFactory.PlantWithAccess,
+                JourneyId1UnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task DeleteJourney_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await JourneysControllerTestsHelper.DeleteJourneyAsync(
+                UserType.Preserver, TestFactory.PlantWithAccess,
+                JourneyId1UnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task DeleteJourney_AsAdmin_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            // Arrange
+            var journeyId = await JourneysControllerTestsHelper.CreateJourneyAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                Guid.NewGuid().ToString());
+            var journey = await JourneysControllerTestsHelper.GetJourneyAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                journeyId);
+            await JourneysControllerTestsHelper.VoidJourneyAsync(
+               UserType.LibraryAdmin,
+               TestFactory.PlantWithAccess,
+               journeyId,
+               journey.RowVersion);
+
+            // Act
+            await JourneysControllerTestsHelper.DeleteJourneyAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                journeyId,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
         #endregion
 
         #region DeleteStep
@@ -488,8 +887,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task DeleteStep_AsAnonymous_ShouldReturnUnauthorized()
             => await JourneysControllerTestsHelper.DeleteStepAsync(
                 UserType.Anonymous, TestFactory.UnknownPlant,
-                9999,
-                8888,
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Unauthorized);
 
@@ -497,8 +896,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task DeleteStep_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
             => await JourneysControllerTestsHelper.DeleteStepAsync(
                 UserType.Hacker, TestFactory.UnknownPlant,
-                9999,
-                8888,
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -506,8 +905,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task DeleteStep_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
             => await JourneysControllerTestsHelper.DeleteStepAsync(
                 UserType.LibraryAdmin, TestFactory.UnknownPlant,
-                9999,
-                8888,
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
@@ -516,8 +915,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task DeleteStep_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
             => await JourneysControllerTestsHelper.DeleteStepAsync(
                 UserType.Hacker, TestFactory.PlantWithoutAccess,
-                9999,
-                8888,
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -525,8 +924,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task DeleteStep_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
             => await JourneysControllerTestsHelper.DeleteStepAsync(
                 UserType.LibraryAdmin, TestFactory.PlantWithoutAccess,
-                9999,
-                8888,
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -534,8 +933,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task DeleteStep_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
             => await JourneysControllerTestsHelper.DeleteStepAsync(
                 UserType.Planner, TestFactory.PlantWithAccess,
-                9999,
-                8888,
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -543,8 +942,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
         public async Task DeleteStep_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
             => await JourneysControllerTestsHelper.DeleteStepAsync(
                 UserType.Preserver, TestFactory.PlantWithAccess,
-                9999,
-                8888,
+                JourneyId1UnderTest,
+                FirstStepIdInJourney1UnderTest,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -558,6 +957,28 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
                 HttpStatusCode.BadRequest,
                 "Journey and/or step doesn't exist!");
 
+
+        [TestMethod]
+        public async Task DeleteStep_AsAdmin_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            // Arrange
+            var (journeyIdUnderTest, step) = await CreateStepAsync(Guid.NewGuid().ToString(), OtherModeIdUnderTest);
+            await JourneysControllerTestsHelper.VoidStepAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                journeyIdUnderTest,
+                step.Id,
+                step.RowVersion);
+
+            // Act
+            await JourneysControllerTestsHelper.DeleteStepAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                journeyIdUnderTest,
+                step.Id,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
         #endregion
 
         #region SwapSteps
@@ -566,7 +987,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
             => await JourneysControllerTestsHelper.SwapStepsAsync(
                 UserType.Anonymous,
                 TestFactory.UnknownPlant,
-                9999,
+                JourneyId1UnderTest,
                 new StepIdAndRowVersion
                 {
                     Id = 2, 
@@ -584,7 +1005,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
             => await JourneysControllerTestsHelper.SwapStepsAsync(
                 UserType.Hacker,
                 TestFactory.UnknownPlant,
-                9999,
+                JourneyId1UnderTest,
                 new StepIdAndRowVersion
                 {
                     Id = 2, 
@@ -602,7 +1023,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
             => await JourneysControllerTestsHelper.SwapStepsAsync(
                 UserType.LibraryAdmin,
                 TestFactory.UnknownPlant,
-                9999,
+                JourneyId1UnderTest,
                 new StepIdAndRowVersion
                 {
                     Id = 2, 
@@ -621,7 +1042,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
             => await JourneysControllerTestsHelper.SwapStepsAsync(
                 UserType.Hacker,
                 TestFactory.PlantWithoutAccess,
-                9999,
+                JourneyId1UnderTest,
                 new StepIdAndRowVersion
                 {
                     Id = 2, 
@@ -639,7 +1060,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
             => await JourneysControllerTestsHelper.SwapStepsAsync(
                 UserType.LibraryAdmin,
                 TestFactory.PlantWithoutAccess,
-                9999,
+                JourneyId1UnderTest,
                 new StepIdAndRowVersion
                 {
                     Id = 2, 
@@ -657,7 +1078,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
             => await JourneysControllerTestsHelper.SwapStepsAsync(
                 UserType.Planner,
                 TestFactory.PlantWithAccess,
-                9999,
+                JourneyId1UnderTest,
                 new StepIdAndRowVersion
                 {
                     Id = 2, 
@@ -675,7 +1096,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
             => await JourneysControllerTestsHelper.SwapStepsAsync(
                 UserType.Preserver,
                 TestFactory.PlantWithAccess,
-                9999,
+                JourneyId1UnderTest,
                 new StepIdAndRowVersion
                 {
                     Id = 2, 
@@ -688,6 +1109,41 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
                 },
                 HttpStatusCode.Forbidden);
 
+
+        [TestMethod]
+        public async Task SwapSteps_AsAdmin_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            var (journeyIdUnderTest, originalFirstStep) = await CreateStepAsync(Guid.NewGuid().ToString(), SupModeAIdUnderTest);
+            Assert.IsTrue(originalFirstStep.Mode.ForSupplier);
+
+            var stepId = await JourneysControllerTestsHelper.CreateStepAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                journeyIdUnderTest,
+                Guid.NewGuid().ToString(),
+                OtherModeIdUnderTest,
+                KnownTestData.ResponsibleCode);
+            var originalSecondStep = await GetStepDetailsAsync(journeyIdUnderTest, stepId);
+            Assert.IsFalse(originalSecondStep.Mode.ForSupplier);
+
+            // Act
+            await JourneysControllerTestsHelper.SwapStepsAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                journeyIdUnderTest,
+                new StepIdAndRowVersion
+                {
+                    Id = originalFirstStep.Id,
+                    RowVersion = TestFactory.WrongButValidRowVersion
+                },
+                new StepIdAndRowVersion
+                {
+                    Id = originalSecondStep.Id,
+                    RowVersion = originalSecondStep.RowVersion
+                },
+                HttpStatusCode.Conflict);
+
+        }
         #endregion
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Journeys/JourneysControllerTestsBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Preservation.MainApi.Responsible;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -37,6 +38,35 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys
                 {
                     Code = KnownTestData.ResponsibleCode, Description = KnownTestData.ResponsibleDescription
                 }));
+        }
+
+        internal async Task<StepDetailsDto> GetStepDetailsAsync(int journeyId, int stepId)
+        {
+            var journey = await JourneysControllerTestsHelper.GetJourneyAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                journeyId);
+            return journey.Steps.SingleOrDefault(s => s.Id == stepId);
+        }
+
+        internal async Task<(int, StepDetailsDto)> CreateStepAsync(string stepTitle, int modeId)
+        {
+            var journeyIdUnderTest = await JourneysControllerTestsHelper.CreateJourneyAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                Guid.NewGuid().ToString());
+
+            // Act
+            var stepId = await JourneysControllerTestsHelper.CreateStepAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                journeyIdUnderTest,
+                stepTitle,
+                modeId,
+                KnownTestData.ResponsibleCode);
+
+            var step = await GetStepDetailsAsync(journeyIdUnderTest, stepId);
+            return (journeyIdUnderTest, step);
         }
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Persons/PersonsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Persons/PersonsControllerNegativeTests.cs
@@ -1,0 +1,260 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Persons
+{
+    [TestClass]
+    public class PersonsControllerNegativeTests : TestBase
+    {
+        private int _filterIdUnderTest;
+
+        [TestInitialize]
+        public async Task TestInitializeAsync()
+        {
+            var filter = await PersonsControllerTestsHelper.CreateAndGetFilterAsync(
+                    UserType.Preserver,
+                    TestFactory.PlantWithAccess,
+                    TestFactory.ProjectWithAccess,
+                    Guid.NewGuid().ToString());
+            _filterIdUnderTest = filter.Id;
+        }
+
+        #region GetSavedFilters
+        [TestMethod]
+        public async Task GetSavedFilters_AsAnonymous_ShouldReturnUnauthorized()
+            => await PersonsControllerTestsHelper.GetSavedFiltersInProjectAsync(
+                UserType.Anonymous,
+                TestFactory.UnknownPlant,
+                TestFactory.ProjectWithAccess,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task GetSavedFilters_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await PersonsControllerTestsHelper.GetSavedFiltersInProjectAsync(
+                UserType.Hacker,
+                TestFactory.UnknownPlant,
+                "P",
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task GetSavedFilters_AsPreserver_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await PersonsControllerTestsHelper.GetSavedFiltersInProjectAsync(
+                UserType.Preserver,
+                TestFactory.UnknownPlant,
+                "P",
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task GetSavedFilters_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await PersonsControllerTestsHelper.GetSavedFiltersInProjectAsync(
+                UserType.Hacker,
+                TestFactory.PlantWithoutAccess,
+                "P",
+                HttpStatusCode.Forbidden);
+        #endregion
+        
+        #region Create
+        [TestMethod]
+        public async Task CreateSavedFilter_AsAnonymous_ShouldReturnUnauthorized()
+            => await PersonsControllerTestsHelper.CreateSavedFilterAsync(
+                UserType.Anonymous,
+                TestFactory.UnknownPlant,
+                "P",
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                false,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task CreateSavedFilter_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await PersonsControllerTestsHelper.CreateSavedFilterAsync(
+                UserType.Hacker,
+                TestFactory.UnknownPlant,
+                "P",
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                false,
+                HttpStatusCode.Forbidden,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task CreateSavedFilter_AsPreserver_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await PersonsControllerTestsHelper.CreateSavedFilterAsync(
+                UserType.Preserver,
+                TestFactory.UnknownPlant,
+                "P",
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                false,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task CreateSavedFilter_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await PersonsControllerTestsHelper.CreateSavedFilterAsync(
+                UserType.Hacker,
+                TestFactory.PlantWithoutAccess,
+                "P",
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                false,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task CreateSavedFilter_AsPreserver_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await PersonsControllerTestsHelper.CreateSavedFilterAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithoutAccess,
+                "P",
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                false,
+                HttpStatusCode.Forbidden);
+        #endregion
+        
+        #region Update
+        [TestMethod]
+        public async Task UpdateSavedFilter_AsAnonymous_ShouldReturnUnauthorized()
+            => await PersonsControllerTestsHelper.UpdateSavedFilterAsync(
+                UserType.Anonymous,
+                TestFactory.UnknownPlant,
+                _filterIdUnderTest,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                false,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task UpdateSavedFilter_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await PersonsControllerTestsHelper.UpdateSavedFilterAsync(
+                UserType.Hacker,
+                TestFactory.UnknownPlant,
+                _filterIdUnderTest,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                false,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateSavedFilter_AsPreserver_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await PersonsControllerTestsHelper.UpdateSavedFilterAsync(
+                UserType.Preserver,
+                TestFactory.UnknownPlant,
+                _filterIdUnderTest,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                false,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task UpdateSavedFilter_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await PersonsControllerTestsHelper.UpdateSavedFilterAsync(
+                UserType.Hacker,
+                TestFactory.PlantWithoutAccess,
+                _filterIdUnderTest,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                false,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateSavedFilter_AsPreserver_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await PersonsControllerTestsHelper.UpdateSavedFilterAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithoutAccess,
+                _filterIdUnderTest,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                false,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateSavedFilter_AsPreserver_ShouldReturnConflict_WhenWrongRowVersion()
+            => await PersonsControllerTestsHelper.UpdateSavedFilterAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                _filterIdUnderTest,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                false,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        
+        #endregion
+
+        #region Delete
+        [TestMethod]
+        public async Task DeleteSavedFilter_AsAnonymous_ShouldReturnUnauthorized()
+            => await PersonsControllerTestsHelper.DeleteSavedFilterAsync(
+                UserType.Anonymous,
+                TestFactory.UnknownPlant,
+                _filterIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task DeleteSavedFilter_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await PersonsControllerTestsHelper.DeleteSavedFilterAsync(
+                UserType.Hacker,
+                TestFactory.UnknownPlant,
+                _filterIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task DeleteSavedFilter_AsPreserver_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await PersonsControllerTestsHelper.DeleteSavedFilterAsync(
+                UserType.Preserver,
+                TestFactory.UnknownPlant,
+                _filterIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task DeleteSavedFilter_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await PersonsControllerTestsHelper.DeleteSavedFilterAsync(
+                UserType.Hacker,
+                TestFactory.PlantWithoutAccess,
+                _filterIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task DeleteSavedFilter_AsPreserver_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await PersonsControllerTestsHelper.DeleteSavedFilterAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithoutAccess,
+                _filterIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task DeleteSavedFilter_AsPreserver_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            var filter = await PersonsControllerTestsHelper.CreateAndGetFilterAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                TestFactory.ProjectWithAccess,
+                Guid.NewGuid().ToString());
+
+            // Act
+            await PersonsControllerTestsHelper.DeleteSavedFilterAsync(
+                           UserType.Preserver,
+                           TestFactory.PlantWithAccess,
+                           filter.Id,
+                           TestFactory.WrongButValidRowVersion,
+                           HttpStatusCode.Conflict);
+        }
+        #endregion
+    }
+}

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Persons/PersonsControllerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Persons/PersonsControllerTests.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Persons
+{
+    [TestClass]
+    public class PersonsControllerTests : TestBase
+    {
+        [TestMethod]
+        public async Task CreateSavedFilter_AsPreserver_ShouldCreateSavedFilter()
+        {
+            var title = Guid.NewGuid().ToString();
+
+            // Act
+            var filter = await PersonsControllerTestsHelper.CreateAndGetFilterAsync(
+                UserType.Preserver, 
+                TestFactory.PlantWithAccess,
+                TestFactory.ProjectWithAccess,
+                title);
+
+            // Assert
+            Assert.AreEqual(title, filter.Title);
+        }
+
+        [TestMethod]
+        public async Task UpdateSavedFilter_AsPreserver_ShouldUpdateSavedFilterAndRowVersion()
+        {
+            var filter = await PersonsControllerTestsHelper.CreateAndGetFilterAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                TestFactory.ProjectWithAccess,
+                Guid.NewGuid().ToString());
+            var newTitle = Guid.NewGuid().ToString();
+
+            // Act
+            var newRowVersion = await PersonsControllerTestsHelper.UpdateSavedFilterAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                filter.Id,
+                newTitle,
+                Guid.NewGuid().ToString(), 
+                false,
+                filter.RowVersion);
+
+            // Assert
+            AssertRowVersionChange(filter.RowVersion, newRowVersion);
+            var filters = await PersonsControllerTestsHelper.GetSavedFiltersInProjectAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                TestFactory.ProjectWithAccess);
+            filter = filters.Single(f => f.Id == filter.Id);
+            Assert.AreEqual(newTitle, filter.Title);
+        }
+
+        [TestMethod]
+        public async Task DeleteSavedFilter_AsPreserver_ShouldDeleteSavedFilter()
+        {
+            // Arrange
+            var filter = await PersonsControllerTestsHelper.CreateAndGetFilterAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                TestFactory.ProjectWithAccess,
+                Guid.NewGuid().ToString());
+
+            // Act
+            await PersonsControllerTestsHelper.DeleteSavedFilterAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                filter.Id,
+                filter.RowVersion);
+
+            // Assert
+            var filters = await PersonsControllerTestsHelper.GetSavedFiltersInProjectAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                TestFactory.ProjectWithAccess);
+            Assert.IsNull(filters.SingleOrDefault(m => m.Id == filter.Id));
+        }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Persons/PersonsControllerTestsHelper.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Persons/PersonsControllerTestsHelper.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Persons
+{
+    public static class PersonsControllerTestsHelper
+    {
+        private const string _route = "Persons";
+
+        public static async Task<SavedFilterDto> CreateAndGetFilterAsync(
+            UserType userType,
+            string plant,
+            string projectName,
+            string title)
+        {
+            var id = await CreateSavedFilterAsync(
+                userType,
+                plant,
+                projectName,
+                title,
+                Guid.NewGuid().ToString(),
+                false);
+
+            // Assert
+            Assert.IsTrue(id > 0);
+            var filters = await GetSavedFiltersInProjectAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                TestFactory.ProjectWithAccess);
+            var filter = filters.SingleOrDefault(f => f.Id == id);
+            Assert.IsNotNull(filter);
+            return filter;
+
+        }
+
+        public static async Task<List<SavedFilterDto>> GetSavedFiltersInProjectAsync(
+            UserType userType,
+            string plant,
+            string projectName,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var parameters = new ParameterCollection
+            {
+                {"projectName", projectName}
+            };
+            var url = $"{_route}/SavedFilters{parameters}";
+            var response = await TestFactory.Instance.GetHttpClient(userType, plant).GetAsync(url);
+
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (expectedStatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            var content = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<List<SavedFilterDto>>(content);
+        }
+
+        public static async Task<int> CreateSavedFilterAsync(
+            UserType userType,
+            string plant,
+            string projectName,
+            string title,
+            string criteria,
+            bool defaultFilter,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                projectName,
+                title,
+                criteria,
+                defaultFilter
+            };
+
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response = await TestFactory.Instance.GetHttpClient(userType, plant).PostAsync($"{_route}/SavedFilter", content);
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                return -1;
+            }
+
+            var jsonString = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<int>(jsonString);
+        }
+
+        public static async Task<string> UpdateSavedFilterAsync(
+            UserType userType,
+            string plant,
+            int id,
+            string title,
+            string criteria,
+            bool defaultFilter,
+            string rowVersion,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                title,
+                criteria,
+                defaultFilter,
+                rowVersion
+            };
+
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response = await TestFactory.Instance.GetHttpClient(userType, plant).PutAsync($"{_route}/SavedFilters/{id}", content);
+
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            return await response.Content.ReadAsStringAsync();
+        }
+        public static async Task DeleteSavedFilterAsync(
+            UserType userType,
+            string plant,
+            int id,
+            string rowVersion,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                rowVersion
+            };
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var request = new HttpRequestMessage(HttpMethod.Delete, $"{_route}/SavedFilters/{id}")
+            {
+                Content = new StringContent(serializePayload, Encoding.UTF8, "application/json")
+            };
+
+            var response = await TestFactory.Instance.GetHttpClient(userType, plant).SendAsync(request);
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+        }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Persons/SavedFilterDto.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Persons/SavedFilterDto.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Persons
+{
+    public class SavedFilterDto
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public string Criteria { get; set; }
+        public bool DefaultFilter { get; set; }
+        public DateTime CreatedAtUtc { get; set; }
+        public string RowVersion { get; set; }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementDefinitionDetailDto.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementDefinitionDetailDto.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using Equinor.ProCoSys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
+
+namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
+{
+    public class RequirementDefinitionDetailDto
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public bool IsInUse { get; set; }
+        public bool IsVoided { get; set; }
+        public int DefaultIntervalWeeks { get; set; }
+        public RequirementUsage Usage { get; set; }
+        public int SortKey { get; set; }
+        public bool NeedsUserInput { get; set; }
+        public IEnumerable<FieldDetailsDto> Fields { get; set; }
+        public string RowVersion { get; set; }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypeDetailsDto.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypeDetailsDto.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using Equinor.ProCoSys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
+
+namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
+{
+    public class RequirementTypeDetailsDto
+    {
+        public int Id { get; set; }
+        public string Code { get; set; }
+        public string Title { get; set; }
+        public RequirementTypeIcon Icon { get; set; }
+        public bool IsInUse { get; set; }
+        public bool IsVoided { get; set; }
+        public int SortKey { get; set; }
+        public string RowVersion { get; set; }
+        public IEnumerable<RequirementDefinitionDetailDto> RequirementDefinitions { get; set; }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypesControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypesControllerNegativeTests.cs
@@ -11,6 +11,152 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
     [TestClass]
     public class RequirementTypesControllerNegativeTests :  RequirementTypesControllerTestsBase
     {
+        #region CreateRequirementType
+        [TestMethod]
+        public async Task CreateRequirementType_AsAnonymous_ShouldReturnUnauthorized()
+            => await RequirementTypesControllerTestsHelper.CreateRequirementTypeAsync(
+                UserType.Anonymous,
+                TestFactory.UnknownPlant,
+                Guid.NewGuid().ToString(),
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task CreateRequirementType_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.CreateRequirementTypeAsync(
+                UserType.Hacker,
+                TestFactory.UnknownPlant,
+                Guid.NewGuid().ToString(),
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task CreateRequirementType_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.CreateRequirementTypeAsync(
+                UserType.LibraryAdmin,
+                TestFactory.UnknownPlant,
+                Guid.NewGuid().ToString(),
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task CreateRequirementType_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await RequirementTypesControllerTestsHelper.CreateRequirementTypeAsync(
+                UserType.Hacker,
+                TestFactory.PlantWithoutAccess,
+                Guid.NewGuid().ToString(),
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task CreateRequirementType_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await RequirementTypesControllerTestsHelper.CreateRequirementTypeAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithoutAccess,
+                Guid.NewGuid().ToString(),
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task CreateRequirementType_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.CreateRequirementTypeAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                Guid.NewGuid().ToString(),
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task CreateRequirementType_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.CreateRequirementTypeAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                Guid.NewGuid().ToString(),
+                HttpStatusCode.Forbidden);
+        #endregion
+
+        #region UpdateRequirementType
+        [TestMethod]
+        public async Task UpdateRequirementType_AsAnonymous_ShouldReturnUnauthorized()
+            => await RequirementTypesControllerTestsHelper.UpdateRequirementTypeAsync(
+                UserType.Anonymous, TestFactory.UnknownPlant,
+                ReqTypeAIdUnderTest,
+                Guid.NewGuid().ToString(),
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task UpdateRequirementType_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.UpdateRequirementTypeAsync(
+                UserType.Hacker, TestFactory.UnknownPlant,
+                ReqTypeAIdUnderTest,
+                Guid.NewGuid().ToString(),
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateRequirementType_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.UpdateRequirementTypeAsync(
+                UserType.LibraryAdmin, TestFactory.UnknownPlant,
+                ReqTypeAIdUnderTest,
+                Guid.NewGuid().ToString(),
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task UpdateRequirementType_AsHacker_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.UpdateRequirementTypeAsync(
+                UserType.Hacker, TestFactory.PlantWithAccess,
+                ReqTypeAIdUnderTest,
+                Guid.NewGuid().ToString(),
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateRequirementType_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.UpdateRequirementTypeAsync(
+                UserType.Planner, TestFactory.PlantWithAccess,
+                ReqTypeAIdUnderTest,
+                Guid.NewGuid().ToString(),
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateRequirementType_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.UpdateRequirementTypeAsync(
+                UserType.Preserver, TestFactory.PlantWithAccess,
+                ReqTypeAIdUnderTest,
+                Guid.NewGuid().ToString(),
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateRequirementType_AsAdmin_ShouldReturnBadRequest_WhenUnknownReqTypeId()
+            => await RequirementTypesControllerTestsHelper.UpdateRequirementTypeAsync(
+                UserType.LibraryAdmin, TestFactory.PlantWithAccess,
+                9999,
+                Guid.NewGuid().ToString(),
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "Requirement type doesn't exist!");
+
+        [TestMethod]
+        public async Task UpdateRequirementType_AsAdmin_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            // Arrange
+            var reqType = await RequirementTypesControllerTestsHelper.CreateAndGetRequirementTypeAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                Guid.NewGuid().ToString());
+
+            // Act
+            await RequirementTypesControllerTestsHelper.UpdateRequirementTypeAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                reqType.Id,
+                Guid.NewGuid().ToString(),
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
+
+        #endregion
+
         #region GetRequirementTypes
         [TestMethod]
         public async Task GetRequirementTypes_AsAnonymous_ShouldReturnUnauthorized()
@@ -56,29 +202,328 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
                 HttpStatusCode.Forbidden);
         #endregion
 
+        #region GetRequirementType
+        [TestMethod]
+        public async Task GetRequirementType_AsAnonymous_ShouldReturnUnauthorized()
+            => await RequirementTypesControllerTestsHelper.GetRequirementTypeAsync(
+                UserType.Anonymous,
+                TestFactory.UnknownPlant,
+                ReqTypeAIdUnderTest,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task GetRequirementType_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.GetRequirementTypeAsync(
+                UserType.Hacker, 
+                TestFactory.UnknownPlant,
+                ReqTypeAIdUnderTest,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task GetRequirementType_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.GetRequirementTypeAsync(
+                UserType.LibraryAdmin,
+                TestFactory.UnknownPlant,
+                ReqTypeAIdUnderTest,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task GetRequirementType_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await RequirementTypesControllerTestsHelper.GetRequirementTypeAsync(
+                UserType.Hacker,
+                TestFactory.PlantWithoutAccess,
+                ReqTypeAIdUnderTest,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task GetRequirementType_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await RequirementTypesControllerTestsHelper.GetRequirementTypeAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithoutAccess,
+                ReqTypeAIdUnderTest,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task GetRequirementType_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.GetRequirementTypeAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                ReqTypeAIdUnderTest,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task GetRequirementType_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.GetRequirementTypeAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                ReqTypeAIdUnderTest,
+                HttpStatusCode.Forbidden);
+        #endregion
+
+        #region VoidRequirementType
+        [TestMethod]
+        public async Task VoidRequirementType_AsAnonymous_ShouldReturnUnauthorized()
+            => await RequirementTypesControllerTestsHelper.VoidRequirementTypeAsync(
+                UserType.Anonymous, TestFactory.UnknownPlant,
+                ReqTypeAIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task VoidRequirementType_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.VoidRequirementTypeAsync(
+                UserType.Hacker, TestFactory.UnknownPlant,
+                ReqTypeAIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidRequirementType_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.VoidRequirementTypeAsync(
+                UserType.LibraryAdmin, TestFactory.UnknownPlant,
+                ReqTypeAIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task VoidRequirementType_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await RequirementTypesControllerTestsHelper.VoidRequirementTypeAsync(
+                UserType.Hacker, TestFactory.PlantWithoutAccess,
+                ReqTypeAIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidRequirementType_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await RequirementTypesControllerTestsHelper.VoidRequirementTypeAsync(
+                UserType.LibraryAdmin, TestFactory.PlantWithoutAccess,
+                ReqTypeAIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidRequirementType_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.VoidRequirementTypeAsync(
+                UserType.Planner, TestFactory.PlantWithAccess,
+                ReqTypeAIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidRequirementType_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.VoidRequirementTypeAsync(
+                UserType.Preserver, TestFactory.PlantWithAccess,
+                ReqTypeAIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidRequirementType_AsAdmin_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            var reqType = await RequirementTypesControllerTestsHelper.CreateAndGetRequirementTypeAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                Guid.NewGuid().ToString());
+
+            // Act
+            await RequirementTypesControllerTestsHelper.VoidRequirementTypeAsync(
+                UserType.LibraryAdmin, TestFactory.PlantWithAccess,
+                reqType.Id,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
+        #endregion
+
+        #region UnvoidRequirementType
+        [TestMethod]
+        public async Task UnvoidRequirementType_AsAnonymous_ShouldReturnUnauthorized()
+            => await RequirementTypesControllerTestsHelper.UnvoidRequirementTypeAsync(
+                UserType.Anonymous, TestFactory.UnknownPlant,
+                ReqTypeAIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task UnvoidRequirementType_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.UnvoidRequirementTypeAsync(
+                UserType.Hacker, TestFactory.UnknownPlant,
+                ReqTypeAIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidRequirementType_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.UnvoidRequirementTypeAsync(
+                UserType.LibraryAdmin, TestFactory.UnknownPlant,
+                ReqTypeAIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task UnvoidRequirementType_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await RequirementTypesControllerTestsHelper.UnvoidRequirementTypeAsync(
+                UserType.Hacker, TestFactory.PlantWithoutAccess,
+                ReqTypeAIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidRequirementType_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await RequirementTypesControllerTestsHelper.UnvoidRequirementTypeAsync(
+                UserType.LibraryAdmin, TestFactory.PlantWithoutAccess,
+                ReqTypeAIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidRequirementType_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.UnvoidRequirementTypeAsync(
+                UserType.Planner, TestFactory.PlantWithAccess,
+                ReqTypeAIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidRequirementType_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.UnvoidRequirementTypeAsync(
+                UserType.Preserver, TestFactory.PlantWithAccess,
+                ReqTypeAIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidRequirementType_AsAdmin_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            var reqType = await RequirementTypesControllerTestsHelper.CreateAndGetRequirementTypeAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                Guid.NewGuid().ToString());
+
+            await RequirementTypesControllerTestsHelper.VoidRequirementTypeAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                reqType.Id,
+                reqType.RowVersion);
+
+            // Act
+            await RequirementTypesControllerTestsHelper.UnvoidRequirementTypeAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                reqType.Id,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
+        #endregion
+
+        #region DeleteRequirementType
+        [TestMethod]
+        public async Task DeleteRequirementType_AsAnonymous_ShouldReturnUnauthorized()
+            => await RequirementTypesControllerTestsHelper.DeleteRequirementTypeAsync(
+                UserType.Anonymous, TestFactory.UnknownPlant,
+                ReqTypeAIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task DeleteRequirementType_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.DeleteRequirementTypeAsync(
+                UserType.Hacker, TestFactory.UnknownPlant,
+                ReqTypeAIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task DeleteRequirementType_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await RequirementTypesControllerTestsHelper.DeleteRequirementTypeAsync(
+                UserType.LibraryAdmin, TestFactory.UnknownPlant,
+                ReqTypeAIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task DeleteRequirementType_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await RequirementTypesControllerTestsHelper.DeleteRequirementTypeAsync(
+                UserType.Hacker, TestFactory.PlantWithoutAccess,
+                ReqTypeAIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task DeleteRequirementType_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await RequirementTypesControllerTestsHelper.DeleteRequirementTypeAsync(
+                UserType.LibraryAdmin, TestFactory.PlantWithoutAccess,
+                ReqTypeAIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task DeleteRequirementType_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.DeleteRequirementTypeAsync(
+                UserType.Planner, TestFactory.PlantWithAccess,
+                ReqTypeAIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task DeleteRequirementType_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await RequirementTypesControllerTestsHelper.DeleteRequirementTypeAsync(
+                UserType.Preserver, TestFactory.PlantWithAccess,
+                ReqTypeAIdUnderTest,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task DeleteRequirementType_AsAdmin_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            var reqType = await RequirementTypesControllerTestsHelper.CreateAndGetRequirementTypeAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                Guid.NewGuid().ToString());
+
+            await RequirementTypesControllerTestsHelper.VoidRequirementTypeAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                reqType.Id,
+                reqType.RowVersion);
+
+            // Act
+            await RequirementTypesControllerTestsHelper.DeleteRequirementTypeAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                reqType.Id,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
+
+        #endregion
+
         #region CreateRequirementDefinition
         [TestMethod]
         public async Task CreateRequirementDefinition_AsAnonymous_ShouldReturnUnauthorized()
             => await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
                 UserType.Anonymous, TestFactory.UnknownPlant,
-                9999,
-                "RequirementDefinition1",
+                ReqTypeAIdUnderTest,
+                Guid.NewGuid().ToString(),
                 expectedStatusCode:HttpStatusCode.Unauthorized);
 
         [TestMethod]
         public async Task CreateRequirementDefinition_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
             => await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
                 UserType.Hacker, TestFactory.UnknownPlant,
-                9999,
-                "RequirementDefinition1",
+                ReqTypeAIdUnderTest,
+                Guid.NewGuid().ToString(),
                 expectedStatusCode:HttpStatusCode.Forbidden);
 
         [TestMethod]
         public async Task CreateRequirementDefinition_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
             => await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
                 UserType.LibraryAdmin, TestFactory.UnknownPlant,
-                9999,
-                "RequirementDefinition1",
+                ReqTypeAIdUnderTest,
+                Guid.NewGuid().ToString(),
                 expectedStatusCode:HttpStatusCode.BadRequest,
                 expectedMessageOnBadRequest:"is not a valid plant");
 
@@ -86,32 +531,32 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task CreateRequirementDefinition_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
             => await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
                 UserType.Hacker, TestFactory.PlantWithoutAccess,
-                9999,
-                "RequirementDefinition1",
+                ReqTypeAIdUnderTest,
+                Guid.NewGuid().ToString(),
                 expectedStatusCode:HttpStatusCode.Forbidden);
 
         [TestMethod]
         public async Task CreateRequirementDefinition_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
             => await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
                 UserType.LibraryAdmin, TestFactory.PlantWithoutAccess,
-                9999,
-                "RequirementDefinition1",
+                ReqTypeAIdUnderTest,
+                Guid.NewGuid().ToString(),
                 expectedStatusCode:HttpStatusCode.Forbidden);
 
         [TestMethod]
         public async Task CreateRequirementDefinition_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
             => await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
                 UserType.Planner, TestFactory.PlantWithAccess,
-                9999,
-                "RequirementDefinition1",
+                ReqTypeAIdUnderTest,
+                Guid.NewGuid().ToString(),
                 expectedStatusCode:HttpStatusCode.Forbidden);
 
         [TestMethod]
         public async Task CreateRequirementDefinition_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
             => await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
                 UserType.Preserver, TestFactory.PlantWithAccess,
-                9999,
-                "RequirementDefinition1",
+                ReqTypeAIdUnderTest,
+                Guid.NewGuid().ToString(),
                 expectedStatusCode:HttpStatusCode.Forbidden);
         #endregion
        
@@ -120,8 +565,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task UpdateRequirementDefinition_AsAnonymous_ShouldReturnUnauthorized()
             => await RequirementTypesControllerTestsHelper.UpdateRequirementDefinitionAsync(
                 UserType.Anonymous, TestFactory.UnknownPlant,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 Guid.NewGuid().ToString(),
                 4,
                 TestFactory.AValidRowVersion,
@@ -131,8 +576,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task UpdateRequirementDefinition_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
             => await RequirementTypesControllerTestsHelper.UpdateRequirementDefinitionAsync(
                 UserType.Hacker, TestFactory.UnknownPlant,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 Guid.NewGuid().ToString(),
                 4,
                 TestFactory.AValidRowVersion,
@@ -142,8 +587,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task UpdateRequirementDefinition_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
             => await RequirementTypesControllerTestsHelper.UpdateRequirementDefinitionAsync(
                 UserType.LibraryAdmin, TestFactory.UnknownPlant,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 Guid.NewGuid().ToString(),
                 4,
                 TestFactory.AValidRowVersion,
@@ -154,8 +599,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task UpdateRequirementDefinition_AsHacker_ShouldReturnForbidden_WhenPermissionMissing()
             => await RequirementTypesControllerTestsHelper.UpdateRequirementDefinitionAsync(
                 UserType.Hacker, TestFactory.PlantWithAccess,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 Guid.NewGuid().ToString(),
                 4,
                 TestFactory.AValidRowVersion,
@@ -165,8 +610,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task UpdateRequirementDefinition_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
             => await RequirementTypesControllerTestsHelper.UpdateRequirementDefinitionAsync(
                 UserType.Planner, TestFactory.PlantWithAccess, 
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 Guid.NewGuid().ToString(),
                 4,
                 TestFactory.AValidRowVersion,
@@ -176,19 +621,19 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task UpdateRequirementDefinition_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
             => await RequirementTypesControllerTestsHelper.UpdateRequirementDefinitionAsync(
                 UserType.Preserver, TestFactory.PlantWithAccess, 
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 Guid.NewGuid().ToString(),
                 4,
                 TestFactory.AValidRowVersion,
                 expectedStatusCode:HttpStatusCode.Forbidden);
 
         [TestMethod]
-        public async Task UpdateRequirementDefinition_AsPreserver_ShouldReturnBadRequest_WhenUnknownReqTypeId()
+        public async Task UpdateRequirementDefinition_AsAdmin_ShouldReturnBadRequest_WhenUnknownReqTypeId()
             => await RequirementTypesControllerTestsHelper.UpdateRequirementDefinitionAsync(
                 UserType.LibraryAdmin, TestFactory.PlantWithAccess,
                 9999, 
-                8888,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 Guid.NewGuid().ToString(),
                 4,
                 TestFactory.AValidRowVersion,
@@ -196,7 +641,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
                 expectedMessageOnBadRequest:"Requirement type and/or requirement definition doesn't exist!");
 
         [TestMethod]
-        public async Task UpdateRequirementDefinition_AsPreserver_ShouldReturnBadRequest_WhenUnknownReqDefId()
+        public async Task UpdateRequirementDefinition_AsAdmin_ShouldReturnBadRequest_WhenUnknownReqDefId()
             => await RequirementTypesControllerTestsHelper.UpdateRequirementDefinitionAsync(
                 UserType.LibraryAdmin, TestFactory.PlantWithAccess,
                 ReqTypeAIdUnderTest, 
@@ -208,7 +653,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
                 expectedMessageOnBadRequest:"Requirement type and/or requirement definition doesn't exist!");
 
         [TestMethod]
-        public async Task UpdateRequirementDefinition_AsPreserver_ShouldReturnBadRequest_WhenUpdatingUnknownFieldId()
+        public async Task UpdateRequirementDefinition_AsAdmin_ShouldReturnBadRequest_WhenUpdatingUnknownFieldId()
         {
             var reqTypeIdUnderTest = ReqTypeAIdUnderTest;
             var reqDefIdUnderTest = ReqDefIdUnderTest_ForReqDefWithCbField_InReqTypeA;
@@ -217,10 +662,10 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
                 reqTypeIdUnderTest,
                 reqDefIdUnderTest);
 
-            var newReqDefId = await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
-                UserType.LibraryAdmin, TestFactory.PlantWithAccess,
+            var newReqDefWithField = await RequirementTypesControllerTestsHelper.CreateAndGetRequirementDefinitionAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
                 reqTypeIdUnderTest,
-                Guid.NewGuid().ToString(),
                 new List<FieldDto>
                 {
                     new FieldDto
@@ -230,10 +675,6 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
                         SortKey = 20
                     }
                 });
-            var newReqDefWithField = await RequirementTypesControllerTestsHelper.GetRequirementDefinitionDetailsAsync(
-                UserType.LibraryAdmin, TestFactory.PlantWithAccess,
-                reqTypeIdUnderTest,
-                newReqDefId);
 
             var fieldsToUpdate = new List<FieldDetailsDto>();
             fieldsToUpdate.AddRange(existingReqDefWithField.Fields);
@@ -253,6 +694,72 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
                 "Field doesn't exist in requirement!");
         }
 
+        [TestMethod]
+        public async Task UpdateRequirementDefinition_AsAdmin_ShouldReturnConflict_WhenWrongRowVersionOnRequirementDefinition()
+        {
+            var reqTypeIdUnderTest = ReqTypeAIdUnderTest;
+            var reqDef = await RequirementTypesControllerTestsHelper.CreateAndGetRequirementDefinitionAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                reqTypeIdUnderTest,
+                new List<FieldDto>
+                {
+                    new FieldDto
+                    {
+                        FieldType = FieldType.Info,
+                        Label = Guid.NewGuid().ToString(),
+                        SortKey = 20
+                    }
+                });
+
+            reqDef.Fields.Single().Label = Guid.NewGuid().ToString();
+
+            // Act
+            await RequirementTypesControllerTestsHelper.UpdateRequirementDefinitionAsync(
+                UserType.LibraryAdmin, TestFactory.PlantWithAccess,
+                reqTypeIdUnderTest,
+                reqDef.Id,
+                reqDef.Title,
+                4,
+                TestFactory.WrongButValidRowVersion,
+                reqDef.Fields.ToList(),
+                HttpStatusCode.Conflict);
+        }
+
+        [TestMethod]
+        public async Task UpdateRequirementDefinition_AsAdmin_ShouldReturnConflict_WhenWrongRowVersionOnField()
+        {
+            var reqTypeIdUnderTest = ReqTypeAIdUnderTest;
+            var reqDef = await RequirementTypesControllerTestsHelper.CreateAndGetRequirementDefinitionAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                reqTypeIdUnderTest,
+                new List<FieldDto>
+                {
+                    new FieldDto
+                    {
+                        FieldType = FieldType.Info,
+                        Label = Guid.NewGuid().ToString(),
+                        SortKey = 20
+                    }
+                });
+
+            var fieldDetailsDto = reqDef.Fields.Single();
+            fieldDetailsDto.Label = Guid.NewGuid().ToString();
+            fieldDetailsDto.RowVersion = TestFactory.WrongButValidRowVersion;
+
+            // Act
+            await RequirementTypesControllerTestsHelper.UpdateRequirementDefinitionAsync(
+                UserType.LibraryAdmin, TestFactory.PlantWithAccess,
+                reqTypeIdUnderTest,
+                reqDef.Id,
+                reqDef.Title,
+                4,
+                reqDef.RowVersion,
+                reqDef.Fields.ToList(),
+                HttpStatusCode.Conflict);
+        }
+
         #endregion
 
         #region VoidRequirementDefinition
@@ -260,8 +767,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task VoidRequirementDefinition_AsAnonymous_ShouldReturnUnauthorized()
             => await RequirementTypesControllerTestsHelper.VoidRequirementDefinitionAsync(
                 UserType.Anonymous, TestFactory.UnknownPlant,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Unauthorized);
 
@@ -269,8 +776,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task VoidRequirementDefinition_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
             => await RequirementTypesControllerTestsHelper.VoidRequirementDefinitionAsync(
                 UserType.Hacker, TestFactory.UnknownPlant,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -278,8 +785,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task VoidRequirementDefinition_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
             => await RequirementTypesControllerTestsHelper.VoidRequirementDefinitionAsync(
                 UserType.LibraryAdmin, TestFactory.UnknownPlant,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
@@ -288,8 +795,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task VoidRequirementDefinition_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
             => await RequirementTypesControllerTestsHelper.VoidRequirementDefinitionAsync(
                 UserType.Hacker, TestFactory.PlantWithoutAccess,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -297,8 +804,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task VoidRequirementDefinition_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
             => await RequirementTypesControllerTestsHelper.VoidRequirementDefinitionAsync(
                 UserType.LibraryAdmin, TestFactory.PlantWithoutAccess,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -306,8 +813,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task VoidRequirementDefinition_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
             => await RequirementTypesControllerTestsHelper.VoidRequirementDefinitionAsync(
                 UserType.Planner, TestFactory.PlantWithAccess,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -315,8 +822,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task VoidRequirementDefinition_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
             => await RequirementTypesControllerTestsHelper.VoidRequirementDefinitionAsync(
                 UserType.Preserver, TestFactory.PlantWithAccess,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -329,6 +836,24 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "Requirement type and/or requirement definition doesn't exist!");
+
+        [TestMethod]
+        public async Task VoidRequirementDefinition_AsAdmin_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            var reqTypeIdUnderTest = ReqTypeAIdUnderTest;
+            var reqDef = await RequirementTypesControllerTestsHelper.CreateAndGetRequirementDefinitionAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                reqTypeIdUnderTest);
+
+            // Act
+            await RequirementTypesControllerTestsHelper.VoidRequirementDefinitionAsync(
+                UserType.LibraryAdmin, TestFactory.PlantWithAccess,
+                reqTypeIdUnderTest,
+                reqDef.Id,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
         #endregion
 
         #region UnvoidRequirementDefinition
@@ -336,8 +861,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task UnvoidRequirementDefinition_AsAnonymous_ShouldReturnUnauthorized()
             => await RequirementTypesControllerTestsHelper.UnvoidRequirementDefinitionAsync(
                 UserType.Anonymous, TestFactory.UnknownPlant,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Unauthorized);
 
@@ -345,8 +870,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task UnvoidRequirementDefinition_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
             => await RequirementTypesControllerTestsHelper.UnvoidRequirementDefinitionAsync(
                 UserType.Hacker, TestFactory.UnknownPlant,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -354,8 +879,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task UnvoidRequirementDefinition_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
             => await RequirementTypesControllerTestsHelper.UnvoidRequirementDefinitionAsync(
                 UserType.LibraryAdmin, TestFactory.UnknownPlant,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
@@ -364,8 +889,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task UnvoidRequirementDefinition_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
             => await RequirementTypesControllerTestsHelper.UnvoidRequirementDefinitionAsync(
                 UserType.Hacker, TestFactory.PlantWithoutAccess,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -373,8 +898,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task UnvoidRequirementDefinition_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
             => await RequirementTypesControllerTestsHelper.UnvoidRequirementDefinitionAsync(
                 UserType.LibraryAdmin, TestFactory.PlantWithoutAccess,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -382,8 +907,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task UnvoidRequirementDefinition_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
             => await RequirementTypesControllerTestsHelper.UnvoidRequirementDefinitionAsync(
                 UserType.Planner, TestFactory.PlantWithAccess,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -391,8 +916,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task UnvoidRequirementDefinition_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
             => await RequirementTypesControllerTestsHelper.UnvoidRequirementDefinitionAsync(
                 UserType.Preserver, TestFactory.PlantWithAccess,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -405,6 +930,32 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "Requirement type and/or requirement definition doesn't exist!");
+
+        [TestMethod]
+        public async Task UnvoidRequirementDefinition_AsAdmin_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            var reqTypeIdUnderTest = ReqTypeAIdUnderTest;
+            var reqDef = await RequirementTypesControllerTestsHelper.CreateAndGetRequirementDefinitionAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                reqTypeIdUnderTest);
+
+            await RequirementTypesControllerTestsHelper.VoidRequirementDefinitionAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                reqTypeIdUnderTest,
+                reqDef.Id,
+                reqDef.RowVersion);
+
+            // Act
+            await RequirementTypesControllerTestsHelper.UnvoidRequirementDefinitionAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                reqTypeIdUnderTest,
+                reqDef.Id,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
         #endregion
 
         #region DeleteRequirementDefinition
@@ -412,8 +963,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task DeleteRequirementDefinition_AsAnonymous_ShouldReturnUnauthorized()
             => await RequirementTypesControllerTestsHelper.DeleteRequirementDefinitionAsync(
                 UserType.Anonymous, TestFactory.UnknownPlant,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Unauthorized);
 
@@ -421,8 +972,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task DeleteRequirementDefinition_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
             => await RequirementTypesControllerTestsHelper.DeleteRequirementDefinitionAsync(
                 UserType.Hacker, TestFactory.UnknownPlant,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -430,8 +981,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task DeleteRequirementDefinition_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
             => await RequirementTypesControllerTestsHelper.DeleteRequirementDefinitionAsync(
                 UserType.LibraryAdmin, TestFactory.UnknownPlant,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
@@ -440,8 +991,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task DeleteRequirementDefinition_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
             => await RequirementTypesControllerTestsHelper.DeleteRequirementDefinitionAsync(
                 UserType.Hacker, TestFactory.PlantWithoutAccess,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -449,8 +1000,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task DeleteRequirementDefinition_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
             => await RequirementTypesControllerTestsHelper.DeleteRequirementDefinitionAsync(
                 UserType.LibraryAdmin, TestFactory.PlantWithoutAccess,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -458,8 +1009,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task DeleteRequirementDefinition_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
             => await RequirementTypesControllerTestsHelper.DeleteRequirementDefinitionAsync(
                 UserType.Planner, TestFactory.PlantWithAccess,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -467,8 +1018,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task DeleteRequirementDefinition_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
             => await RequirementTypesControllerTestsHelper.DeleteRequirementDefinitionAsync(
                 UserType.Preserver, TestFactory.PlantWithAccess,
-                9999,
-                8888,
+                ReqTypeAIdUnderTest,
+                ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -481,6 +1032,32 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "Requirement type and/or requirement definition doesn't exist!");
+
+        [TestMethod]
+        public async Task DeleteRequirementDefinition_AsAdmin_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            var reqTypeIdUnderTest = ReqTypeAIdUnderTest;
+            var reqDef = await RequirementTypesControllerTestsHelper.CreateAndGetRequirementDefinitionAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                reqTypeIdUnderTest);
+
+            await RequirementTypesControllerTestsHelper.VoidRequirementDefinitionAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                reqTypeIdUnderTest,
+                reqDef.Id,
+                reqDef.RowVersion);
+
+            // Act
+            await RequirementTypesControllerTestsHelper.DeleteRequirementDefinitionAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                reqTypeIdUnderTest,
+                reqDef.Id,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
 
         #endregion
     }

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypesControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypesControllerTestsBase.cs
@@ -28,6 +28,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
             
             var reqTypeB = requirementTypes.Single(j => j.Code == KnownTestData.ReqTypeB);
             ReqTypeBIdUnderTest = reqTypeB.Id;
-            ReqDefInReqTypeBIdUnderTest = reqTypeB.RequirementDefinitions.First().Id;        }
+            ReqDefInReqTypeBIdUnderTest = reqTypeB.RequirementDefinitions.First().Id;
+        }
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypesControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypesControllerTestsBase.cs
@@ -6,6 +6,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
 {
     public class RequirementTypesControllerTestsBase : TestBase
     {
+        protected int InitialReqTypesCount;
         protected int ReqTypeAIdUnderTest;
         protected int ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA;
         protected int ReqDefIdUnderTest_ForReqDefWithCbField_InReqTypeA;
@@ -16,7 +17,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
         public async Task TestInitialize()
         {
             var requirementTypes = await RequirementTypesControllerTestsHelper.GetRequirementTypesAsync(UserType.LibraryAdmin, TestFactory.PlantWithAccess);
-            
+            InitialReqTypesCount = requirementTypes.Count;
+
             var reqTypeA = requirementTypes.Single(j => j.Code == KnownTestData.ReqTypeA);
             ReqTypeAIdUnderTest = reqTypeA.Id;
             ReqDefIdUnderTest_ForReqDefWithNoFields_InReqTypeA

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypesControllerTestsHelper.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/RequirementTypes/RequirementTypesControllerTestsHelper.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 
 namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
@@ -12,8 +14,83 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
     {
         private const string _route = "RequirementTypes";
 
+        public static async Task<int> CreateRequirementTypeAsync(
+            UserType userType,
+            string plant,
+            string title,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                sortKey = 10,
+                code = Guid.NewGuid().ToString("B").Substring(0, 32),
+                title,
+                icon = 0
+            };
+
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response = await TestFactory.Instance.GetHttpClient(userType, plant).PostAsync(_route, content);
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                return -1;
+            }
+
+            var jsonString = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<int>(jsonString);
+        }
+
+        public static async Task<RequirementTypeDetailsDto> CreateAndGetRequirementTypeAsync(
+            UserType userType,
+            string plant,
+            string title)
+        {
+            var id = await CreateRequirementTypeAsync(userType, plant, title);
+
+            // Assert
+            Assert.IsTrue(id > 0);
+            return await GetRequirementTypeAsync(UserType.LibraryAdmin, TestFactory.PlantWithAccess, id); 
+        }
+
+        public static async Task<string> UpdateRequirementTypeAsync(
+            UserType userType,
+            string plant,
+            int requirementTypeId,
+            string title,
+            string rowVersion,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                sortKey = 10,
+                code = Guid.NewGuid().ToString("B").Substring(0, 32),
+                title,
+                icon = 0,
+                rowVersion
+            };
+
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response =
+                await TestFactory.Instance.GetHttpClient(userType, plant).PutAsync($"{_route}/{requirementTypeId}",
+                    content);
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            return await response.Content.ReadAsStringAsync();
+        }
+
         public static async Task<List<RequirementTypeDto>> GetRequirementTypesAsync(
-            UserType userType, string plant,
+            UserType userType,
+            string plant,
             HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
             string expectedMessageOnBadRequest = null)
         {
@@ -31,9 +108,77 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
             var content = await response.Content.ReadAsStringAsync();
             return JsonConvert.DeserializeObject<List<RequirementTypeDto>>(content);
         }
-        
-        public static async Task<int> CreateRequirementDefinitionAsync(
+
+        public static async Task<RequirementTypeDetailsDto> GetRequirementTypeAsync(
+            UserType userType,
+            string plant,
+            int id,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var response = await TestFactory.Instance.GetHttpClient(userType, plant).GetAsync($"{_route}/{id}");
+
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (expectedStatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            var content = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<RequirementTypeDetailsDto>(content);
+        }
+
+        public static async Task<string> VoidRequirementTypeAsync(
             UserType userType, string plant,
+            int reqTypeId,
+            string rowVersion,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+            => await VoidUnvoidRequirementTypeAsync(TestFactory.Instance.GetHttpClient(userType, plant),
+                reqTypeId,
+                rowVersion,
+                "Void",
+                expectedStatusCode,
+                expectedMessageOnBadRequest);
+
+        public static async Task<string> UnvoidRequirementTypeAsync(
+            UserType userType, string plant,
+            int reqTypeId,
+            string rowVersion,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+            => await VoidUnvoidRequirementTypeAsync(TestFactory.Instance.GetHttpClient(userType, plant),
+                reqTypeId,
+                rowVersion,
+                "Unvoid",
+                expectedStatusCode,
+                expectedMessageOnBadRequest);
+
+        public static async Task DeleteRequirementTypeAsync(
+            UserType userType, string plant,
+            int reqTypeId,
+            string rowVersion,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                rowVersion
+            };
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var request = new HttpRequestMessage(HttpMethod.Delete, $"{_route}/{reqTypeId}")
+            {
+                Content = new StringContent(serializePayload, Encoding.UTF8, "application/json")
+            };
+
+            var response = await TestFactory.Instance.GetHttpClient(userType, plant).SendAsync(request);
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+        }
+
+        public static async Task<int> CreateRequirementDefinitionAsync(
+            UserType userType,
+            string plant,
             int reqTypeId,
             string title,
             List<FieldDto> fields = null,
@@ -95,6 +240,25 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
             }
 
             return await response.Content.ReadAsStringAsync();
+        }
+
+        public static async Task<RequirementDefinitionDto> CreateAndGetRequirementDefinitionAsync(
+            UserType userType,
+            string plant,
+            int reqTypeId,
+            List<FieldDto> fields = null)
+        {
+            var reqDefId = await CreateRequirementDefinitionAsync(
+                userType,
+                plant,
+                reqTypeId,
+                Guid.NewGuid().ToString(),
+                fields);
+
+            return await GetRequirementDefinitionDetailsAsync(
+                UserType.LibraryAdmin, TestFactory.PlantWithAccess,
+                reqTypeId,
+                reqDefId);
         }
 
         public static async Task<string> VoidRequirementDefinitionAsync(
@@ -175,6 +339,32 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes
             var serializePayload = JsonConvert.SerializeObject(bodyPayload);
             var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
             var response = await client.PutAsync($"{_route}/{reqTypeId}/RequirementDefinitions/{reqDefId}/{action}", content);
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            return await response.Content.ReadAsStringAsync();
+        }
+
+        private static async Task<string> VoidUnvoidRequirementTypeAsync(
+            HttpClient client,
+            int reqTypeId,
+            string rowVersion,
+            string action,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                rowVersion
+            };
+
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response = await client.PutAsync($"{_route}/{reqTypeId}/{action}", content);
             await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
 
             if (response.StatusCode != HttpStatusCode.OK)

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/TagFunctions/RequirementDto.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/TagFunctions/RequirementDto.cs
@@ -1,0 +1,9 @@
+﻿namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.TagFunctions
+{
+    public class RequirementDto
+    {
+        public int Id { get; set; }
+        public int RequirementDefinitionId { get; set; }
+        public int IntervalWeeks { get; set; }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/TagFunctions/TagFunctionDetailsDto.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/TagFunctions/TagFunctionDetailsDto.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.TagFunctions
+{
+    public class TagFunctionDetailsDto
+    {
+        public int Id { get; set; }
+        public string Code { get; set; }
+        public string Description { get; set; }
+        public string RegisterCode { get; set; }
+        public bool IsVoided { get; set; }
+        public IEnumerable<RequirementDto> Requirements { get; set; }
+        public string RowVersion { get; set; }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/TagFunctions/TagFunctionRequirementDto.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/TagFunctions/TagFunctionRequirementDto.cs
@@ -1,0 +1,8 @@
+﻿namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.TagFunctions
+{
+    public class TagFunctionRequirementDto
+    {
+        public int RequirementDefinitionId { get; set; }
+        public int IntervalWeeks { get; set; }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/TagFunctions/TagFunctionsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/TagFunctions/TagFunctionsControllerNegativeTests.cs
@@ -1,0 +1,334 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.TagFunctions
+{
+    [TestClass]
+    public class TagFunctionsControllerNegativeTests : TagFunctionsControllerTestsBase
+    {
+        #region Get
+        [TestMethod]
+        public async Task GetTagFunction_AsAnonymous_ShouldReturnUnauthorized()
+            => await TagFunctionsControllerTestsHelper.GetTagFunctionDetailsAsync(
+                UserType.Anonymous,
+                TestFactory.PlantWithAccess,
+                TagFunctionUnderTest.Code,
+                TagFunctionUnderTest.RegisterCode,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task GetTagFunction_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await TagFunctionsControllerTestsHelper.GetTagFunctionDetailsAsync(
+                UserType.Hacker,
+                TestFactory.UnknownPlant,
+                TagFunctionUnderTest.Code,
+                TagFunctionUnderTest.RegisterCode,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task GetTagFunction_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await TagFunctionsControllerTestsHelper.GetTagFunctionDetailsAsync(
+                UserType.LibraryAdmin,
+                TestFactory.UnknownPlant,
+                TagFunctionUnderTest.Code,
+                TagFunctionUnderTest.RegisterCode,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task GetTagFunction_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await TagFunctionsControllerTestsHelper.GetTagFunctionDetailsAsync(
+                UserType.Hacker,
+                TestFactory.PlantWithoutAccess,
+                TagFunctionUnderTest.Code,
+                TagFunctionUnderTest.RegisterCode,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task GetTagFunction_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await TagFunctionsControllerTestsHelper.GetTagFunctionDetailsAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithoutAccess,
+                TagFunctionUnderTest.Code,
+                TagFunctionUnderTest.RegisterCode,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task GetTagFunction_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagFunctionsControllerTestsHelper.GetTagFunctionDetailsAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                TagFunctionUnderTest.Code,
+                TagFunctionUnderTest.RegisterCode,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task GetTagFunction_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagFunctionsControllerTestsHelper.GetTagFunctionDetailsAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                TagFunctionUnderTest.Code,
+                TagFunctionUnderTest.RegisterCode,
+                HttpStatusCode.Forbidden);
+        #endregion
+        
+        #region Update
+        [TestMethod]
+        public async Task UpdateTagFunction_AsAnonymous_ShouldReturnUnauthorized()
+            => await TagFunctionsControllerTestsHelper.UpdateTagFunctionAsync(
+                UserType.Anonymous,
+                TestFactory.UnknownPlant,
+                TagFunctionUnderTest.Code,
+                TagFunctionUnderTest.RegisterCode,
+                null,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task UpdateTagFunction_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await TagFunctionsControllerTestsHelper.UpdateTagFunctionAsync(
+                UserType.Hacker,
+                TestFactory.UnknownPlant,
+                TagFunctionUnderTest.Code,
+                TagFunctionUnderTest.RegisterCode,
+                null,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateTagFunction_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await TagFunctionsControllerTestsHelper.UpdateTagFunctionAsync(
+                UserType.LibraryAdmin,
+                TestFactory.UnknownPlant,
+                TagFunctionUnderTest.Code,
+                TagFunctionUnderTest.RegisterCode,
+                null,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task UpdateTagFunction_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await TagFunctionsControllerTestsHelper.UpdateTagFunctionAsync(
+                UserType.Hacker,
+                TestFactory.PlantWithoutAccess,
+                TagFunctionUnderTest.Code,
+                TagFunctionUnderTest.RegisterCode,
+                null,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateTagFunction_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await TagFunctionsControllerTestsHelper.UpdateTagFunctionAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithoutAccess,
+                TagFunctionUnderTest.Code,
+                TagFunctionUnderTest.RegisterCode,
+                null,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateTagFunction_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagFunctionsControllerTestsHelper.UpdateTagFunctionAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                TagFunctionUnderTest.Code,
+                TagFunctionUnderTest.RegisterCode,
+                null,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateTagFunction_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagFunctionsControllerTestsHelper.UpdateTagFunctionAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                TagFunctionUnderTest.Code,
+                TagFunctionUnderTest.RegisterCode,
+                null,
+                HttpStatusCode.Forbidden);
+
+        #endregion
+
+        #region Void
+        [TestMethod]
+        public async Task VoidTagFunction_AsAnonymous_ShouldReturnUnauthorized()
+            => await TagFunctionsControllerTestsHelper.VoidTagFunctionAsync(
+                UserType.Anonymous,
+                TestFactory.UnknownPlant,
+                TagFunctionUnderVoidingTest.Code,
+                TagFunctionUnderVoidingTest.RegisterCode,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task VoidTagFunction_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await TagFunctionsControllerTestsHelper.VoidTagFunctionAsync(
+                UserType.Hacker,
+                TestFactory.UnknownPlant,
+                TagFunctionUnderVoidingTest.Code,
+                TagFunctionUnderVoidingTest.RegisterCode,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidTagFunction_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await TagFunctionsControllerTestsHelper.VoidTagFunctionAsync(
+                UserType.LibraryAdmin,
+                TestFactory.UnknownPlant,
+                TagFunctionUnderVoidingTest.Code,
+                TagFunctionUnderVoidingTest.RegisterCode,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task VoidTagFunction_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await TagFunctionsControllerTestsHelper.VoidTagFunctionAsync(
+                UserType.Hacker,
+                TestFactory.PlantWithoutAccess,
+                TagFunctionUnderVoidingTest.Code,
+                TagFunctionUnderVoidingTest.RegisterCode,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidTagFunction_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await TagFunctionsControllerTestsHelper.VoidTagFunctionAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithoutAccess,
+                TagFunctionUnderVoidingTest.Code,
+                TagFunctionUnderVoidingTest.RegisterCode,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidTagFunction_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagFunctionsControllerTestsHelper.VoidTagFunctionAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                TagFunctionUnderVoidingTest.Code,
+                TagFunctionUnderVoidingTest.RegisterCode,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidTagFunction_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagFunctionsControllerTestsHelper.VoidTagFunctionAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                TagFunctionUnderVoidingTest.Code,
+                TagFunctionUnderVoidingTest.RegisterCode,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidTagFunction_AsAdmin_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            // Arrange
+            await EnsureTagFunctionIsUnvoidedAsync(
+                TestFactory.PlantWithAccess,
+                TagFunctionUnderVoidingTest.Code,
+                TagFunctionUnderVoidingTest.RegisterCode);
+
+            // Act
+            await TagFunctionsControllerTestsHelper.VoidTagFunctionAsync(
+                           UserType.LibraryAdmin,
+                           TestFactory.PlantWithAccess,
+                           TagFunctionUnderVoidingTest.Code,
+                           TagFunctionUnderVoidingTest.RegisterCode,
+                           TestFactory.WrongButValidRowVersion,
+                           HttpStatusCode.Conflict);
+        }
+        #endregion
+
+        #region Unvoid
+        [TestMethod]
+        public async Task UnvoidTagFunction_AsAnonymous_ShouldReturnUnauthorized()
+            => await TagFunctionsControllerTestsHelper.UnvoidTagFunctionAsync(
+                UserType.Anonymous,
+                TestFactory.UnknownPlant,
+                TagFunctionUnderUnvoidingTest.Code,
+                TagFunctionUnderUnvoidingTest.RegisterCode,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task UnvoidTagFunction_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await TagFunctionsControllerTestsHelper.UnvoidTagFunctionAsync(
+                UserType.Hacker,
+                TestFactory.UnknownPlant,
+                TagFunctionUnderUnvoidingTest.Code,
+                TagFunctionUnderUnvoidingTest.RegisterCode,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidTagFunction_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await TagFunctionsControllerTestsHelper.UnvoidTagFunctionAsync(
+                UserType.LibraryAdmin,
+                TestFactory.UnknownPlant,
+                TagFunctionUnderUnvoidingTest.Code,
+                TagFunctionUnderUnvoidingTest.RegisterCode,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task UnvoidTagFunction_AsHacker_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await TagFunctionsControllerTestsHelper.UnvoidTagFunctionAsync(
+                UserType.Hacker,
+                TestFactory.PlantWithoutAccess,
+                TagFunctionUnderUnvoidingTest.Code,
+                TagFunctionUnderUnvoidingTest.RegisterCode,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidTagFunction_AsAdmin_ShouldReturnForbidden_WhenNoAccessToPlant()
+            => await TagFunctionsControllerTestsHelper.UnvoidTagFunctionAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithoutAccess,
+                TagFunctionUnderUnvoidingTest.Code,
+                TagFunctionUnderUnvoidingTest.RegisterCode,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidTagFunction_AsPlanner_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagFunctionsControllerTestsHelper.UnvoidTagFunctionAsync(
+                UserType.Planner, 
+                TestFactory.PlantWithAccess,
+                TagFunctionUnderUnvoidingTest.Code,
+                TagFunctionUnderUnvoidingTest.RegisterCode,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidTagFunction_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagFunctionsControllerTestsHelper.UnvoidTagFunctionAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                TagFunctionUnderUnvoidingTest.Code,
+                TagFunctionUnderUnvoidingTest.RegisterCode,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidTagFunction_AsAdmin_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            // Arrange
+            await EnsureTagFunctionIsVoidedAsync(
+                TestFactory.PlantWithAccess,
+                TagFunctionUnderUnvoidingTest.Code,
+                TagFunctionUnderUnvoidingTest.RegisterCode);
+
+            // Act
+            await TagFunctionsControllerTestsHelper.UnvoidTagFunctionAsync(
+                           UserType.LibraryAdmin,
+                           TestFactory.PlantWithAccess,
+                           TagFunctionUnderUnvoidingTest.Code,
+                           TagFunctionUnderUnvoidingTest.RegisterCode,
+                           TestFactory.WrongButValidRowVersion,
+                           HttpStatusCode.Conflict);
+        }
+        #endregion
+    }
+}

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/TagFunctions/TagFunctionsControllerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/TagFunctions/TagFunctionsControllerTests.cs
@@ -1,0 +1,90 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.TagFunctions
+{
+    [TestClass]
+    public class TagFunctionsControllerTests : TagFunctionsControllerTestsBase
+    {
+        [TestMethod]
+        public async Task UpdateTagFunction_AsAdmin_ShouldCreateTagFunctionWithRequirements()
+        {
+            // Arrange
+            var newReqDefId = await CreateRequirementDefinitionAsync(TestFactory.PlantWithAccess);
+            var intervalWeeks = 4;
+
+            // Act
+            var tagFunction = await UpdateAndGetTagFunctionAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                TagFunctionUnderTest.Code,
+                TagFunctionUnderTest.RegisterCode,
+                newReqDefId,
+                intervalWeeks);
+
+            // Assert
+            Assert.IsNotNull(tagFunction);
+            Assert.AreEqual(TagFunctionUnderTest.Code, tagFunction.Code);
+            Assert.AreEqual(TagFunctionUnderTest.RegisterCode, tagFunction.RegisterCode);
+            Assert.AreEqual(1, tagFunction.Requirements.Count());
+            Assert.AreEqual(newReqDefId, tagFunction.Requirements.Single().RequirementDefinitionId);
+            Assert.AreEqual(intervalWeeks, tagFunction.Requirements.Single().IntervalWeeks);
+        }
+
+        [TestMethod]
+        public async Task VoidTagFunction_AsAdmin_ShouldVoidTagFunction()
+        {
+            // Arrange
+            var currentRowVersion = await EnsureTagFunctionIsUnvoidedAsync(
+                TestFactory.PlantWithAccess,
+                TagFunctionUnderVoidingTest.Code,
+                TagFunctionUnderVoidingTest.RegisterCode);
+
+            // Act
+            var newRowVersion = await TagFunctionsControllerTestsHelper.VoidTagFunctionAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                TagFunctionUnderVoidingTest.Code,
+                TagFunctionUnderVoidingTest.RegisterCode,
+                currentRowVersion);
+
+            // Assert
+            var tagFunction = await TagFunctionsControllerTestsHelper.GetTagFunctionDetailsAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                TagFunctionUnderVoidingTest.Code,
+                TagFunctionUnderVoidingTest.RegisterCode);
+
+            AssertRowVersionChange(currentRowVersion, newRowVersion);
+            Assert.IsTrue(tagFunction.IsVoided);
+        }
+
+        [TestMethod]
+        public async Task UnvoidTagFunction_AsAdmin_ShouldUnvoidTagFunction()
+        {
+            // Arrange
+            var currentRowVersion = await EnsureTagFunctionIsVoidedAsync(
+                TestFactory.PlantWithAccess,
+                TagFunctionUnderUnvoidingTest.Code,
+                TagFunctionUnderUnvoidingTest.RegisterCode);
+
+            // Act
+            var newRowVersion = await TagFunctionsControllerTestsHelper.UnvoidTagFunctionAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                TagFunctionUnderUnvoidingTest.Code,
+                TagFunctionUnderUnvoidingTest.RegisterCode,
+                currentRowVersion);
+
+            // Assert
+            var tagFunction = await TagFunctionsControllerTestsHelper.GetTagFunctionDetailsAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                TagFunctionUnderUnvoidingTest.Code,
+                TagFunctionUnderUnvoidingTest.RegisterCode);
+            AssertRowVersionChange(currentRowVersion, newRowVersion);
+            Assert.IsFalse(tagFunction.IsVoided);
+        }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/TagFunctions/TagFunctionsControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/TagFunctions/TagFunctionsControllerTestsBase.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.Preservation.MainApi.TagFunction;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.TagFunctions
+{
+    public class TagFunctionsControllerTestsBase : TestBase
+    {
+        protected TagFunctionDetailsDto TagFunctionUnderTest;
+        protected TagFunctionDetailsDto TagFunctionUnderVoidingTest;
+        protected TagFunctionDetailsDto TagFunctionUnderUnvoidingTest;
+
+        [TestInitialize]
+        public async Task TestInitializeAsync()
+        {
+            var tagFunctionCodeUnderTest = "TestTF";
+            var registerCodeUnderTest = "RegA";
+            var registerCodeForVoidingTest = "RegB";
+            var registerCodeForUnvoidingTest = "RegC";
+            var newReqDefId = await CreateRequirementDefinitionAsync(TestFactory.PlantWithAccess);
+
+            TagFunctionUnderTest = await UpdateAndGetTagFunctionAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                tagFunctionCodeUnderTest,
+                registerCodeUnderTest,
+                newReqDefId,
+                4);
+
+            TagFunctionUnderVoidingTest = await UpdateAndGetTagFunctionAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                tagFunctionCodeUnderTest,
+                registerCodeForVoidingTest,
+                newReqDefId,
+                4);
+
+            TagFunctionUnderUnvoidingTest = await UpdateAndGetTagFunctionAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                tagFunctionCodeUnderTest,
+                registerCodeForUnvoidingTest,
+                newReqDefId,
+                4);
+        }
+
+        protected async Task<TagFunctionDetailsDto> UpdateAndGetTagFunctionAsync(
+            UserType userType,
+            string plant,
+            string tagFunctionCode,
+            string registerCode,
+            int reqDefId,
+            int intervalWeeks)
+        {
+            MockMainApiDataForTagFunction(plant, tagFunctionCode, registerCode);
+
+            await TagFunctionsControllerTestsHelper.UpdateTagFunctionAsync(
+                UserType.LibraryAdmin,
+                plant,
+                tagFunctionCode,
+                registerCode,
+                new List<TagFunctionRequirementDto>
+                {
+                    new TagFunctionRequirementDto
+                    {
+                        RequirementDefinitionId = reqDefId,
+                        IntervalWeeks = intervalWeeks
+                    }
+                });
+
+            return await TagFunctionsControllerTestsHelper.GetTagFunctionDetailsAsync(
+                UserType.LibraryAdmin,
+                plant,
+                tagFunctionCode,
+                registerCode);
+        }
+
+        private void MockMainApiDataForTagFunction(string plant, string tagFunctionCode, string registerCode)
+        {
+            var mainTagFunctionDetails = new PCSTagFunction
+            {
+                Code = tagFunctionCode,
+                Description = $"{tagFunctionCode} {registerCode} Description",
+                RegisterCode = registerCode
+            };
+
+            TestFactory.Instance
+                .TagFunctionApiServiceMock
+                .Setup(service => service.TryGetTagFunctionAsync(
+                    plant,
+                    tagFunctionCode,
+                    registerCode))
+                .Returns(Task.FromResult(mainTagFunctionDetails));
+        }
+
+        protected async Task<string> EnsureTagFunctionIsUnvoidedAsync(
+            string plant,
+            string code,
+            string registerCode)
+        {
+            var tagFunction = await TagFunctionsControllerTestsHelper.GetTagFunctionDetailsAsync(
+                UserType.LibraryAdmin,
+                plant,
+                code,
+                registerCode);
+
+            if (tagFunction.IsVoided)
+            {
+                return await TagFunctionsControllerTestsHelper.UnvoidTagFunctionAsync(
+                    UserType.LibraryAdmin,
+                    plant,
+                    code,
+                    registerCode,
+                    tagFunction.RowVersion);
+            }
+            
+            return tagFunction.RowVersion;
+        }
+
+        protected async Task<string> EnsureTagFunctionIsVoidedAsync(
+            string plant,
+            string code,
+            string registerCode)
+        {
+            var tagFunction = await TagFunctionsControllerTestsHelper.GetTagFunctionDetailsAsync(
+                UserType.LibraryAdmin,
+                plant,
+                code,
+                registerCode);
+
+            if (!tagFunction.IsVoided)
+            {
+                return await TagFunctionsControllerTestsHelper.VoidTagFunctionAsync(
+                    UserType.LibraryAdmin,
+                    plant,
+                    code,
+                    registerCode,
+                    tagFunction.RowVersion);
+            }
+
+            return tagFunction.RowVersion;
+        }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/TagFunctions/TagFunctionsControllerTestsHelper.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/TagFunctions/TagFunctionsControllerTestsHelper.cs
@@ -1,0 +1,125 @@
+﻿using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.TagFunctions
+{
+    public static class TagFunctionsControllerTestsHelper
+    {
+        private const string _route = "TagFunctions";
+        
+        public static async Task<TagFunctionDetailsDto> GetTagFunctionDetailsAsync(
+            UserType userType,
+            string plant,
+            string code,
+            string registerCode,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var parameters = new ParameterCollection
+            {
+                {"registerCode", registerCode}
+            };
+            var url = $"{_route}/{code}{parameters}";
+            var response = await TestFactory.Instance.GetHttpClient(userType, plant).GetAsync(url);
+
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (expectedStatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            var content = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<TagFunctionDetailsDto>(content);
+        }
+
+        public static async Task UpdateTagFunctionAsync(
+            UserType userType,
+            string plant,
+            string tagFunctionCode,
+            string registerCode,
+            IEnumerable<TagFunctionRequirementDto> requirements,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                tagFunctionCode,
+                registerCode,
+                requirements
+            };
+
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response = await TestFactory.Instance.GetHttpClient(userType, plant).PutAsync(_route, content);
+
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+        }
+
+        public static async Task<string> VoidTagFunctionAsync(
+            UserType userType,
+            string plant,
+            string code,
+            string registerCode,
+            string rowVersion,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+            => await VoidUnvoidTagFunctionAsync(
+                TestFactory.Instance.GetHttpClient(userType, plant),
+                code,
+                registerCode,
+                rowVersion,
+                "Void",
+                expectedStatusCode,
+                expectedMessageOnBadRequest);
+
+        public static async Task<string> UnvoidTagFunctionAsync(
+            UserType userType,
+            string plant,
+            string code,
+            string registerCode,
+            string rowVersion,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+            => await VoidUnvoidTagFunctionAsync(
+                TestFactory.Instance.GetHttpClient(userType, plant),
+                code,
+                registerCode,
+                rowVersion,
+                "Unvoid",
+                expectedStatusCode,
+                expectedMessageOnBadRequest);
+
+        private static async Task<string> VoidUnvoidTagFunctionAsync(
+            HttpClient client,
+            string code,
+            string registerCode,
+            string rowVersion,
+            string action,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                registerCode,
+                rowVersion
+            };
+
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var content = new StringContent(serializePayload, Encoding.UTF8, "application/json");
+            var response = await client.PutAsync($"{_route}/{code}/{action}", content);
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                return null;
+            }
+
+            return await response.Content.ReadAsStringAsync();
+        }
+    }
+}

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerNegativeTests.cs
@@ -615,6 +615,75 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         }
         #endregion
 
+        #region Delete
+        [TestMethod]
+        public async Task Delete_AsAnonymous_ShouldReturnUnauthorized()
+            => await TagsControllerTestsHelper.DeleteTagAsync(
+                UserType.Anonymous,
+                TestFactory.UnknownPlant,
+                9999,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task Delete_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await TagsControllerTestsHelper.DeleteTagAsync(
+                UserType.Hacker,
+                TestFactory.UnknownPlant,
+                9999,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task Delete_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await TagsControllerTestsHelper.DeleteTagAsync(
+                UserType.LibraryAdmin,
+                TestFactory.UnknownPlant,
+                9999,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task Delete_AsHacker_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.DeleteTagAsync(
+                UserType.Hacker,
+                TestFactory.PlantWithAccess,
+                9999,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task Delete_AsAdmin_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.DeleteTagAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                9999,
+                TestFactory.AValidRowVersion,
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task Delete_AsPlanner_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            // Arrange
+            var tag = await CreateAndGetAreaTagAsync(
+                AreaTagType.PreArea,
+                TwoStepJourneyWithTags.Steps.First(s => !s.IsVoided).Id,
+                null,
+                false);
+
+            await TagsControllerTestsHelper.VoidTagAsync(UserType.Planner, TestFactory.PlantWithAccess, tag.Id, tag.RowVersion);
+
+            // Act
+            await TagsControllerTestsHelper.DeleteTagAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                tag.Id,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
+        #endregion
+
         #region GetAllTagAttachments
         [TestMethod]
         public async Task GetAllTagAttachments_AsAnonymous_ShouldReturnUnauthorized()
@@ -1451,7 +1520,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         {
             // Arrange
             var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithAttachmentRequirement_Started;
-            var requirement = await TagsControllerTestsHelper.GetTagRequirementInfoAsync(UserType.Preserver, TestFactory.PlantWithAccess, tagIdUnderTest);
+            var requirement = await GetTagRequirementInfoAsync(UserType.Preserver, TestFactory.PlantWithAccess, tagIdUnderTest);
 
             // Act
             await TagsControllerTestsHelper.UploadFieldValueAttachmentAsync(
@@ -1469,7 +1538,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         {
             // Arrange
             var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithAttachmentRequirement_Started;
-            var requirement = await TagsControllerTestsHelper.GetTagRequirementInfoAsync(UserType.Preserver, TestFactory.PlantWithAccess, tagIdUnderTest);
+            var requirement = await GetTagRequirementInfoAsync(UserType.Preserver, TestFactory.PlantWithAccess, tagIdUnderTest);
 
             // Act
             await TagsControllerTestsHelper.UploadFieldValueAttachmentAsync(
@@ -1487,7 +1556,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         {
             // Arrange
             var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithAttachmentRequirement_Started;
-            var requirement = await TagsControllerTestsHelper.GetTagRequirementInfoAsync(UserType.Preserver, TestFactory.PlantWithAccess, tagIdUnderTest);
+            var requirement = await GetTagRequirementInfoAsync(UserType.Preserver, TestFactory.PlantWithAccess, tagIdUnderTest);
 
             // Act
             await TagsControllerTestsHelper.UploadFieldValueAttachmentAsync(
@@ -1550,7 +1619,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         {
             // Arrange
             var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithAttachmentRequirement_Started;
-            var requirement = await TagsControllerTestsHelper.GetTagRequirementInfoAsync(
+            var requirement = await GetTagRequirementInfoAsync(
                 UserType.Preserver,
                 TestFactory.PlantWithAccess,
                 tagIdUnderTest);
@@ -1638,7 +1707,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         {
             // Arrange
             var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithAttachmentRequirement_Started;
-            var requirement = await TagsControllerTestsHelper.GetTagRequirementInfoAsync(UserType.Preserver, TestFactory.PlantWithAccess, tagIdUnderTest);
+            var requirement = await GetTagRequirementInfoAsync(UserType.Preserver, TestFactory.PlantWithAccess, tagIdUnderTest);
 
             // Act
             await TagsControllerTestsHelper.RecordCbValueAsync(
@@ -1657,7 +1726,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         {
             // Arrange
             var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithAttachmentRequirement_Started;
-            var requirement = await TagsControllerTestsHelper.GetTagRequirementInfoAsync(UserType.Preserver, TestFactory.PlantWithAccess, tagIdUnderTest);
+            var requirement = await GetTagRequirementInfoAsync(UserType.Preserver, TestFactory.PlantWithAccess, tagIdUnderTest);
 
             // Act
             await TagsControllerTestsHelper.RecordCbValueAsync(
@@ -1676,7 +1745,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         {
             // Arrange
             var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithAttachmentRequirement_Started;
-            var requirement = await TagsControllerTestsHelper.GetTagRequirementInfoAsync(UserType.Preserver, TestFactory.PlantWithAccess, tagIdUnderTest);
+            var requirement = await GetTagRequirementInfoAsync(UserType.Preserver, TestFactory.PlantWithAccess, tagIdUnderTest);
 
             // Act
             await TagsControllerTestsHelper.RecordCbValueAsync(

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerNegativeTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerNegativeTests.cs
@@ -355,6 +355,27 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
                 expectedStatusCode:HttpStatusCode.BadRequest,
                 expectedMessageOnBadRequest:"Tag must be an area tag to update description!");
         }
+
+        [TestMethod]
+        public async Task UpdateTagRequirements_AsPlanner_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            // Arrange
+            var stepId = TwoStepJourneyWithTags.Steps.First(s => !s.IsVoided).Id;
+            var tag = await CreateAndGetAreaTagAsync(
+                AreaTagType.PreArea,
+                stepId,
+                null,
+                false);
+
+            // Act
+            await TagsControllerTestsHelper.UpdateTagRequirementsAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                tag.Id,
+                Guid.NewGuid().ToString(),
+                TestFactory.WrongButValidRowVersion,
+                expectedStatusCode: HttpStatusCode.Conflict);
+        }
         #endregion
 
         #region UpdateTagStepAndRequirements
@@ -491,6 +512,34 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
                 null,
                 5555,
                 expectedStatusCode: HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateTagStep_AsPreserver_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            var supplierStepId = TwoStepJourneyWithTags.Steps.First(s => !s.IsVoided && s.Mode.ForSupplier).Id;
+            var tag = await CreateAndGetAreaTagAsync(
+                AreaTagType.PreArea,
+                supplierStepId,
+                null,
+                false);
+
+            var otherStepId = TwoStepJourneyWithTags.Steps.First(s => !s.IsVoided && !s.Mode.ForSupplier).Id;
+
+            // Act
+            var idAndRowVersions = await TagsControllerTestsHelper.UpdateTagStepAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                new List<IdAndRowVersion>
+                {
+                    new IdAndRowVersion
+                    {
+                        Id = tag.Id,
+                        RowVersion = TestFactory.WrongButValidRowVersion
+                    }
+                },
+                otherStepId,
+                HttpStatusCode.Conflict);
+        }
         #endregion
 
         #region UpdateTag
@@ -544,6 +593,26 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
                 null,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UpdateTag_AsPlanner_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            var stepId = TwoStepJourneyWithTags.Steps.First(s => !s.IsVoided).Id;
+            var tag = await CreateAndGetAreaTagAsync(
+                AreaTagType.PreArea,
+                stepId,
+                null,
+                false);
+
+            await TagsControllerTestsHelper.UpdateTagAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                tag.Id,
+                Guid.NewGuid().ToString(),
+                null,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
         #endregion
 
         #region GetAllTagAttachments
@@ -658,8 +727,25 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "Tag and/or attachment doesn't exist!");
+
+        [TestMethod]
+        public async Task DeleteTagAttachment_AsPlanner_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithAttachmentsAndActionAttachments_Started;
+            var attachmentDtos = await TagsControllerTestsHelper.GetAllTagAttachmentsAsync(
+                UserType.Preserver, TestFactory.PlantWithAccess,
+                tagIdUnderTest);
+            var tagAttachmentId = attachmentDtos.First().Id;
+            await TagsControllerTestsHelper.DeleteTagAttachmentAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                tagIdUnderTest,
+                tagAttachmentId,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
         #endregion
-        
+
         #region GetAllActionAttachments
         [TestMethod]
         public async Task GetAllActionAttachments_AsAnonymous_ShouldReturnUnauthorized()
@@ -805,8 +891,35 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
                 HttpStatusCode.BadRequest,
                 "Tag, action and/or attachment doesn't exist!");
 
+        [TestMethod]
+        public async Task DeleteActionAttachment_AsPreserver_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            // Arrange
+            var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithAttachmentsAndActionAttachments_Started;
+            var actionsDtos = await TagsControllerTestsHelper.GetAllActionsAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                tagIdUnderTest);
+            var actionId = actionsDtos.First().Id;
+            var actionAttachmentDtos = await TagsControllerTestsHelper.GetAllActionAttachmentsAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                tagIdUnderTest,
+                actionId);
+            var actionAttachmentId = actionAttachmentDtos.First().Id;
+            
+            // Act
+            await TagsControllerTestsHelper.DeleteActionAttachmentAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                tagIdUnderTest,
+                actionId,
+                actionAttachmentId,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
         #endregion
-        
+
         #region GetAllActions
         [TestMethod]
         public async Task GetAllActions_AsAnonymous_ShouldReturnUnauthorized()
@@ -860,8 +973,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
                 UserType.Anonymous, TestFactory.UnknownPlant,
                 9999,
                 8888,
-                null,
-                null,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Unauthorized);
 
@@ -871,8 +984,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
                 UserType.Hacker, TestFactory.UnknownPlant,
                 9999,
                 8888,
-                null,
-                null,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -882,8 +995,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
                 UserType.LibraryAdmin, TestFactory.UnknownPlant,
                 9999,
                 8888,
-                null,
-                null,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "is not a valid plant");
@@ -894,8 +1007,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
                 UserType.Hacker, TestFactory.PlantWithAccess,
                 9999, 
                 8888,
-                null,
-                null,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -905,8 +1018,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
                 UserType.LibraryAdmin, TestFactory.PlantWithAccess, 
                 9999, 
                 8888,
-                null,
-                null,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
 
@@ -916,8 +1029,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
                 UserType.Preserver, TestFactory.PlantWithAccess,
                 9999, 
                 _tagActionId2,
-                "TestTitle",
-                "TestDescription",
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "Tag and/or action doesn't exist!");
@@ -926,15 +1039,38 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         public async Task UpdateAction_AsPreserver_ShouldReturnBadRequest_WhenUnknownActionId()
             => await TagsControllerTestsHelper.UpdateActionAsync(
                 UserType.Preserver, TestFactory.PlantWithAccess,
-                TagIdUnderTest_ForSiteAreaTagReadyForBulkPreserve_NotStarted, 
+                TagIdUnderTest_ForSiteAreaTagReadyForBulkPreserve_NotStarted,
                 _tagActionId1,   // known actionId, but under other Tag
-                "TestTitle",
-                "TestDescription",
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "Tag and/or action doesn't exist!");
+
+        [TestMethod]
+        public async Task UpdateAction_AsPreserver_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            // Arrange
+            var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithAttachmentsAndActionAttachments_Started;
+            var actionsDtos = await TagsControllerTestsHelper.GetAllActionsAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                tagIdUnderTest);
+            var actionId = actionsDtos.First().Id;
+            
+            // Act
+            await TagsControllerTestsHelper.UpdateActionAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                tagIdUnderTest,
+                actionId,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
         #endregion
-        
+
         #region GetAction
         [TestMethod]
         public async Task GetAction_AsAnonymous_ShouldReturnUnauthorized()
@@ -1056,13 +1192,34 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         public async Task CloseAction_AsPreserver_ShouldReturnBadRequest_WhenUnknownActionId()
             => await TagsControllerTestsHelper.CloseActionAsync(
                 UserType.Preserver, TestFactory.PlantWithAccess,
-                TagIdUnderTest_ForSiteAreaTagReadyForBulkPreserve_NotStarted, 
+                TagIdUnderTest_ForSiteAreaTagReadyForBulkPreserve_NotStarted,
                 _tagActionId1,   // known actionId, but under other Tag
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.BadRequest,
                 "Tag and/or action doesn't exist!");
+
+        [TestMethod]
+        public async Task CloseAction_AsPreserver_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            // Arrange
+            var tagIdUnderTest = TagIdUnderTest_ForStandardTagWithAttachmentsAndActionAttachments_Started;
+            var actionsDtos = await TagsControllerTestsHelper.GetAllActionsAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                tagIdUnderTest);
+            var actionId = actionsDtos.First(a => !a.IsClosed).Id;
+            
+            // Act
+            await TagsControllerTestsHelper.CloseActionAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                tagIdUnderTest,
+                actionId,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
         #endregion
-        
+
         #region UploadActionAttachment
         [TestMethod]
         public async Task UploadActionAttachment_AsAnonymous_ShouldReturnUnauthorized()
@@ -1125,13 +1282,13 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         public async Task UploadActionAttachment_AsPreserver_ShouldReturnBadRequest_WhenUnknownActionId()
             => await TagsControllerTestsHelper.UploadActionAttachmentAsync(
                 UserType.Preserver, TestFactory.PlantWithAccess,
-                TagIdUnderTest_ForSiteAreaTagReadyForBulkPreserve_NotStarted, 
+                TagIdUnderTest_ForSiteAreaTagReadyForBulkPreserve_NotStarted,
                 _tagActionId1,   // known actionId, but under other Tag
                 FileToBeUploaded,
                 HttpStatusCode.BadRequest,
                 "Tag and/or action doesn't exist!");
         #endregion
-        
+
         #region CreateAction
         [TestMethod]
         public async Task CreateAction_AsAnonymous_ShouldReturnUnauthorized()
@@ -1185,8 +1342,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
             => await TagsControllerTestsHelper.CreateActionAsync(
                 UserType.Preserver, TestFactory.PlantWithAccess,
                 9999, 
-                "TestTitle",
-                "TestDescription",
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
                 HttpStatusCode.BadRequest,
                 "Tag doesn't exist!");
         #endregion
@@ -1591,7 +1748,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
             
             // Act
             await TagsControllerTestsHelper.TransferAsync(
-                UserType.Planner, TestFactory.PlantWithAccess,
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
                 new List<IdAndRowVersion>
                 {
                     new IdAndRowVersion
@@ -1604,6 +1762,31 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
                 "Not a valid row version!");
         }
 
+
+        [TestMethod]
+        public async Task Transfer_AsPlanner_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            // Arrange 
+            var tagResultDto = await TagsControllerTestsHelper.GetPageOfTagsAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                TestFactory.ProjectWithAccess);
+            var tagToTransfer = tagResultDto.Tags.FirstOrDefault(t => t.ReadyToBeTransferred);
+            Assert.IsNotNull(tagToTransfer, "Bad test setup: Didn't find tag ready to be transferred");
+
+            // Act
+            await TagsControllerTestsHelper.TransferAsync(
+                UserType.Planner, TestFactory.PlantWithAccess,
+                new List<IdAndRowVersion>
+                {
+                    new IdAndRowVersion
+                    {
+                        Id = tagToTransfer.Id,
+                        RowVersion = TestFactory.WrongButValidRowVersion
+                    }
+                },
+                HttpStatusCode.Conflict);
+        }
         #endregion
 
         #region UndoStartPreservation
@@ -1675,6 +1858,31 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
                 "Not a valid row version!");
         }
 
+        [TestMethod]
+        public async Task UndoStartPreservation_AsPlanner_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            // Arrange 
+            var tagResultDto = await TagsControllerTestsHelper.GetPageOfTagsAsync(
+                UserType.Planner, TestFactory.PlantWithAccess,
+                TestFactory.ProjectWithAccess);
+            var tagToUndoStartPreservation = tagResultDto.Tags.FirstOrDefault(t => t.ReadyToUndoStarted);
+            Assert.IsNotNull(tagToUndoStartPreservation, "Bad test setup: Didn't find tag ready to undo start");
+
+            // Act
+            await TagsControllerTestsHelper.UndoStartPreservationAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                new List<IdAndRowVersion>
+                {
+                    new IdAndRowVersion
+                    {
+                        Id = tagToUndoStartPreservation.Id,
+                        RowVersion = TestFactory.WrongButValidRowVersion
+                    }
+                },
+                HttpStatusCode.Conflict);
+        }
+
         #endregion
 
         #region CompletePreservation
@@ -1725,45 +1933,21 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         public async Task CompletePreservation_AsPlanner_ShouldReturnBadRequest_WhenIllegalRowVersion()
         {
             // Arrange 
-            var newReqDefId = await CreateRequirementDefinitionAsync(UserType.LibraryAdmin, TestFactory.PlantWithAccess);
-            var stepId = TwoStepJourneyWithTags.Steps.Last(s => !s.IsVoided).Id;
-
-            var newTagId = await TagsControllerTestsHelper.CreateAreaTagAsync(
-                UserType.Planner, TestFactory.PlantWithAccess,
-                TestFactory.ProjectWithAccess,
+            var newTag = await CreateAndGetAreaTagAsync(
                 AreaTagType.PreArea,
-                KnownDisciplineCode,
-                KnownAreaCode,
-                Guid.NewGuid().ToString(),
-                new List<TagRequirementDto>
-                {
-                    new TagRequirementDto
-                    {
-                        IntervalWeeks = 4,
-                        RequirementDefinitionId = newReqDefId
-                    }
-                },
-                stepId,
-                "Desc",
+                TwoStepJourneyWithTags.Steps.Last(s => !s.IsVoided).Id,
                 null,
-                null,
-                null);
-            await TagsControllerTestsHelper.StartPreservationAsync(UserType.Planner, TestFactory.PlantWithAccess, new List<int> {newTagId});
-
-            var tagsResult = await TagsControllerTestsHelper.GetPageOfTagsAsync(
-                UserType.Planner, TestFactory.PlantWithAccess,
-                TestFactory.ProjectWithAccess);
-            var tagToCompletedPreservation = tagsResult.Tags.Single(t => t.Id == newTagId);
-            Assert.IsTrue(tagToCompletedPreservation.ReadyToBeCompleted, "Bad test setup: Didn't find tag ready to be completed");
+                true);
             
             // Act
             await TagsControllerTestsHelper.CompletePreservationAsync(
-                UserType.Planner, TestFactory.PlantWithAccess,
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
                 new List<IdAndRowVersion>
                 {
                     new IdAndRowVersion
                     {
-                        Id = tagToCompletedPreservation.Id,
+                        Id = newTag.Id,
                         RowVersion = "invalidrowversion"
                     }
                 },
@@ -1771,8 +1955,33 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
                 "Not a valid row version!");
         }
 
+        [TestMethod]
+        public async Task CompletePreservation_AsPlanner_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            // Arrange 
+            var newTag = await CreateAndGetAreaTagAsync(
+                AreaTagType.PreArea,
+                TwoStepJourneyWithTags.Steps.Last(s => !s.IsVoided).Id,
+                null,
+                true);
+
+            // Act
+            await TagsControllerTestsHelper.CompletePreservationAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                new List<IdAndRowVersion>
+                {
+                    new IdAndRowVersion
+                    {
+                        Id = newTag.Id,
+                        RowVersion = TestFactory.WrongButValidRowVersion
+                    }
+                },
+                HttpStatusCode.Conflict);
+        }
+
         #endregion
-        
+
         #region StartPreservation
         [TestMethod]
         public async Task StartPreservation_AsAnonymous_ShouldReturnUnauthorized()
@@ -2104,8 +2313,27 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
                 9999,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task VoidTag_AsPlanner_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            // Arrange
+            var newTagId = await CreateAreaTagAsync(
+                AreaTagType.PreArea,
+                TwoStepJourneyWithTags.Steps.First(s => !s.IsVoided).Id,
+                null,
+                true);
+
+            // Act
+            await TagsControllerTestsHelper.VoidTagAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                newTagId,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
         #endregion
-        
+
         #region UnvoidTag
         [TestMethod]
         public async Task UnvoidTag_AsAnonymous_ShouldReturnUnauthorized()
@@ -2155,6 +2383,128 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
                 9999,
                 TestFactory.AValidRowVersion,
                 HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task UnvoidTag_AsPlanner_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            // Arrange
+            var tag = await CreateAndGetAreaTagAsync(
+                AreaTagType.PreArea,
+                TwoStepJourneyWithTags.Steps.First().Id,
+                null,
+                true);
+            await TagsControllerTestsHelper.VoidTagAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                tag.Id,
+                tag.RowVersion);
+
+            // Act
+            await TagsControllerTestsHelper.UnvoidTagAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                tag.Id,
+                TestFactory.WrongButValidRowVersion,
+                HttpStatusCode.Conflict);
+        }
+        #endregion
+
+        #region Reschedule
+        [TestMethod]
+        public async Task Reschedule_AsAnonymous_ShouldReturnUnauthorized()
+            => await TagsControllerTestsHelper.RescheduleAsync(
+                UserType.Anonymous, 
+                TestFactory.UnknownPlant,
+                null,
+                1,
+                Domain.Events.RescheduledDirection.Later,
+                Guid.NewGuid().ToString(),
+                HttpStatusCode.Unauthorized);
+
+        [TestMethod]
+        public async Task Reschedule_AsHacker_ShouldReturnForbidden_WhenUnknownPlant()
+            => await TagsControllerTestsHelper.RescheduleAsync(
+                UserType.Hacker, 
+                TestFactory.UnknownPlant,
+                null,
+                1,
+                Domain.Events.RescheduledDirection.Later,
+                Guid.NewGuid().ToString(),
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task Reschedule_AsAdmin_ShouldReturnBadRequest_WhenUnknownPlant()
+            => await TagsControllerTestsHelper.RescheduleAsync(
+                UserType.LibraryAdmin, 
+                TestFactory.UnknownPlant,
+                null,
+                1,
+                Domain.Events.RescheduledDirection.Later,
+                Guid.NewGuid().ToString(),
+                HttpStatusCode.BadRequest,
+                "is not a valid plant");
+
+        [TestMethod]
+        public async Task Reschedule_AsHacker_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.RescheduleAsync(
+                UserType.Hacker,
+                TestFactory.PlantWithAccess,
+                null,
+                1,
+                Domain.Events.RescheduledDirection.Later,
+                Guid.NewGuid().ToString(),
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task Reschedule_AsAdmin_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.RescheduleAsync(
+                UserType.LibraryAdmin,
+                TestFactory.PlantWithAccess,
+                null,
+                1,
+                Domain.Events.RescheduledDirection.Later,
+                Guid.NewGuid().ToString(),
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task Reschedule_AsPreserver_ShouldReturnForbidden_WhenPermissionMissing()
+            => await TagsControllerTestsHelper.RescheduleAsync(
+                UserType.Preserver,
+                TestFactory.PlantWithAccess,
+                null,
+                1,
+                Domain.Events.RescheduledDirection.Later,
+                Guid.NewGuid().ToString(),
+                HttpStatusCode.Forbidden);
+
+        [TestMethod]
+        public async Task Reschedule_AsPlanner_ShouldReturnConflict_WhenWrongRowVersion()
+        {
+            // Arrange 
+            var tag = await CreateAndGetAreaTagAsync(
+                AreaTagType.PreArea,
+                TwoStepJourneyWithTags.Steps.First().Id,
+                null,
+                true);
+
+            // Act
+            await TagsControllerTestsHelper.RescheduleAsync(
+                UserType.Planner,
+                TestFactory.PlantWithAccess,
+                new List<IdAndRowVersion>
+                {
+                    new IdAndRowVersion
+                    {
+                        Id = tag.Id,
+                        RowVersion = TestFactory.WrongButValidRowVersion
+                    }
+                },
+                52,
+                Domain.Events.RescheduledDirection.Later,
+                Guid.NewGuid().ToString(),
+                HttpStatusCode.Conflict);
+        }
+
         #endregion
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTests.cs
@@ -142,7 +142,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         public async Task UpdateTagRequirements_AsPlanner_ShouldUpdateAndAddRequirements()
         {
             // Arrange
-            var newReqDefId = await CreateRequirementDefinitionAsync(UserType.LibraryAdmin, TestFactory.PlantWithAccess);
+            var newReqDefId = await CreateRequirementDefinitionAsync(TestFactory.PlantWithAccess);
 
             var tag = await CreateAndGetAreaTagAsync(AreaTagType.PreArea,
                 TwoStepJourneyWithTags.Steps.First(s => !s.IsVoided).Id,
@@ -200,7 +200,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         public async Task UpdateTagRequirements_AsPlanner_ShouldDeleteRequirement()
         {
             // Arrange
-            var newReqDefId = await CreateRequirementDefinitionAsync(UserType.LibraryAdmin, TestFactory.PlantWithAccess);
+            var newReqDefId = await CreateRequirementDefinitionAsync(TestFactory.PlantWithAccess);
 
             var tag = await CreateAndGetAreaTagAsync(AreaTagType.PreArea,
                 TwoStepJourneyWithTags.Steps.First(s => !s.IsVoided).Id,
@@ -320,7 +320,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         public async Task UpdateTagStepAndRequirements_AsPlanner_ShouldUpdateAndAddRequirements()
         {
             // Arrange
-            var newReqDefId = await CreateRequirementDefinitionAsync(UserType.LibraryAdmin, TestFactory.PlantWithAccess);
+            var newReqDefId = await CreateRequirementDefinitionAsync(TestFactory.PlantWithAccess);
 
             var tag = await CreateAndGetAreaTagAsync(AreaTagType.PreArea,
                 TwoStepJourneyWithTags.Steps.First(s => !s.IsVoided).Id,
@@ -380,7 +380,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
         public async Task UpdateTagStepAndRequirements_AsPlanner_ShouldDeleteRequirement()
         {
             // Arrange
-            var newReqDefId = await CreateRequirementDefinitionAsync(UserType.LibraryAdmin, TestFactory.PlantWithAccess);
+            var newReqDefId = await CreateRequirementDefinitionAsync(TestFactory.PlantWithAccess);
 
             var tag = await CreateAndGetAreaTagAsync(AreaTagType.PreArea,
                 TwoStepJourneyWithTags.Steps.First(s => !s.IsVoided).Id,
@@ -1197,7 +1197,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
             int stepId,
             bool startPreservation)
         {
-            var newReqDefId = await CreateRequirementDefinitionAsync(UserType.LibraryAdmin, TestFactory.PlantWithAccess);
+            var newReqDefId = await CreateRequirementDefinitionAsync(TestFactory.PlantWithAccess);
 
             var tagNo = Guid.NewGuid().ToString();
             MockMainApiDataForTag(tagNo);

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTestsBase.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTestsBase.cs
@@ -6,7 +6,6 @@ using Equinor.ProCoSys.Preservation.MainApi.Area;
 using Equinor.ProCoSys.Preservation.MainApi.Discipline;
 using Equinor.ProCoSys.Preservation.WebApi.Controllers.Tags;
 using Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Journeys;
-using Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
@@ -97,21 +96,13 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
             return await TagsControllerTestsHelper.GetTagAsync(UserType.Planner, TestFactory.PlantWithAccess, tagIdUnderTest);
         }
 
-        protected async Task<int> CreateRequirementDefinitionAsync(UserType userType, string plant)
-        {
-            var reqTypes = await RequirementTypesControllerTestsHelper.GetRequirementTypesAsync(userType, plant);
-            var newReqDefId = await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
-                userType, plant, reqTypes.First().Id, Guid.NewGuid().ToString());
-            return newReqDefId;
-        }
-
         protected async Task<int> CreateAreaTagAsync(
             AreaTagType areaTagType,
             int stepId,
             string purchaseOrderCalloffCode,
             bool startPreservation)
         {
-            var newReqDefId = await CreateRequirementDefinitionAsync(UserType.LibraryAdmin, TestFactory.PlantWithAccess);
+            var newReqDefId = await CreateRequirementDefinitionAsync(TestFactory.PlantWithAccess);
 
             var newTagId = await TagsControllerTestsHelper.CreateAreaTagAsync(
                 UserType.Planner,

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTestsHelper.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Tags/TagsControllerTestsHelper.cs
@@ -545,18 +545,6 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
             await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
         }
 
-        public static async Task<GetTagRequirementInfo> GetTagRequirementInfoAsync(UserType userType, string plant, int tagId)
-        {
-            var requirementDetailDtos = await GetTagRequirementsAsync(userType, plant, tagId);
-            var requirementDetailDto = requirementDetailDtos.First();
-            Assert.IsNotNull(requirementDetailDto.NextDueTimeUtc, "Bad test setup: Preservation not started");
-            Assert.AreEqual(1, requirementDetailDto.Fields.Count, "Bad test setup: Expect to find 1 requirement on tag under test");
-            return new GetTagRequirementInfo(
-                requirementDetailDto.Id,
-                requirementDetailDto.NextDueTimeUtc.Value,
-                requirementDetailDto.Fields);
-        }
-
         public static async Task PreserveRequirementAsync(
             UserType userType, string plant,
             int tagId,
@@ -836,6 +824,94 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.Tags
             }
 
             return await response.Content.ReadAsStringAsync();
+        }
+
+        public static async Task DeleteTagAsync(
+            UserType userType,
+            string plant,
+            int tagId,
+            string rowVersion,
+            HttpStatusCode expectedStatusCode = HttpStatusCode.OK,
+            string expectedMessageOnBadRequest = null)
+        {
+            var bodyPayload = new
+            {
+                rowVersion
+            };
+            var serializePayload = JsonConvert.SerializeObject(bodyPayload);
+            var request = new HttpRequestMessage(HttpMethod.Delete, $"{_route}/{tagId}")
+            {
+                Content = new StringContent(serializePayload, Encoding.UTF8, "application/json")
+            };
+
+            var response = await TestFactory.Instance.GetHttpClient(userType, plant).SendAsync(request);
+            await TestsHelper.AssertResponseAsync(response, expectedStatusCode, expectedMessageOnBadRequest);
+        }
+
+        public static void GetActionAttachmentAsync()
+        {
+            // todo
+        }
+
+        public static void MigrateTagsAsync()
+        {
+            // todo
+        }
+
+        public static void AutoScopeAsync()
+        {
+            // todo
+        }
+
+        public static void CheckAreaTagNoAsync()
+        {
+            // todo
+        }
+
+        public static void PreserveTagAsync()
+        {
+            // todo
+        }
+
+        public static void BulkPreserveTagsAsync()
+        {
+            // todo
+        }
+
+        public static void AutoTransferAsync()
+        {
+            // todo
+        }
+
+        public static void DeleteFieldValueAttachmentAsync()
+        {
+            // todo
+        }
+
+        public static void GetFieldValueAttachmentAsync()
+        {
+            // todo
+        }
+
+
+        public static void UploadTagAttachmentAsync()
+        {
+            // todo
+        }
+
+        public static void GetTagAttachmentAsync()
+        {
+            // todo
+        }
+
+        public static void GetPreservationRecordAsync()
+        {
+            // todo
+        }
+
+        public static void GetHistoricalFieldValueAttachmentAsync()
+        {
+            // todo
         }
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/TestBase.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/TestBase.cs
@@ -1,4 +1,8 @@
-﻿using Equinor.ProCoSys.Preservation.Command.Validators;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.Preservation.Command.Validators;
+using Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.RequirementTypes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests
@@ -16,6 +20,14 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests
             Assert.IsTrue(_rowVersionValidator.IsValid(oldRowVersion));
             Assert.IsTrue(_rowVersionValidator.IsValid(newRowVersion));
             Assert.AreNotEqual(oldRowVersion, newRowVersion);
+        }
+
+        protected async Task<int> CreateRequirementDefinitionAsync(string plant)
+        {
+            var reqTypes = await RequirementTypesControllerTestsHelper.GetRequirementTypesAsync(UserType.LibraryAdmin, plant);
+            var newReqDefId = await RequirementTypesControllerTestsHelper.CreateRequirementDefinitionAsync(
+                UserType.LibraryAdmin, plant, reqTypes.First().Id, Guid.NewGuid().ToString());
+            return newReqDefId;
         }
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/TestFactory.cs
@@ -14,6 +14,7 @@ using Equinor.ProCoSys.Preservation.MainApi.Plant;
 using Equinor.ProCoSys.Preservation.MainApi.Project;
 using Equinor.ProCoSys.Preservation.MainApi.Responsible;
 using Equinor.ProCoSys.Preservation.MainApi.Tag;
+using Equinor.ProCoSys.Preservation.MainApi.TagFunction;
 using Equinor.ProCoSys.Preservation.WebApi.Authorizations;
 using Equinor.ProCoSys.Preservation.WebApi.Middleware;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -50,6 +51,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests
         public readonly Mock<IAreaApiService> AreaApiServiceMock = new Mock<IAreaApiService>();
         public readonly Mock<IBlobStorage> BlobStorageMock = new Mock<IBlobStorage>();
         public readonly Mock<ITagApiService> TagApiServiceMock = new Mock<ITagApiService>();
+        public readonly Mock<ITagFunctionApiService> TagFunctionApiServiceMock = new Mock<ITagFunctionApiService>();
 
         public static string PlantWithAccess => KnownPlantData.PlantA;
         public static string PlantWithoutAccess => KnownPlantData.PlantB;
@@ -154,6 +156,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests
                 services.AddScoped(_ => _plantApiServiceMock.Object);
                 services.AddScoped(_ => _projectApiServiceMock.Object);
                 services.AddScoped(_ => TagApiServiceMock.Object);
+                services.AddScoped(_ => TagFunctionApiServiceMock.Object);
                 services.AddScoped(_ => _permissionApiServiceMock.Object);
                 services.AddScoped(_ => ResponsibleApiServiceMock.Object);
                 services.AddScoped(_ => DisciplineApiServiceMock.Object);


### PR DESCRIPTION
[AB#88576](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/88576)

Near 100% test coverage now, with focus testing Conflict when using wrong RowVersion

**Found a BUG which is fixed**: Validators for TagFunction need to honor both TagFunctionCode + RegisterCode when checking for exists / isvoided. Old code crash when Voiding/Unvoiding a TagFunctionCode/RegisterCode when same TagFunctionCode exists in multiple registers (due to a SingleOrDefault)