### PR TITLE
91017 - AutoTransferCommand must not inherit IProjectRequest

### DIFF
--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/AutoTransfer/AutoTransferCommand.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/AutoTransfer/AutoTransferCommand.cs
@@ -1,10 +1,9 @@
-﻿using Equinor.ProCoSys.Preservation.Domain;
-using MediatR;
+﻿using MediatR;
 using ServiceResult;
 
 namespace Equinor.ProCoSys.Preservation.Command.TagCommands.AutoTransfer
 {
-    public class AutoTransferCommand : IRequest<Result<Unit>>, IProjectRequest
+    public class AutoTransferCommand : IRequest<Result<Unit>>
     {
         public AutoTransferCommand(string projectName, string certificateNo, string certificateType)
         {

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.Tests/Authorizations/AccessValidatorTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.Tests/Authorizations/AccessValidatorTests.cs
@@ -1497,34 +1497,6 @@ namespace Equinor.ProCoSys.Preservation.WebApi.Tests.Authorizations
             Assert.IsTrue(result);
         }
         #endregion
-
-        #region AutoTransferCommand
-        [TestMethod]
-        public async Task ValidateAsync_OnAutoTransferCommand_ShouldReturnTrue_WhenAccessToBothProjectAndContent()
-        {
-            // Arrange
-            var command = new AutoTransferCommand(ProjectWithAccess, null, null);
-            
-            // act
-            var result = await _dut.ValidateAsync(command);
-
-            // Assert
-            Assert.IsTrue(result);
-        }
-
-        [TestMethod]
-        public async Task ValidateAsync_OnAutoTransferCommand_ShouldReturnFalse_WhenNoAccessToProject()
-        {
-            // Arrange
-            var command = new AutoTransferCommand(ProjectWithoutAccess, null, null);
-            
-            // act
-            var result = await _dut.ValidateAsync(command);
-
-            // Assert
-            Assert.IsFalse(result);
-        }
-        #endregion
         
         #endregion
 


### PR DESCRIPTION
In AutoTransfer context it's legal to try to autotransfer on unknown projects
[AB#91017](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/91017)