### PR TITLE
108176_Remove ImageTagName from promoted environments

### DIFF
--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -104,7 +104,6 @@ spec:
           cpu: '100m'
     # Test environment
     - environment: test
-      imageTagName: latest
       variables:
         LEASE_TIME: 5
       monitoring: false
@@ -118,7 +117,6 @@ spec:
           cpu: '100m'
     # Prod environment
     - environment: prod
-      imageTagName: latest
       variables:
          LEASE_TIME: 5
       replicas: 1


### PR DESCRIPTION
We want to use the same image as was used in deploy


[AB#108176](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/108176)