### PR TITLE
96688 - Sync ProCoSysGuids again

### DIFF
--- a/src/Equinor.ProCoSys.Preservation.Command/TagCommands/SyncTagData/SyncTagDataCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagCommands/SyncTagData/SyncTagDataCommandHandler.cs
@@ -38,7 +38,7 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.SyncTagData
             var count = 0;
             foreach (var project in allProjects)
             {
-                var tagsToFill = project.Tags.Where(t => t.TagType == TagType.Standard).ToList();
+                var tagsToFill = project.Tags.Where(t => t.TagType == TagType.Standard && !t.ProCoSysGuid.HasValue).ToList();
                 _logger.LogInformation($"SyncTagData: Found {tagsToFill.Count} in project {project.Name}, plant {_plantProvider.Plant}");
                 if (tagsToFill.Count == 0)
                 {
@@ -58,12 +58,16 @@ namespace Equinor.ProCoSys.Preservation.Command.TagCommands.SyncTagData
                     var pcsTagDetail = pcsTagDetails.SingleOrDefault(t => t.TagNo == tag.TagNo);
                     if (pcsTagDetail != null)
                     {
+                        tag.ProCoSysGuid = pcsTagDetail.ProCoSysGuid;
+                        tag.McPkgProCoSysGuid = pcsTagDetail.McPkgProCoSysGuid;
+                        tag.CommPkgProCoSysGuid = pcsTagDetail.CommPkgProCoSysGuid;
+                        tagNos += pcsTagDetail.TagNo + ", ";
+                        count++;
+
                         if (pcsTagDetail.IsVoided != tag.IsVoidedInSource)
                         {
                             _logger.LogWarning($"SyncTagData: {tag.TagNo} in {project.Name} in {_plantProvider.Plant}. Setting IsVoidedInSource = {pcsTagDetail.IsVoided}");
-                            tagNos += tag.TagNo + ", ";
                             tag.IsVoidedInSource = pcsTagDetail.IsVoided;
-                            count++;
                         }
                     }
                     else if (!tag.IsDeletedInSource)

--- a/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/ProjectAggregate/Tag.cs
+++ b/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/ProjectAggregate/Tag.cs
@@ -96,7 +96,7 @@ namespace Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate
         }
 
         public Guid ObjectGuid { get; private set; }
-        public Guid? ProCoSysGuid { get; private set; }
+        public Guid? ProCoSysGuid { get; set; }
         public PreservationStatus Status { get; private set; }
         public string AreaCode { get; private set; }
         public string AreaDescription { get; private set; }


### PR DESCRIPTION
Sync ProCoSysGuids into preservation DB again since there was a BUG in Main API, which delivered wrong Guids. Existing Guids already populated into preservation will be cleared by a manual script (No automation by migration)

[AB#96688](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/96688)