### PR TITLE
Use GUID instead og OLD-values

### DIFF
--- a/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/ProjectAggregate/IProjectRepository.cs
+++ b/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/ProjectAggregate/IProjectRepository.cs
@@ -19,6 +19,7 @@ namespace Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate
         Task<List<Tag>> GetStandardTagsInProjectInStepsAsync(string projectName, IEnumerable<string> tagNos, IEnumerable<int> stepIds);
         Task<Project> GetProjectAndTagWithPreservationHistoryByTagIdAsync(int tagId);
         Task<Project> GetProjectOnlyByTagIdAsync(int tagId);
+        Task<Project> GetProjectOnlyByTagGuidAsync(Guid tagId);
         Task<Project> GetProjectWithTagsByNameAsync(string projectName);
         Task<Tag> GetTagOnlyByGuidAsync(Guid guid);
     }

--- a/src/Equinor.ProCoSys.Preservation.Infrastructure/Repositories/ProjectRepository.cs
+++ b/src/Equinor.ProCoSys.Preservation.Infrastructure/Repositories/ProjectRepository.cs
@@ -111,5 +111,10 @@ namespace Equinor.ProCoSys.Preservation.Infrastructure.Repositories
             => Set
                 .Where(project => project.Tags.Any(tag => tag.Id == tagId))
                 .SingleOrDefaultAsync();
+
+        public Task<Project> GetProjectOnlyByTagGuidAsync(Guid tagGuid)
+            => Set
+                .Where(project => project.Tags.Any(tag => tag.Guid == tagGuid))
+                .SingleOrDefaultAsync();
     }
 }

--- a/src/Equinor.ProCoSys.Preservation.Infrastructure/Repositories/ProjectRepository.cs
+++ b/src/Equinor.ProCoSys.Preservation.Infrastructure/Repositories/ProjectRepository.cs
@@ -115,6 +115,6 @@ namespace Equinor.ProCoSys.Preservation.Infrastructure.Repositories
         public Task<Project> GetProjectOnlyByTagGuidAsync(Guid tagGuid)
             => Set
                 .Where(project => project.Tags.Any(tag => tag.Guid == tagGuid))
-                .SingleOrDefaultAsync();
+                .SingleAsync();
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.Tests/Synchronization/BusReceiverServiceTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.Tests/Synchronization/BusReceiverServiceTests.cs
@@ -63,6 +63,8 @@ namespace Equinor.ProCoSys.Preservation.WebApi.Tests.Synchronization
         private const string OldTagDescription1 = "OldTagDescription1";
         private const string OldTagDescription2 = "OldTagDescription2";
 
+        private const string ProCoSysGuid1 = "EB38CCCAAE98D926E0532810000AC5B2";
+
         private const string CommPkg1 = "Comm1";
         private const string CommPkg2 = "Comm2";
         private const string McPkg1 = "MC1";
@@ -117,12 +119,17 @@ namespace Equinor.ProCoSys.Preservation.WebApi.Tests.Synchronization
                 .Returns(Task.FromResult(_project1));
             _projectRepository.Setup(p => p.GetProjectOnlyByNameAsync(Project1Name))
                 .Returns(Task.FromResult(_project1));
+            _projectRepository.Setup(p => p.GetProjectOnlyByTagGuidAsync(Guid.ParseExact("EB38CCCAAE98D926E0532810000AC5B2", "N")))
+                .Returns(Task.FromResult(_project1));
             _project2 = new Project(Plant, Project2Name, Project2Description, ProjectProCoSysGuid2);
             _projectRepository.Setup(p => p.GetProjectWithTagsByNameAsync(Project2Name))
                 .Returns(Task.FromResult(_project2));
             _projectRepository.Setup(p => p.GetProjectOnlyByNameAsync(Project2Name))
                 .Returns(Task.FromResult(_project2));
             _projectRepository.Setup(p => p.Add(It.IsAny<Project>())).Callback((Project p) => _newProjectCreated = p);
+
+            _projectRepository.Setup(p => p.GetTagOnlyByGuidAsync(Guid.ParseExact("EB38CCCAAE98D926E0532810000AC5B2", "N"))).Returns(Task.FromResult(_tag1));
+
 
             _tagFunction = new TagFunction(Plant, TagFunctionCode, TagFunctionDescription, RegisterCode);
             _tagFunctionRepository.Setup(t => t.GetByCodesAsync(TagFunctionCode, RegisterCode))
@@ -598,7 +605,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.Tests.Synchronization
             var poNo = "321";
             var tagFunctionCodeNew = "FCS123";
             var message =
