### PR TITLE
Removing unowned data from integration events

### DIFF
--- a/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/EventHelpers/CreateProjectTagEventHelper.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/EventHelpers/CreateProjectTagEventHelper.cs
@@ -28,18 +28,11 @@ public class CreateProjectTagEventHelper  : ICreateChildEventHelper<Project, Tag
             ProCoSysGuid = entity.Guid,
             Plant = entity.Plant,
             ProjectName = parentEntity.Name,
-            Description = entity.Description,
             Remark = entity.Remark,
             NextDueTimeUtc = entity.NextDueTimeUtc,
             StepGuid = step.Guid,
-            DisciplineCode = entity.DisciplineCode,
-            AreaCode = entity.AreaCode,
-            TagFunctionCode = entity.TagFunctionCode,
-            PurchaseOrderNo = entity.PurchaseOrderNo,
             TagType = entity.TagType.ToString(),
             StorageArea = entity.StorageArea,
-            AreaDescription = entity.AreaDescription,
-            DisciplineDescription = entity.DisciplineDescription,
             CreatedAtUtc = entity.CreatedAtUtc,
             CreatedByGuid = createdBy.Guid,
             ModifiedAtUtc = entity.ModifiedAtUtc,
@@ -48,7 +41,6 @@ public class CreateProjectTagEventHelper  : ICreateChildEventHelper<Project, Tag
             CommPkgGuid = entity.CommPkgProCoSysGuid,
             McPkgGuid = entity.McPkgProCoSysGuid,
             IsVoided = entity.IsVoided,
-            IsVoidedInSource = entity.IsVoidedInSource
         };
     }
 

