### PR TITLE
107616 Correct misspelling of endpoint used in AutoScope

### DIFF
--- a/src/Equinor.ProCoSys.Preservation.MainApi/Tag/MainApiTagService.cs
+++ b/src/Equinor.ProCoSys.Preservation.MainApi/Tag/MainApiTagService.cs
@@ -120,7 +120,7 @@ namespace Equinor.ProCoSys.Preservation.MainApi.Tag
             PCSTagSearchResult tagSearchResult;
             do
             {
-                var url = $"{_baseAddress}Tag/Search/ByTagFunction" +
+                var url = $"{_baseAddress}Tag/Search/ByTagFunctions" +
                           $"?plantId={plant}" +
                           $"&projectName={WebUtility.UrlEncode(projectName)}" +
                           $"&currentPage={currentPage++}" +


### PR DESCRIPTION
[AB#107616](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/107616)