-                $"{{\"TagNo\" : \"{TagNo1}\",\"Description\" : \"Test 123\",\"ProjectName\" : \"{Project1Name}\",\"McPkgNo\" : \"{McPkg1}\",\"CommPkgNo\" : \"{CommPkg1}\",\"AreaCode\" : \"{area}\",\"AreaDescription\" : \"{areaDescription}\",\"DisciplineCode\" : \"{discipline}\",\"DisciplineDescription\" : \"{disciplineDescription}\",\"CallOffNo\" : \"{callOffNo}\",\"PurchaseOrderNo\" : \"{poNo}\",\"TagFunctionCode\" : \"{tagFunctionCodeNew}\",\"IsVoided\" : true,\"Plant\" : \"{Plant}\"}}";
+                $"{{\"TagNo\" : \"{TagNo1}\",\"ProCoSysGuid\" : \"{ProCoSysGuid1}\",\"Description\" : \"Test 123\",\"ProjectName\" : \"{Project1Name}\",\"McPkgNo\" : \"{McPkg1}\",\"CommPkgNo\" : \"{CommPkg1}\",\"AreaCode\" : \"{area}\",\"AreaDescription\" : \"{areaDescription}\",\"DisciplineCode\" : \"{discipline}\",\"DisciplineDescription\" : \"{disciplineDescription}\",\"CallOffNo\" : \"{callOffNo}\",\"PurchaseOrderNo\" : \"{poNo}\",\"TagFunctionCode\" : \"{tagFunctionCodeNew}\",\"IsVoided\" : true,\"Plant\" : \"{Plant}\"}}";
 
             // Act
             await _dut.ProcessMessageAsync(PcsTopicConstants.Tag, message, default);
@@ -626,7 +633,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.Tests.Synchronization
             var poNo = "321";
             var tagFunctionCodeNew = "FCS123";
             var message =
-                $"{{\"TagNo\" : \"{tagNew}\",\"TagNoOld\" : \"{TagNo1}\",\"Description\" : \"Test 123\",\"ProjectName\" : \"{Project1Name}\",\"McPkgNo\" : \"{McPkg1}\",\"CommPkgNo\" : \"{CommPkg1}\",\"AreaCode\" : \"{area}\",\"AreaDescription\" : \"{areaDescription}\",\"DisciplineCode\" : \"{discipline}\",\"DisciplineDescription\" : \"{disciplineDescription}\",\"CallOffNo\" : \"{callOffNo}\",\"PurchaseOrderNo\" : \"{poNo}\",\"TagFunctionCode\" : \"{tagFunctionCodeNew}\",\"IsVoided\" : true,\"Plant\" : \"{Plant}\"}}";
+                $"{{\"TagNo\" : \"{tagNew}\",\"TagNoOld\" : \"{TagNo1}\",\"ProCoSysGuid\" : \"{ProCoSysGuid1}\",\"Description\" : \"Test 123\",\"ProjectName\" : \"{Project1Name}\",\"McPkgNo\" : \"{McPkg1}\",\"CommPkgNo\" : \"{CommPkg1}\",\"AreaCode\" : \"{area}\",\"AreaDescription\" : \"{areaDescription}\",\"DisciplineCode\" : \"{discipline}\",\"DisciplineDescription\" : \"{disciplineDescription}\",\"CallOffNo\" : \"{callOffNo}\",\"PurchaseOrderNo\" : \"{poNo}\",\"TagFunctionCode\" : \"{tagFunctionCodeNew}\",\"IsVoided\" : true,\"Plant\" : \"{Plant}\"}}";
 
             // Act
             await _dut.ProcessMessageAsync(PcsTopicConstants.Tag, message, default);
@@ -654,7 +661,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.Tests.Synchronization
             var poNo = "321";
             var tagFunctionCodeNew = "FCS123";
             var message =
-                $"{{\"TagNo\" : \"{TagNo1}\",\"Description\" : \"Test 123\",\"ProjectName\" : \"{Project1Name}\",\"McPkgNo\" : \"{McPkg1}\",\"CommPkgNo\" : \"{CommPkg1}\",\"AreaCode\" : \"{area}\",\"AreaDescription\" : \"{areaDescription}\",\"DisciplineCode\" : \"{discipline}\",\"DisciplineDescription\" : \"{disciplineDescription}\",\"CallOffNo\" : \"{callOffNo}\",\"PurchaseOrderNo\" : \"{poNo}\",\"TagFunctionCode\" : \"{tagFunctionCodeNew}\",\"IsVoided\" : true,\"Plant\" : \"{Plant}\"}}";
+                $"{{\"TagNo\" : \"{TagNo1}\",\"ProCoSysGuid\" : \"{ProCoSysGuid1}\",\"Description\" : \"Test 123\",\"ProjectName\" : \"{Project1Name}\",\"McPkgNo\" : \"{McPkg1}\",\"CommPkgNo\" : \"{CommPkg1}\",\"AreaCode\" : \"{area}\",\"AreaDescription\" : \"{areaDescription}\",\"DisciplineCode\" : \"{discipline}\",\"DisciplineDescription\" : \"{disciplineDescription}\",\"CallOffNo\" : \"{callOffNo}\",\"PurchaseOrderNo\" : \"{poNo}\",\"TagFunctionCode\" : \"{tagFunctionCodeNew}\",\"IsVoided\" : true,\"Plant\" : \"{Plant}\"}}";
 
             Assert.IsFalse(_tag1.IsVoided);
             Assert.IsFalse(_tag1.IsVoidedInSource);
