### PR TITLE
98580 - Fix JourneyDetailsDto returned by GetJourneyByIdQueryHandler to reflect new rule for Journey.InUse

### DIFF
--- a/src/Equinor.ProCoSys.Preservation.Query/GetJourneyById/GetJourneyByIdQueryHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Query/GetJourneyById/GetJourneyByIdQueryHandler.cs
@@ -51,7 +51,7 @@ namespace Equinor.ProCoSys.Preservation.Query.GetJourneyById
             var journeyDto = new JourneyDetailsDto(
                 journey.Id,
                 journey.Title,
-                journey.Steps.Any(),
+                anyStepInUse,
                 journey.IsVoided,
                 journey.OrderedSteps()
                     .Where(s => !s.IsVoided || request.IncludeVoided)

--- a/src/tests/Equinor.ProCoSys.Preservation.Query.Tests/GetJourneyById/GetJourneyByIdQueryHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Query.Tests/GetJourneyById/GetJourneyByIdQueryHandlerTests.cs
@@ -95,6 +95,25 @@ namespace Equinor.ProCoSys.Preservation.Query.Tests.GetJourneyById
         }
 
         [TestMethod]
+        public async Task HandleGetJourneyByIdQueryHandler_BeforeTagsAddedToStep_ShouldReturnJourneyNotInUse()
+        {
+            int journeyId;
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                journeyId = AddJourneyWithStep(context, "J3", "Step1", _testDataSet.Mode1, _testDataSet.Responsible1).Id;
+            }
+
+            using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))
+            {
+                var dut = new GetJourneyByIdQueryHandler(context);
+                var result = await dut.Handle(new GetJourneyByIdQuery(journeyId, true), default);
+
+                var journey = result.Data;
+                Assert.IsFalse(journey.IsInUse);
+            }
+        }
+
+        [TestMethod]
         public async Task HandleGetJourneyByIdQueryHandler_AfterTagsAddedToAStep_ShouldReturnAllStepsInUse()
         {
             using (var context = new PreservationContext(_dbContextOptions, _plantProvider, _eventDispatcher, _currentUserProvider))


### PR DESCRIPTION
[AB#98580](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/98580)

Journey.InUse = any step in use