--- a/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/EventHelpers/CreateResponsibleEventHelper.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/EventHelpers/CreateResponsibleEventHelper.cs
@@ -20,8 +20,6 @@ public class CreateResponsibleEventHelper : ICreateEventHelper<Responsible, Resp
         {
             ProCoSysGuid = entity.Guid,
             Plant = entity.Plant,
-            Code = entity.Code,
-            Description = entity.Description,
             IsVoided = entity.IsVoided,
             CreatedAtUtc = entity.CreatedAtUtc,
             CreatedByGuid = createdBy.Guid,

--- a/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/EventHelpers/CreateResponsibleEventHelper.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/EventHelpers/CreateResponsibleEventHelper.cs
@@ -20,6 +20,7 @@ public class CreateResponsibleEventHelper : ICreateEventHelper<Responsible, Resp
         {
             ProCoSysGuid = entity.Guid,
             Plant = entity.Plant,
+            Code = entity.Code,
             IsVoided = entity.IsVoided,
             CreatedAtUtc = entity.CreatedAtUtc,
             CreatedByGuid = createdBy.Guid,

--- a/src/Equinor.ProCoSys.Preservation.Command/Events/ResponsibleEvent.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/Events/ResponsibleEvent.cs
@@ -14,8 +14,6 @@ public class ResponsibleEvent : IResponsibleEventV1
     [JsonIgnore] //ProjectName isnt needed for Responsible but is required for IIntegrationEvent
     public string ProjectName { get; init; } = null;
     
-    public string Code { get; init; }
-    public string Description { get; init; }
     public bool IsVoided { get; init; }
     
     public DateTime CreatedAtUtc { get; init; }

--- a/src/Equinor.ProCoSys.Preservation.Command/Events/ResponsibleEvent.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/Events/ResponsibleEvent.cs
@@ -14,6 +14,7 @@ public class ResponsibleEvent : IResponsibleEventV1
     [JsonIgnore] //ProjectName isnt needed for Responsible but is required for IIntegrationEvent
     public string ProjectName { get; init; } = null;
     
+    public string Code { get; init; }
     public bool IsVoided { get; init; }
     
     public DateTime CreatedAtUtc { get; init; }

--- a/src/Equinor.ProCoSys.Preservation.Command/Events/TagEvent.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/Events/TagEvent.cs
@@ -13,23 +13,14 @@ public class TagEvent : ITagEventV1
 
     public Guid StepGuid { get; init; }
 
-    public string Description { get; init; }
     public string Remark { get; init; }
     public DateTime? NextDueTimeUtc { get; init; }
-    public string DisciplineCode { get; init; }
-    public string AreaCode { get; init; }
-    public string TagFunctionCode { get; init; }
-    public string PurchaseOrderNo { get; init; }
     public string TagType { get; init; }
     public string StorageArea { get; init; }
-    public string AreaDescription { get; init; }
-    public string DisciplineDescription { get; init; }
     public string Status { get; init; }
     public Guid? CommPkgGuid { get; init; }
     public Guid? McPkgGuid { get; init; }
     public bool IsVoided { get; init; }
-    public bool IsVoidedInSource { get; init; }
-    public bool IsDeletedInSource { get; init; }
 
     public DateTime CreatedAtUtc { get; init; }
     public Guid CreatedByGuid { get; init; }

--- a/src/Equinor.ProCoSys.Preservation.MessageContracts/IResponsibleEventV1.cs
+++ b/src/Equinor.ProCoSys.Preservation.MessageContracts/IResponsibleEventV1.cs
@@ -2,8 +2,6 @@
 
 public interface IResponsibleEventV1 : IIntegrationEvent
 {
-    string Code { get; }
-    string Description { get; }
     bool IsVoided { get; }
 
     DateTime CreatedAtUtc { get; }

--- a/src/Equinor.ProCoSys.Preservation.MessageContracts/IResponsibleEventV1.cs
+++ b/src/Equinor.ProCoSys.Preservation.MessageContracts/IResponsibleEventV1.cs
@@ -2,6 +2,7 @@
 
 public interface IResponsibleEventV1 : IIntegrationEvent
 {
+    string Code { get; init; }
     bool IsVoided { get; }
 
     DateTime CreatedAtUtc { get; }

--- a/src/Equinor.ProCoSys.Preservation.MessageContracts/ITagEventV1.cs
+++ b/src/Equinor.ProCoSys.Preservation.MessageContracts/ITagEventV1.cs
@@ -2,20 +2,13 @@
 
 public interface ITagEventV1 : IIntegrationEvent
 {
-    string Description { get; }
     string Remark { get; }
     DateTime? NextDueTimeUtc { get; }
 
     Guid StepGuid { get; }
 
-    string DisciplineCode { get; }
-    string AreaCode { get; }
-    string TagFunctionCode { get; }
-    string PurchaseOrderNo { get; }
     string TagType { get; }
     string StorageArea { get; }
-    string AreaDescription { get; }
-    string DisciplineDescription { get; }
 
     DateTime CreatedAtUtc { get; }
     Guid CreatedByGuid { get; }
@@ -29,6 +22,4 @@ public interface ITagEventV1 : IIntegrationEvent
     Guid? McPkgGuid { get; }
 
     bool IsVoided { get; }
-    bool IsVoidedInSource { get; }
-    bool IsDeletedInSource { get; }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/EventHandlers/IntegrationEvents/CreateProjectTagEventHelperTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/EventHandlers/IntegrationEvents/CreateProjectTagEventHelperTests.cs
@@ -82,19 +82,11 @@ public class CreateProjectTagEventHelperTests
     [DataTestMethod]
     [DataRow(nameof(TagEvent.Plant), TestPlant)]
     [DataRow(nameof(TagEvent.ProjectName), TestProjectName)]
-    [DataRow(nameof(TagEvent.Description), "Test Description")]
     [DataRow(nameof(TagEvent.Remark), "Test Remark")]
-    [DataRow(nameof(TagEvent.DisciplineCode), "D")]
-    [DataRow(nameof(TagEvent.AreaCode), "A")]
-    [DataRow(nameof(TagEvent.TagFunctionCode), "Test Function Code")]
-    [DataRow(nameof(TagEvent.PurchaseOrderNo), "Test Purchase Order")]
     [DataRow(nameof(TagEvent.TagType), "Standard")]
     [DataRow(nameof(TagEvent.StorageArea), "Test Storage Area")]
-    [DataRow(nameof(TagEvent.AreaDescription), "A desc")]
-    [DataRow(nameof(TagEvent.DisciplineDescription), "D desc")]
     [DataRow(nameof(TagEvent.Status), "NotStarted")]
     [DataRow(nameof(TagEvent.IsVoided), false)]
-    [DataRow(nameof(TagEvent.IsVoidedInSource), false)]
     public async Task CreateEvent_ShouldCreateTagEventExpectedValues(string property, object expected)
     {
         // Act

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/EventHandlers/IntegrationEvents/CreateResponsibleEventHelperTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/EventHandlers/IntegrationEvents/CreateResponsibleEventHelperTests.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.Common.Misc;
+using Equinor.ProCoSys.Common.Time;
+using Equinor.ProCoSys.Preservation.Command.EventHandlers.IntegrationEvents.EventHelpers;
+using Equinor.ProCoSys.Preservation.Command.Events;
+using Equinor.ProCoSys.Preservation.Domain.AggregateModels.JourneyAggregate;
+using Equinor.ProCoSys.Preservation.Domain.AggregateModels.ModeAggregate;
+using Equinor.ProCoSys.Preservation.Domain.AggregateModels.PersonAggregate;
+using Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate;
+using Equinor.ProCoSys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
+using Equinor.ProCoSys.Preservation.Domain.AggregateModels.ResponsibleAggregate;
+using Equinor.ProCoSys.Preservation.Test.Common;
+using Equinor.ProCoSys.Preservation.Test.Common.ExtensionMethods;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Action = Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate.Action;
+
+namespace Equinor.ProCoSys.Preservation.Command.Tests.EventHandlers.IntegrationEvents;
+
+[TestClass]
+public class CreateResponsibleEventHelperTests
+{
+    private const string TestPlant = "PCS$PlantA";
+    private static DateTime TestTime => DateTime.Parse("2012-12-12T11:22:33Z").ToUniversalTime();
+    private static Guid TestGuid => new("11111111-1111-1111-1111-111111111111");
+
+    private Responsible _responsible;
+    private Person _person;
+    private CreateResponsibleEventHelper _dut;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        // Arrange
+        var timeProvider = new ManualTimeProvider(TestTime);
+        TimeService.SetProvider(timeProvider);
+        
+        _responsible = new Responsible(TestPlant, "Test Code", "Test description");
+        
+        _person = new Person(TestGuid, "Test", "Person");
+
+        var personRepositoryMock = new Mock<IPersonRepository>();
+        personRepositoryMock.Setup(x => x.GetReadOnlyByIdAsync(It.IsAny<int>())).ReturnsAsync(_person);
+        
+        _dut = new CreateResponsibleEventHelper(personRepositoryMock.Object);
+    }
+
+    [DataTestMethod]
+    [DataRow(nameof(ResponsibleEvent.Plant), TestPlant)]
+    [DataRow(nameof(ResponsibleEvent.IsVoided), false)]
+    public async Task CreateEvent_ShouldCreateResponsibleEventWithExpectedValues(string property, object expected)
+    {
+        // Act
+        var integrationEvent = await _dut.CreateEvent(_responsible);
+        var result = integrationEvent.GetType()
+            .GetProperties()
+            .Single(p => p.Name == property)
+            .GetValue(integrationEvent);
+
+        // Assert
+        Assert.AreEqual(result, expected);
+    }
+    
+    [TestMethod]
+    public async Task CreateEvent_ShouldCreateActionEventExpectedProCoSysGuidValue()
+    {
+        // Arrange
+        var expected = _responsible.Guid;
+        
+        // Act
+        var integrationEvent = await _dut.CreateEvent(_responsible);
+        var result = integrationEvent.ProCoSysGuid;
+
+        // Assert
+        Assert.AreEqual(expected, result);
+    }
+    
+    [TestMethod]
+    public async Task CreateEvent_ShouldCreateActionEventExpectedCreatedByGuidValue()
+    {
+        // Arrange
+        _responsible.SetCreated(_person);
+        
+        // Act
+        var integrationEvent = await _dut.CreateEvent(_responsible);
+        var result = integrationEvent.CreatedByGuid;
+
+        // Assert
+        Assert.AreEqual(TestGuid, result);
+    }
+
+    [TestMethod]
+    public async Task CreateEvent_ShouldCreateActionEventWithExpectedCreatedAtUtcValue()
+    {
+        // Arrange
+        _responsible.SetCreated(_person);
+
+        // Act
+        var integrationEvent = await _dut.CreateEvent(_responsible);
+
+        // Assert
+        Assert.AreEqual(TestTime, integrationEvent.CreatedAtUtc);
+    }
+    
+    [TestMethod]
+    public async Task CreateEvent_ShouldCreateActionEventWithModifiedByGuid()
+    {
+        // Arrange
+        _responsible.SetModified(_person);
+        
+        // Act
+        var integrationEvent = await _dut.CreateEvent(_responsible);
+        var result = integrationEvent.ModifiedByGuid;
+
+        // Assert
+        Assert.AreEqual(TestGuid, result);
+    }
+
+    [TestMethod]
+    public async Task CreateEvent_ShouldCreateActionEventWithExpectedModifiedAtUtcValue()
+    {
+        // Arrange
+        _responsible.SetModified(_person);
+
+        // Act
+        var integrationEvent = await _dut.CreateEvent(_responsible);
+
+        // Assert
+        Assert.AreEqual(TestTime, integrationEvent.ModifiedAtUtc);
+    }
+}


### PR DESCRIPTION
Data is received by Preservation over service bus and is used internally. Some of that data was included in integration events that are sent to Alpha. Since Preservation is not the source/owner of that information, that data should not be included in the events. 