@@ -680,7 +687,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.Tests.Synchronization
             var poNo = "321";
             var tagFunctionCodeNew = "FCS123";
             var message =
-                $"{{\"TagNo\" : \"{tagNew}\",\"TagNoOld\" : \"{TagNo1}\",\"Description\" : \"Test 123\",\"ProjectNameOld\" : \"{Project1Name}\",\"ProjectName\" : \"{Project2Name}\",\"McPkgNo\" : \"{McPkg1}\",\"CommPkgNo\" : \"{CommPkg1}\",\"AreaCode\" : \"{area}\",\"AreaDescription\" : \"{areaDescription}\",\"DisciplineCode\" : \"{discipline}\",\"DisciplineDescription\" : \"{disciplineDescription}\",\"CallOffNo\" : \"{callOffNo}\",\"PurchaseOrderNo\" : \"{poNo}\",\"TagFunctionCode\" : \"{tagFunctionCodeNew}\",\"IsVoided\" : true,\"Plant\" : \"{Plant}\"}}";
+                $"{{\"TagNo\" : \"{tagNew}\",\"TagNoOld\" : \"{TagNo1}\",\"ProCoSysGuid\" : \"{ProCoSysGuid1}\",\"Description\" : \"Test 123\",\"ProjectNameOld\" : \"{Project1Name}\",\"ProjectName\" : \"{Project2Name}\",\"McPkgNo\" : \"{McPkg1}\",\"CommPkgNo\" : \"{CommPkg1}\",\"AreaCode\" : \"{area}\",\"AreaDescription\" : \"{areaDescription}\",\"DisciplineCode\" : \"{discipline}\",\"DisciplineDescription\" : \"{disciplineDescription}\",\"CallOffNo\" : \"{callOffNo}\",\"PurchaseOrderNo\" : \"{poNo}\",\"TagFunctionCode\" : \"{tagFunctionCodeNew}\",\"IsVoided\" : true,\"Plant\" : \"{Plant}\"}}";
 
             // Assert
             Assert.IsTrue(_project1.Tags.Contains(_tag1));
@@ -715,7 +722,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.Tests.Synchronization
             var tagFunctionCodeNew = "FCS123";
 
             var message =
-                $"{{\"TagNo\" : \"{tagNew}\",\"TagNoOld\" : \"{TagNo1}\",\"Description\" : \"Test 123\",\"ProjectNameOld\" : \"{Project1Name}\",\"ProjectName\" : \"{_projectNotInPreservation}\",\"McPkgNo\" : \"{McPkg1}\",\"CommPkgNo\" : \"{CommPkg1}\",\"AreaCode\" : \"{area}\",\"AreaDescription\" : \"{areaDescription}\",\"DisciplineCode\" : \"{discipline}\",\"DisciplineDescription\" : \"{disciplineDescription}\",\"CallOffNo\" : \"{callOffNo}\",\"PurchaseOrderNo\" : \"{poNo}\",\"TagFunctionCode\" : \"{tagFunctionCodeNew}\",\"IsVoided\" : true,\"Plant\" : \"{Plant}\"}}";
+                $"{{\"TagNo\" : \"{tagNew}\",\"TagNoOld\" : \"{TagNo1}\",\"ProCoSysGuid\" : \"{ProCoSysGuid1}\",\"Description\" : \"Test 123\",\"ProjectNameOld\" : \"{Project1Name}\",\"ProjectName\" : \"{_projectNotInPreservation}\",\"McPkgNo\" : \"{McPkg1}\",\"CommPkgNo\" : \"{CommPkg1}\",\"AreaCode\" : \"{area}\",\"AreaDescription\" : \"{areaDescription}\",\"DisciplineCode\" : \"{discipline}\",\"DisciplineDescription\" : \"{disciplineDescription}\",\"CallOffNo\" : \"{callOffNo}\",\"PurchaseOrderNo\" : \"{poNo}\",\"TagFunctionCode\" : \"{tagFunctionCodeNew}\",\"IsVoided\" : true,\"Plant\" : \"{Plant}\"}}";
 
             // Assert
             Assert.IsTrue(_project1.Tags.Contains(_tag1));


### PR DESCRIPTION
This will remove the need for old-values in Tag-messages.

McPkg messages and CommPkg messages would still need old-values.  A new feature will be added that enables the removal of this requirement too.