### PR TITLE
696 active tag add requirement fix

### DIFF
--- a/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/HistoryEvents/ActionAddedEventHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/HistoryEvents/ActionAddedEventHandler.cs
@@ -8,13 +8,13 @@ using Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate;
 
 namespace Equinor.ProCoSys.Preservation.Command.EventHandlers.HistoryEvents
 {
-    public class ActionAddedEventHandler : INotificationHandler<EntityAddedChildEntityEvent<Tag, Action>>
+    public class ActionAddedEventHandler : INotificationHandler<ChildEntityAddedEvent<Tag, Action>>
     {
         private readonly IHistoryRepository _historyRepository;
 
         public ActionAddedEventHandler(IHistoryRepository historyRepository) => _historyRepository = historyRepository;
 
-        public Task Handle(EntityAddedChildEntityEvent<Tag, Action> notification, CancellationToken cancellationToken)
+        public Task Handle(ChildEntityAddedEvent<Tag, Action> notification, CancellationToken cancellationToken)
         {
             var eventType = EventType.ActionAdded;
             var description = $"{eventType.GetDescription()} - '{notification.ChildEntity.Title}'";

--- a/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/ChildEntityAddedEventHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/ChildEntityAddedEventHandler.cs
@@ -3,8 +3,6 @@ using System.Threading.Tasks;
 using Equinor.ProCoSys.Common;
 using Equinor.ProCoSys.Preservation.Command.EventHandlers.IntegrationEvents.EventHelpers;
 using Equinor.ProCoSys.Preservation.Command.EventPublishers;
-using Equinor.ProCoSys.Preservation.Command.Events;
-using Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Equinor.ProCoSys.Preservation.Domain.Audit;
 using Equinor.ProCoSys.Preservation.Domain.Events;
 using Equinor.ProCoSys.Preservation.MessageContracts;
@@ -12,7 +10,7 @@ using MediatR;
 
 namespace Equinor.ProCoSys.Preservation.Command.EventHandlers.IntegrationEvents;
 
-public class EntityAddedChildEntityEventHandler<TParent, TChild, TEvent>  : INotificationHandler<ChildEntityAddedEvent<TParent, TChild>>
+public class ChildEntityAddedEventHandler<TParent, TChild, TEvent>  : INotificationHandler<ChildEntityAddedEvent<TParent, TChild>>
     where TParent : PlantEntityBase, ICreationAuditable, IModificationAuditable, IHaveGuid
     where TChild : PlantEntityBase, ICreationAuditable, IModificationAuditable, IHaveGuid
     where TEvent : class, IIntegrationEvent
@@ -20,7 +18,7 @@ public class EntityAddedChildEntityEventHandler<TParent, TChild, TEvent>  : INot
     private readonly ICreateChildEventHelper<TParent, TChild, TEvent> _createTagEventHelper;
     private readonly IIntegrationEventPublisher _integrationEventPublisher;
 
-    public EntityAddedChildEntityEventHandler(
+    public ChildEntityAddedEventHandler(
         ICreateChildEventHelper<TParent, TChild, TEvent> createTagEventHelper,
         IIntegrationEventPublisher integrationEventPublisher)
     {

--- a/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/Converters/ProjectTagAddedEventConverter.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/Converters/ProjectTagAddedEventConverter.cs
@@ -9,7 +9,7 @@ using Equinor.ProCoSys.Preservation.MessageContracts;
 
 namespace Equinor.ProCoSys.Preservation.Command.EventHandlers.IntegrationEvents.Converters;
 
-public class ProjectTagAddedEventConverter : IDomainToIntegrationEventConverter<EntityAddedChildEntityEvent<Project, Tag>>
+public class ProjectTagAddedEventConverter : IDomainToIntegrationEventConverter<ChildEntityAddedEvent<Project, Tag>>
 {
     private readonly ICreateChildEventHelper<Project, Tag, TagEvent> _createTagEventHelper;
     private readonly ICreateChildEventHelper<Project, TagRequirement, TagRequirementEvent> _createTagRequirementEventHelper;
@@ -22,7 +22,7 @@ public class ProjectTagAddedEventConverter : IDomainToIntegrationEventConverter<
         _createTagRequirementEventHelper = createTagRequirementEventHelper;
     }
 
-    public async Task<IEnumerable<IIntegrationEvent>> Convert(EntityAddedChildEntityEvent<Project, Tag> domainAddedEvent)
+    public async Task<IEnumerable<IIntegrationEvent>> Convert(ChildEntityAddedEvent<Project, Tag> domainAddedEvent)
     {
         var tagRequirementsEvents = await CreateTagRequirementEvents(domainAddedEvent);
         
@@ -31,7 +31,7 @@ public class ProjectTagAddedEventConverter : IDomainToIntegrationEventConverter<
         return tagRequirementsEvents.Append(tagEvent);
     }
 
-    private async Task<IEnumerable<IIntegrationEvent>> CreateTagRequirementEvents(EntityAddedChildEntityEvent<Project, Tag> domainAddedEvent)
+    private async Task<IEnumerable<IIntegrationEvent>> CreateTagRequirementEvents(ChildEntityAddedEvent<Project, Tag> domainAddedEvent)
     {
         var events = new List<IIntegrationEvent>();
 
@@ -45,5 +45,5 @@ public class ProjectTagAddedEventConverter : IDomainToIntegrationEventConverter<
         return events;
     }
     
-    private async Task<TagEvent> CreateTagEvent(EntityAddedChildEntityEvent<Project, Tag> domainAddedEvent) => await _createTagEventHelper.CreateEvent(domainAddedEvent.Entity, domainAddedEvent.ChildEntity);
+    private async Task<TagEvent> CreateTagEvent(ChildEntityAddedEvent<Project, Tag> domainAddedEvent) => await _createTagEventHelper.CreateEvent(domainAddedEvent.Entity, domainAddedEvent.ChildEntity);
 }

--- a/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/EntityAddedChildEntityEventHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/EntityAddedChildEntityEventHandler.cs
@@ -12,7 +12,7 @@ using MediatR;
 
 namespace Equinor.ProCoSys.Preservation.Command.EventHandlers.IntegrationEvents;
 
-public class EntityAddedChildEntityEventHandler<TParent, TChild, TEvent>  : INotificationHandler<EntityAddedChildEntityEvent<TParent, TChild>>
+public class EntityAddedChildEntityEventHandler<TParent, TChild, TEvent>  : INotificationHandler<ChildEntityAddedEvent<TParent, TChild>>
     where TParent : PlantEntityBase, ICreationAuditable, IModificationAuditable, IHaveGuid
     where TChild : PlantEntityBase, ICreationAuditable, IModificationAuditable, IHaveGuid
     where TEvent : class, IIntegrationEvent
@@ -28,7 +28,7 @@ public class EntityAddedChildEntityEventHandler<TParent, TChild, TEvent>  : INot
         _integrationEventPublisher = integrationEventPublisher;
     }
 
-    public async Task Handle(EntityAddedChildEntityEvent<TParent, TChild> notification, CancellationToken cancellationToken)
+    public async Task Handle(ChildEntityAddedEvent<TParent, TChild> notification, CancellationToken cancellationToken)
     {
         var integrationEvent = await _createTagEventHelper.CreateEvent(notification.Entity, notification.ChildEntity);
         await _integrationEventPublisher.PublishAsync(integrationEvent, cancellationToken);

--- a/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/EventHelpers/CreateRequirementDefinitionEventHelper.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/EventHelpers/CreateRequirementDefinitionEventHelper.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading.Tasks;
 using Equinor.ProCoSys.Preservation.Command.Events;
-using Equinor.ProCoSys.Preservation.Domain.AggregateModels.PersonAggregate;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
 
 namespace Equinor.ProCoSys.Preservation.Command.EventHandlers.IntegrationEvents.EventHelpers;

--- a/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/EventHelpers/CreateTagEventHelper.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/EventHelpers/CreateTagEventHelper.cs
@@ -1,7 +1,5 @@
 ﻿using System.Threading.Tasks;
 using Equinor.ProCoSys.Preservation.Command.Events;
-using Equinor.ProCoSys.Preservation.Domain.AggregateModels.JourneyAggregate;
-using Equinor.ProCoSys.Preservation.Domain.AggregateModels.PersonAggregate;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate;
 
 namespace Equinor.ProCoSys.Preservation.Command.EventHandlers.IntegrationEvents.EventHelpers;

--- a/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/EventHelpers/CreateTagRequirementEventHelper.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/EventHelpers/CreateTagRequirementEventHelper.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Equinor.ProCoSys.Preservation.Command.Events;
-using Equinor.ProCoSys.Preservation.Domain.AggregateModels.PersonAggregate;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate;
-using Equinor.ProCoSys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
 
 namespace Equinor.ProCoSys.Preservation.Command.EventHandlers.IntegrationEvents.EventHelpers;
 

--- a/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/EventHelpers/CreateTagRequirementPreservationPeriodEventHelper.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/EventHelpers/CreateTagRequirementPreservationPeriodEventHelper.cs
@@ -1,0 +1,41 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.Preservation.Command.Events;
+using Equinor.ProCoSys.Preservation.Domain.AggregateModels.PersonAggregate;
+using Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate;
+
+namespace Equinor.ProCoSys.Preservation.Command.EventHandlers.IntegrationEvents.EventHelpers;
+
+public class CreateTagRequirementPreservationPeriodEventHelper : ICreateChildEventHelper<TagRequirement, PreservationPeriod, PreservationPeriodsEvent>
+{
+    private readonly IPersonRepository _personRepository;
+
+    public CreateTagRequirementPreservationPeriodEventHelper(IPersonRepository personRepository) => _personRepository = personRepository;
+
+    public async Task<PreservationPeriodsEvent> CreateEvent(TagRequirement parentEntity, PreservationPeriod entity)
+    {
+        var preservationRecord = entity.PreservationRecord;
+
+        var createdBy = await _personRepository.GetReadOnlyByIdAsync(entity.CreatedById);
+        var modifiedBy = entity.ModifiedById.HasValue ? await _personRepository.GetReadOnlyByIdAsync(entity.ModifiedById.Value) : null;
+        var preservedBy = entity.PreservationRecord != null ? await _personRepository.GetReadOnlyByIdAsync(entity.PreservationRecord.PreservedById) : null;
+
+        // TODO test
+        return new PreservationPeriodsEvent
+        {
+            Status = entity.Status.ToString(),
+            DueTimeUtc = entity.DueTimeUtc,
+            Comment = entity.Comment,
+            CreatedAtUtc = entity.CreatedAtUtc,
+            CreatedByGuid = createdBy.Guid,
+            ModifiedAtUtc = entity.ModifiedAtUtc,
+            ModifiedByGuid = modifiedBy?.Guid,
+            TagRequirementGuid = parentEntity.Guid,
+            ProCoSysGuid = entity.Guid,
+            Plant = entity.Plant,
+            PreservedAtUtc = preservationRecord?.PreservedAtUtc,
+            PreservedByGuid = preservedBy?.Guid,
+            BulkPreserved = preservationRecord?.BulkPreserved
+        };
+    }
+}

--- a/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/EventHelpers/CreateTagRequirementPreservationPeriodEventHelper.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/EventHelpers/CreateTagRequirementPreservationPeriodEventHelper.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Equinor.ProCoSys.Preservation.Command.Events;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.PersonAggregate;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate;
@@ -20,7 +19,6 @@ public class CreateTagRequirementPreservationPeriodEventHelper : ICreateChildEve
         var modifiedBy = entity.ModifiedById.HasValue ? await _personRepository.GetReadOnlyByIdAsync(entity.ModifiedById.Value) : null;
         var preservedBy = entity.PreservationRecord != null ? await _personRepository.GetReadOnlyByIdAsync(entity.PreservationRecord.PreservedById) : null;
 
-        // TODO test
         return new PreservationPeriodsEvent
         {
             Status = entity.Status.ToString(),

--- a/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/EventHelpers/PublishDeleteEntityEventHelper.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/EventHelpers/PublishDeleteEntityEventHelper.cs
@@ -4,7 +4,6 @@ using Equinor.ProCoSys.Common;
 using Equinor.ProCoSys.Preservation.Command.EventPublishers;
 using Equinor.ProCoSys.Preservation.Command.Events;
 using Equinor.ProCoSys.Preservation.Domain.Audit;
-using Equinor.ProCoSys.Preservation.MessageContracts;
 
 namespace Equinor.ProCoSys.Preservation.Command.EventHandlers.IntegrationEvents.EventHelpers;
 

--- a/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/ProjectTagAddedEventHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/ProjectTagAddedEventHandler.cs
@@ -8,18 +8,18 @@ using MediatR;
 
 namespace Equinor.ProCoSys.Preservation.Command.EventHandlers.IntegrationEvents;
 
-public class ProjectTagAddedEventHandler : INotificationHandler<EntityAddedChildEntityEvent<Project, Tag>>
+public class ProjectTagAddedEventHandler : INotificationHandler<ChildEntityAddedEvent<Project, Tag>>
 {
-    private readonly IDomainToIntegrationEventConverter<EntityAddedChildEntityEvent<Project, Tag>> _converter;
+    private readonly IDomainToIntegrationEventConverter<ChildEntityAddedEvent<Project, Tag>> _converter;
     private readonly IIntegrationEventPublisher _integrationEventPublisher;
 
-    public ProjectTagAddedEventHandler(IDomainToIntegrationEventConverter<EntityAddedChildEntityEvent<Project, Tag>> converter, IIntegrationEventPublisher integrationEventPublisher)
+    public ProjectTagAddedEventHandler(IDomainToIntegrationEventConverter<ChildEntityAddedEvent<Project, Tag>> converter, IIntegrationEventPublisher integrationEventPublisher)
     {
         _converter = converter;
         _integrationEventPublisher = integrationEventPublisher;
     }
 
-    public async Task Handle(EntityAddedChildEntityEvent<Project, Tag> notification, CancellationToken cancellationToken)
+    public async Task Handle(ChildEntityAddedEvent<Project, Tag> notification, CancellationToken cancellationToken)
     {
         var integrationEvents = await _converter.Convert(notification);
         foreach (var integrationEvent in integrationEvents)

--- a/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/ProjectAggregate/PreservationPeriod.cs
+++ b/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/ProjectAggregate/PreservationPeriod.cs
@@ -215,8 +215,6 @@ namespace Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate
                 throw new ArgumentNullException(nameof(createdBy));
             }
             CreatedById = createdBy.Id;
-
-            AddDomainEvent(new PlantEntityCreatedEvent<PreservationPeriod>(this));
         }
 
         public void SetModified(Person modifiedBy)

--- a/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/ProjectAggregate/Project.cs
+++ b/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/ProjectAggregate/Project.cs
@@ -59,7 +59,7 @@ namespace Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate
 
             _tags.Add(tag);
 
-            AddDomainEvent(new EntityAddedChildEntityEvent<Project, Tag>(this, tag));
+            AddDomainEvent(new ChildEntityAddedEvent<Project, Tag>(this, tag));
         }
 
         public void Close() => IsClosed = true;

--- a/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/ProjectAggregate/Tag.cs
+++ b/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/ProjectAggregate/Tag.cs
@@ -306,7 +306,7 @@ namespace Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate
 
             _actions.Add(action);
 
-            AddDomainEvent(new EntityAddedChildEntityEvent<Tag, Action>(this, action));
+            AddDomainEvent(new ChildEntityAddedEvent<Tag, Action>(this, action));
         }
 
         public Action CloseAction(int actionId, Person closedBy, DateTime closedAtUtc, string rowVersion)

--- a/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/ProjectAggregate/TagRequirement.cs
+++ b/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/ProjectAggregate/TagRequirement.cs
@@ -266,6 +266,8 @@ namespace Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate
             {
                 var preservationPeriod = new PreservationPeriod(Plant, IntervalWeeks, _initialPreservationPeriodStatus);
                 _preservationPeriods.Add(preservationPeriod);
+                
+                AddDomainEvent(new ChildEntityAddedEvent<TagRequirement, PreservationPeriod>(this, preservationPeriod));
             }
 
             NextDueTimeUtc = ActivePeriod.DueTimeUtc;

--- a/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/RequirementTypeAggregate/RequirementDefinition.cs
+++ b/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/RequirementTypeAggregate/RequirementDefinition.cs
@@ -61,7 +61,7 @@ namespace Equinor.ProCoSys.Preservation.Domain.AggregateModels.RequirementTypeAg
 
             _fields.Add(field);
             
-            AddDomainEvent(new EntityAddedChildEntityEvent<RequirementDefinition, Field>(this, field));
+            AddDomainEvent(new ChildEntityAddedEvent<RequirementDefinition, Field>(this, field));
         }
 
         public void RemoveField(Field field)

--- a/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/RequirementTypeAggregate/RequirementType.cs
+++ b/src/Equinor.ProCoSys.Preservation.Domain/AggregateModels/RequirementTypeAggregate/RequirementType.cs
@@ -60,7 +60,7 @@ namespace Equinor.ProCoSys.Preservation.Domain.AggregateModels.RequirementTypeAg
 
             _requirementDefinitions.Add(requirementDefinition);
             
-            AddDomainEvent(new EntityAddedChildEntityEvent<RequirementType, RequirementDefinition>(this, requirementDefinition));
+            AddDomainEvent(new ChildEntityAddedEvent<RequirementType, RequirementDefinition>(this, requirementDefinition));
         }
         
         public override string ToString() => Title;

--- a/src/Equinor.ProCoSys.Preservation.Domain/Events/ChildEntityAddedEvent.cs
+++ b/src/Equinor.ProCoSys.Preservation.Domain/Events/ChildEntityAddedEvent.cs
@@ -2,11 +2,11 @@
 
 namespace Equinor.ProCoSys.Preservation.Domain.Events;
 
-public class EntityAddedChildEntityEvent<TEntity, TChild> : IPlantEntityEvent<TEntity>, IDomainEvent 
+public class ChildEntityAddedEvent<TEntity, TChild> : IPlantEntityEvent<TEntity>, IDomainEvent 
     where TEntity : PlantEntityBase, IHaveGuid 
     where TChild : PlantEntityBase, IHaveGuid
 {
-    public EntityAddedChildEntityEvent(TEntity entity, TChild childEntity)
+    public ChildEntityAddedEvent(TEntity entity, TChild childEntity)
     {
         Entity = entity;
         ChildEntity = childEntity;

--- a/src/Equinor.ProCoSys.Preservation.WebApi/DiModules/ApplicationModule.cs
+++ b/src/Equinor.ProCoSys.Preservation.WebApi/DiModules/ApplicationModule.cs
@@ -119,7 +119,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.DIModules
             services.AddHttpClient();
 
             // Transient - Created each time it is requested from the service container
-            services.AddTransient<IDomainToIntegrationEventConverter<EntityAddedChildEntityEvent<Project, Tag>>, ProjectTagAddedEventConverter>();
+            services.AddTransient<IDomainToIntegrationEventConverter<ChildEntityAddedEvent<Project, Tag>>, ProjectTagAddedEventConverter>();
             
             services.AddTransient<INotificationHandler<PlantEntityModifiedEvent<Tag>>, IntegrationEventHandler<PlantEntityModifiedEvent<Tag>, Tag>>();
             services.AddTransient<INotificationHandler<PlantEntityDeletedEvent<Tag>>, IntegrationDeleteEventHandler<PlantEntityDeletedEvent<Tag>, Tag>>();
@@ -135,7 +135,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.DIModules
             services.AddTransient<ICreateEventHelper<TagRequirement, TagRequirementEvent>, CreateTagRequirementEventHelper>();
             services.AddTransient<ICreateChildEventHelper<Project, TagRequirement, TagRequirementEvent>, CreateProjectTagRequirementEventHelper>();
             
-            services.AddTransient<INotificationHandler<EntityAddedChildEntityEvent<RequirementType, RequirementDefinition>>, EntityAddedChildEntityEventHandler<RequirementType, RequirementDefinition, RequirementDefinitionEvent>>();
+            services.AddTransient<INotificationHandler<ChildEntityAddedEvent<RequirementType, RequirementDefinition>>, EntityAddedChildEntityEventHandler<RequirementType, RequirementDefinition, RequirementDefinitionEvent>>();
             services.AddTransient<INotificationHandler<PlantEntityModifiedEvent<RequirementDefinition>>, IntegrationEventHandler<PlantEntityModifiedEvent<RequirementDefinition>, RequirementDefinition>>();
             services.AddTransient<INotificationHandler<PlantEntityDeletedEvent<RequirementDefinition>>, IntegrationDeleteEventHandler<PlantEntityDeletedEvent<RequirementDefinition>, RequirementDefinition>>();
             services.AddTransient<IPublishEntityEventHelper<RequirementDefinition>, PublishEntityEventHelper<RequirementDefinition, RequirementDefinitionEvent>>();
@@ -144,13 +144,13 @@ namespace Equinor.ProCoSys.Preservation.WebApi.DIModules
             services.AddTransient<ICreateEventHelper<RequirementDefinition, RequirementDefinitionDeleteEvent>, CreateRequirementDefinitionDeletedEventHelper>();
             services.AddTransient<IPublishDeleteEntityEventHelper<RequirementDefinition>, PublishDeleteEntityEventHelper<RequirementDefinition, RequirementDefinitionDeleteEvent>>();
 
-            services.AddTransient<INotificationHandler<EntityAddedChildEntityEvent<Tag, Action>>, EntityAddedChildEntityEventHandler<Tag, Action, ActionEvent>>();
+            services.AddTransient<INotificationHandler<ChildEntityAddedEvent<Tag, Action>>, EntityAddedChildEntityEventHandler<Tag, Action, ActionEvent>>();
             services.AddTransient<INotificationHandler<PlantEntityModifiedEvent<Action>>, IntegrationEventHandler<PlantEntityModifiedEvent<Action>, Action>>();
             services.AddTransient<IPublishEntityEventHelper<Action>, PublishEntityEventHelper<Action, ActionEvent>>();
             services.AddTransient<ICreateEventHelper<Action, ActionEvent>, CreateActionEventHelper>();
             services.AddTransient<ICreateChildEventHelper<Tag, Action, ActionEvent>, CreateTagActionEventHelper>();
             
-            services.AddTransient<INotificationHandler<EntityAddedChildEntityEvent<RequirementDefinition, Field>>, EntityAddedChildEntityEventHandler<RequirementDefinition, Field, FieldEvent>>();
+            services.AddTransient<INotificationHandler<ChildEntityAddedEvent<RequirementDefinition, Field>>, EntityAddedChildEntityEventHandler<RequirementDefinition, Field, FieldEvent>>();
             services.AddTransient<INotificationHandler<PlantEntityModifiedEvent<Field>>, IntegrationEventHandler<PlantEntityModifiedEvent<Field>, Field>>();
             services.AddTransient<INotificationHandler<PlantEntityModifiedEvent<Field>>, IntegrationDeleteEventHandler<PlantEntityModifiedEvent<Field>, Field>>();
             services.AddTransient<IPublishEntityEventHelper<Field>, PublishEntityEventHelper<Field, FieldEvent>>();

--- a/src/Equinor.ProCoSys.Preservation.WebApi/DiModules/ApplicationModule.cs
+++ b/src/Equinor.ProCoSys.Preservation.WebApi/DiModules/ApplicationModule.cs
@@ -135,7 +135,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.DIModules
             services.AddTransient<ICreateEventHelper<TagRequirement, TagRequirementEvent>, CreateTagRequirementEventHelper>();
             services.AddTransient<ICreateChildEventHelper<Project, TagRequirement, TagRequirementEvent>, CreateProjectTagRequirementEventHelper>();
             
-            services.AddTransient<INotificationHandler<ChildEntityAddedEvent<RequirementType, RequirementDefinition>>, EntityAddedChildEntityEventHandler<RequirementType, RequirementDefinition, RequirementDefinitionEvent>>();
+            services.AddTransient<INotificationHandler<ChildEntityAddedEvent<RequirementType, RequirementDefinition>>, ChildEntityAddedEventHandler<RequirementType, RequirementDefinition, RequirementDefinitionEvent>>();
             services.AddTransient<INotificationHandler<PlantEntityModifiedEvent<RequirementDefinition>>, IntegrationEventHandler<PlantEntityModifiedEvent<RequirementDefinition>, RequirementDefinition>>();
             services.AddTransient<INotificationHandler<PlantEntityDeletedEvent<RequirementDefinition>>, IntegrationDeleteEventHandler<PlantEntityDeletedEvent<RequirementDefinition>, RequirementDefinition>>();
             services.AddTransient<IPublishEntityEventHelper<RequirementDefinition>, PublishEntityEventHelper<RequirementDefinition, RequirementDefinitionEvent>>();
@@ -144,13 +144,13 @@ namespace Equinor.ProCoSys.Preservation.WebApi.DIModules
             services.AddTransient<ICreateEventHelper<RequirementDefinition, RequirementDefinitionDeleteEvent>, CreateRequirementDefinitionDeletedEventHelper>();
             services.AddTransient<IPublishDeleteEntityEventHelper<RequirementDefinition>, PublishDeleteEntityEventHelper<RequirementDefinition, RequirementDefinitionDeleteEvent>>();
 
-            services.AddTransient<INotificationHandler<ChildEntityAddedEvent<Tag, Action>>, EntityAddedChildEntityEventHandler<Tag, Action, ActionEvent>>();
+            services.AddTransient<INotificationHandler<ChildEntityAddedEvent<Tag, Action>>, ChildEntityAddedEventHandler<Tag, Action, ActionEvent>>();
             services.AddTransient<INotificationHandler<PlantEntityModifiedEvent<Action>>, IntegrationEventHandler<PlantEntityModifiedEvent<Action>, Action>>();
             services.AddTransient<IPublishEntityEventHelper<Action>, PublishEntityEventHelper<Action, ActionEvent>>();
             services.AddTransient<ICreateEventHelper<Action, ActionEvent>, CreateActionEventHelper>();
             services.AddTransient<ICreateChildEventHelper<Tag, Action, ActionEvent>, CreateTagActionEventHelper>();
             
-            services.AddTransient<INotificationHandler<ChildEntityAddedEvent<RequirementDefinition, Field>>, EntityAddedChildEntityEventHandler<RequirementDefinition, Field, FieldEvent>>();
+            services.AddTransient<INotificationHandler<ChildEntityAddedEvent<RequirementDefinition, Field>>, ChildEntityAddedEventHandler<RequirementDefinition, Field, FieldEvent>>();
             services.AddTransient<INotificationHandler<PlantEntityModifiedEvent<Field>>, IntegrationEventHandler<PlantEntityModifiedEvent<Field>, Field>>();
             services.AddTransient<INotificationHandler<PlantEntityModifiedEvent<Field>>, IntegrationDeleteEventHandler<PlantEntityModifiedEvent<Field>, Field>>();
             services.AddTransient<IPublishEntityEventHelper<Field>, PublishEntityEventHelper<Field, FieldEvent>>();
@@ -175,9 +175,10 @@ namespace Equinor.ProCoSys.Preservation.WebApi.DIModules
             services.AddTransient<ICreateEventHelper<Mode, ModeEvent>, CreateModeEventHelper>();
             services.AddTransient<ICreateEventHelper<Mode, ModeDeleteEvent>, CreateModeDeletedEventHelper>();
             
-            services.AddTransient<INotificationHandler<PlantEntityCreatedEvent<PreservationPeriod>>, IntegrationEventHandler<PlantEntityCreatedEvent<PreservationPeriod>, PreservationPeriod>>();
+            services.AddTransient<INotificationHandler<ChildEntityAddedEvent<TagRequirement, PreservationPeriod>>, ChildEntityAddedEventHandler<TagRequirement, PreservationPeriod, PreservationPeriodsEvent>>();
             services.AddTransient<INotificationHandler<PlantEntityModifiedEvent<PreservationPeriod>>, IntegrationEventHandler<PlantEntityModifiedEvent<PreservationPeriod>, PreservationPeriod>>();
             services.AddTransient<IPublishEntityEventHelper<PreservationPeriod>, PublishEntityEventHelper<PreservationPeriod, PreservationPeriodsEvent>>();
+            services.AddTransient<ICreateChildEventHelper<TagRequirement, PreservationPeriod, PreservationPeriodsEvent>, CreateTagRequirementPreservationPeriodEventHelper>();
             services.AddTransient<ICreateEventHelper<PreservationPeriod, PreservationPeriodsEvent>, CreatePreservationPeriodEventHelper>();
             
             services.AddTransient<INotificationHandler<PlantEntityCreatedEvent<RequirementType>>, IntegrationEventHandler<PlantEntityCreatedEvent<RequirementType>, RequirementType>>();

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/EventHandlers/HistoryEvents/ActionAddedEventHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/EventHandlers/HistoryEvents/ActionAddedEventHandlerTests.cs
@@ -55,7 +55,7 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.EventHandlers.HistoryEvent
             var plant = "TestPlant";
             var title = "Action1";
 
-            _dut.Handle(new EntityAddedChildEntityEvent<Tag, Action>(_mockTag, new Action(plant, title, "", null)), default);
+            _dut.Handle(new ChildEntityAddedEvent<Tag, Action>(_mockTag, new Action(plant, title, "", null)), default);
 
             // Assert
             var expectedDescription = $"{EventType.ActionAdded.GetDescription()} - '{title}'";

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/EventHandlers/IntegrationEvents/ChildEntityAddedEventHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/EventHandlers/IntegrationEvents/ChildEntityAddedEventHandlerTests.cs
@@ -12,10 +12,10 @@ using Moq;
 namespace Equinor.ProCoSys.Preservation.Command.Tests.EventHandlers.IntegrationEvents;
 
 [TestClass]
-public class EntityAddedChildEntityEventHandlerTests
+public class ChildEntityAddedEventHandlerTests
 {
     private const string TestPlant = "PCS$PlantA";
-    private EntityAddedChildEntityEventHandler<RequirementDefinition, Field, FieldEvent> _dut;
+    private ChildEntityAddedEventHandler<RequirementDefinition, Field, FieldEvent> _dut;
     private bool _eventPublished;
     private RequirementDefinition _requirementDefinition;
     private Field _field;
@@ -33,7 +33,7 @@ public class EntityAddedChildEntityEventHandlerTests
 
         _eventPublished = false;
 
-        _dut = new EntityAddedChildEntityEventHandler<RequirementDefinition, Field, FieldEvent>(mockCreateEventHelper.Object, mockPublisher.Object);
+        _dut = new ChildEntityAddedEventHandler<RequirementDefinition, Field, FieldEvent>(mockCreateEventHelper.Object, mockPublisher.Object);
 
         _requirementDefinition = new RequirementDefinition(TestPlant, "D2", 2, RequirementUsage.ForSuppliersOnly, 1);
         _field = new Field(TestPlant, "F1", FieldType.Number, 1, "UnitA", true);

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/EventHandlers/IntegrationEvents/CreateTagRequirementPreservationPeriodEventHelperTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/EventHandlers/IntegrationEvents/CreateTagRequirementPreservationPeriodEventHelperTests.cs
@@ -1,0 +1,202 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.Common.Misc;
+using Equinor.ProCoSys.Common.Time;
+using Equinor.ProCoSys.Preservation.Command.EventHandlers.IntegrationEvents.EventHelpers;
+using Equinor.ProCoSys.Preservation.Command.Events;
+using Equinor.ProCoSys.Preservation.Domain.AggregateModels.PersonAggregate;
+using Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate;
+using Equinor.ProCoSys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
+using Equinor.ProCoSys.Preservation.Test.Common;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Equinor.ProCoSys.Preservation.Command.Tests.EventHandlers.IntegrationEvents;
+
+[TestClass]
+public class CreateTagRequirementPreservationPeriodEventHelperTests
+{
+    private const string TestPlant = "PCS$PlantA";
+    private static DateTime TestTime => DateTime.Parse("2012-12-12T11:22:33Z").ToUniversalTime();
+    private static Guid TestGuid => new("11111111-1111-1111-1111-111111111111");
+    private const int Interval = 2;
+
+    private TagRequirement _tagRequirement;
+    private PreservationPeriod _preservationPeriod;
+    private Person _person;
+    private CreateTagRequirementPreservationPeriodEventHelper _dut;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        // Arrange
+        var timeProvider = new ManualTimeProvider(TestTime);
+        TimeService.SetProvider(timeProvider);
+
+        var requirementDefinition = new RequirementDefinition(TestPlant, "D2", 2, RequirementUsage.ForSuppliersOnly, 1);
+        _tagRequirement = new TagRequirement(TestPlant, Interval, requirementDefinition);
+        _tagRequirement.StartPreservation();
+        
+        _preservationPeriod = _tagRequirement.PreservationPeriods.First();
+        
+        _person = new Person(TestGuid, "Test", "Person");
+
+        var personRepositoryMock = new Mock<IPersonRepository>();
+        personRepositoryMock.Setup(x => x.GetReadOnlyByIdAsync(It.IsAny<int>())).ReturnsAsync(_person);
+        
+        _dut = new CreateTagRequirementPreservationPeriodEventHelper(personRepositoryMock.Object);
+    }
+
+    [DataTestMethod]
+    [DataRow(nameof(PreservationPeriodsEvent.Status), nameof(PreservationPeriodStatus.ReadyToBePreserved))]
+    [DataRow(nameof(PreservationPeriodsEvent.Comment), null)]
+    [DataRow(nameof(PreservationPeriodsEvent.Plant), TestPlant)]
+    [DataRow(nameof(PreservationPeriodsEvent.PreservedAtUtc), null)]
+    [DataRow(nameof(PreservationPeriodsEvent.PreservedByGuid), null)]
+    [DataRow(nameof(PreservationPeriodsEvent.BulkPreserved), null)]
+    public async Task CreateEvent_ShouldCreatePreservationPeriodsEventExpectedValues(string property, object expected)
+    {
+        // Act
+        var integrationEvent = await _dut.CreateEvent(_tagRequirement, _preservationPeriod);
+        var result = integrationEvent.GetType()
+            .GetProperties()
+            .Single(p => p.Name == property)
+            .GetValue(integrationEvent);
+
+        // Assert
+        Assert.AreEqual(expected, result);
+    }
+    
+    [TestMethod]
+    public async Task CreateEvent_ShouldCreatePreservationPeriodsEventExpectedProCoSysGuidValue()
+    {
+        // Arrange
+        var expected = _preservationPeriod.Guid;
+        
+        // Act
+        var integrationEvent = await _dut.CreateEvent(_tagRequirement, _preservationPeriod);
+        var result = integrationEvent.ProCoSysGuid;
+
+        // Assert
+        Assert.AreEqual(expected, result);
+    }
+    
+    [TestMethod]
+    public async Task CreateEvent_ShouldCreatePreservationPeriodsEventExpectedCreatedByGuidValue()
+    {
+        // Act
+        var integrationEvent = await _dut.CreateEvent(_tagRequirement, _preservationPeriod);
+        var result = integrationEvent.CreatedByGuid;
+
+        // Assert
+        Assert.AreEqual(TestGuid, result);
+    }
+    
+    [TestMethod]
+    public async Task CreateEvent_ShouldCreatePreservationPeriodsEventExpectedTagRequirementGuidValue()
+    {
+        // Arrange
+        var expected = _tagRequirement.Guid;
+        
+        // Act
+        var integrationEvent = await _dut.CreateEvent(_tagRequirement, _preservationPeriod);
+        var result = integrationEvent.TagRequirementGuid;
+
+        // Assert
+        Assert.AreEqual(expected, result);
+    }
+
+    [TestMethod]
+    public async Task CreateEvent_ShouldCreatePreservationPeriodsEventWithExpectedDueTimeUtcValue()
+    {
+        // Arrange
+        var expected = TestTime.AddWeeks(Interval);
+
+        // Act
+        var integrationEvent = await _dut.CreateEvent(_tagRequirement, _preservationPeriod);
+
+        // Assert
+        Assert.AreEqual(expected, integrationEvent.DueTimeUtc);
+    }
+    
+    [TestMethod]
+    public async Task CreateEvent_ShouldCreatePreservationPeriodsEventWithExpectedCreatedAtUtcValue()
+    {
+        // Arrange
+        _preservationPeriod.SetCreated(_person);
+
+        // Act
+        var integrationEvent = await _dut.CreateEvent(_tagRequirement, _preservationPeriod);
+
+        // Assert
+        Assert.AreEqual(TestTime, integrationEvent.CreatedAtUtc);
+    }
+    
+    [TestMethod]
+    public async Task CreateEvent_ShouldCreatePreservationPeriodsEventWithModifiedByGuid()
+    {
+        // Arrange
+        _preservationPeriod.SetModified(_person);
+        
+        // Act
+        var integrationEvent = await _dut.CreateEvent(_tagRequirement, _preservationPeriod);
+        var result = integrationEvent.ModifiedByGuid;
+
+        // Assert
+        Assert.AreEqual(TestGuid, result);
+    }
+
+    [TestMethod]
+    public async Task CreateEvent_ShouldCreatePreservationPeriodsEventWithExpectedModifiedAtUtcValue()
+    {
+        // Arrange
+        _preservationPeriod.SetModified(_person);
+
+        // Act
+        var integrationEvent = await _dut.CreateEvent(_tagRequirement, _preservationPeriod);
+
+        // Assert
+        Assert.AreEqual(TestTime, integrationEvent.ModifiedAtUtc);
+    }
+    
+    [TestMethod]
+    public async Task CreateEvent_ShouldCreatePreservationPeriodsEventWithPreservedByGuid()
+    {
+        // Arrange
+        _preservationPeriod.Preserve(_person, false);
+        
+        // Act
+        var integrationEvent = await _dut.CreateEvent(_tagRequirement, _preservationPeriod);
+        var result = integrationEvent.PreservedByGuid;
+
+        // Assert
+        Assert.AreEqual(TestGuid, result);
+    }
+    
+    [TestMethod]
+    public async Task CreateEvent_ShouldCreatePreservationPeriodsEventWithExpectedPreservedAtUtcValue()
+    {
+        // Arrange
+        _preservationPeriod.Preserve(_person, false);
+
+        // Act
+        var integrationEvent = await _dut.CreateEvent(_tagRequirement, _preservationPeriod);
+
+        // Assert
+        Assert.AreEqual(TestTime, integrationEvent.PreservedAtUtc);
+    }
+    
+    [TestMethod]
+    public async Task CreateEvent_ShouldCreatePreservationPeriodsEventWithExpectedBulkPreservedValue()
+    {
+        // Arrange
+        _preservationPeriod.Preserve(_person, true);
+
+        // Act
+        var integrationEvent = await _dut.CreateEvent(_tagRequirement, _preservationPeriod);
+
+        // Assert
+        Assert.IsTrue(integrationEvent.BulkPreserved);
+    }
+}

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/EventHandlers/IntegrationEvents/EntityAddedChildEntityEventHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/EventHandlers/IntegrationEvents/EntityAddedChildEntityEventHandlerTests.cs
@@ -43,7 +43,7 @@ public class EntityAddedChildEntityEventHandlerTests
     public async Task Handle_ShouldSendIntegrationEvent()
     {
         // Arrange
-        var domainEvent = new EntityAddedChildEntityEvent<RequirementDefinition, Field>(_requirementDefinition, _field);
+        var domainEvent = new ChildEntityAddedEvent<RequirementDefinition, Field>(_requirementDefinition, _field);
 
         // Act
         await _dut.Handle(domainEvent, default);

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/EventHandlers/IntegrationEvents/ProjectTagAddedEventConverterTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/EventHandlers/IntegrationEvents/ProjectTagAddedEventConverterTests.cs
@@ -51,7 +51,7 @@ public class ProjectTagAddedEventConverterTests
     public async Task Convert_ShouldConvertToIntegrationEventsWithTagEvent()
     {
         // Arrange
-        var domainEvent = new EntityAddedChildEntityEvent<Project, Tag>(_project, _tag);
+        var domainEvent = new ChildEntityAddedEvent<Project, Tag>(_project, _tag);
 
         // Act
         var integrationEvents = await _dut.Convert(domainEvent);
@@ -65,7 +65,7 @@ public class ProjectTagAddedEventConverterTests
     public async Task Convert_ShouldConvertToIntegrationEventsWithTagRequirementEvent()
     {
         // Arrange
-        var domainEvent = new EntityAddedChildEntityEvent<Project, Tag>(_project, _tag);
+        var domainEvent = new ChildEntityAddedEvent<Project, Tag>(_project, _tag);
 
         // Act
         var integrationEvents = await _dut.Convert(domainEvent);

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/EventHandlers/IntegrationEvents/ProjectTagAddedEventHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/EventHandlers/IntegrationEvents/ProjectTagAddedEventHandlerTests.cs
@@ -30,8 +30,8 @@ public class ProjectTagAddedEventHandlerTests
     {
         // Arrange
         var mockIntegrationEvent = new Mock<IIntegrationEvent>();
-        var mockConverter = new Mock<IDomainToIntegrationEventConverter<EntityAddedChildEntityEvent<Project, Tag>>>();
-        mockConverter.Setup(x => x.Convert(It.IsAny<EntityAddedChildEntityEvent<Project, Tag>>())).ReturnsAsync(new List<IIntegrationEvent> { mockIntegrationEvent.Object });
+        var mockConverter = new Mock<IDomainToIntegrationEventConverter<ChildEntityAddedEvent<Project, Tag>>>();
+        mockConverter.Setup(x => x.Convert(It.IsAny<ChildEntityAddedEvent<Project, Tag>>())).ReturnsAsync(new List<IIntegrationEvent> { mockIntegrationEvent.Object });
 
         var mockPublisher = new Mock<IIntegrationEventPublisher>();
         mockPublisher.Setup(x => x.PublishAsync(It.IsAny<IIntegrationEvent>(), default))
@@ -56,7 +56,7 @@ public class ProjectTagAddedEventHandlerTests
     public async Task Handle_ShouldSendIntegrationEvent()
     {
         // Arrange
-        var domainEvent = new EntityAddedChildEntityEvent<Project, Tag>(_project, _tag);
+        var domainEvent = new ChildEntityAddedEvent<Project, Tag>(_project, _tag);
 
         // Act
         await _dut.Handle(domainEvent, default);

--- a/src/tests/Equinor.ProCoSys.Preservation.Domain.Tests/AggregateModels/ProjectAggregate/PreservationPeriodTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Domain.Tests/AggregateModels/ProjectAggregate/PreservationPeriodTests.cs
@@ -263,21 +263,6 @@ namespace Equinor.ProCoSys.Preservation.Domain.Tests.AggregateModels.ProjectAggr
         }
         
         [TestMethod]
-        public void SetCreated_ShouldAddPlantEntityCreatedEvent()
-        {
-            // Arrange
-            var dut = new PreservationPeriod(TestPlant, 1, PreservationPeriodStatus.ReadyToBePreserved);
-            var person = new Person(Guid.Empty, "Espen", "Askeladd");
-            
-            // Act
-            dut.SetCreated(person);
-            var eventTypes = dut.DomainEvents.Select(e => e.GetType()).ToList();
-
-            // Assert
-            CollectionAssert.Contains(eventTypes, typeof(PlantEntityCreatedEvent<PreservationPeriod>));
-        }
-        
-        [TestMethod]
         public void SetModified_ShouldAddPlantEntityModifiedEvent()
         {
             // Arrange

--- a/src/tests/Equinor.ProCoSys.Preservation.Domain.Tests/AggregateModels/ProjectAggregate/ProjectTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Domain.Tests/AggregateModels/ProjectAggregate/ProjectTests.cs
@@ -174,7 +174,7 @@ namespace Equinor.ProCoSys.Preservation.Domain.Tests.AggregateModels.ProjectAggr
             var eventTypes = _dut.DomainEvents.Select(e => e.GetType()).ToList();
 
             // Assert
-            CollectionAssert.Contains(eventTypes, typeof(EntityAddedChildEntityEvent<Project, Tag>));
+            CollectionAssert.Contains(eventTypes, typeof(ChildEntityAddedEvent<Project, Tag>));
         }
     }
 }

--- a/src/tests/Equinor.ProCoSys.Preservation.Domain.Tests/AggregateModels/ProjectAggregate/TagRequirementTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Domain.Tests/AggregateModels/ProjectAggregate/TagRequirementTests.cs
@@ -290,6 +290,17 @@ namespace Equinor.ProCoSys.Preservation.Domain.Tests.AggregateModels.ProjectAggr
             Assert.AreEqual(expectedUpdatedNextDueTimeUtc, dut.PreservationPeriods.Single().DueTimeUtc);
             Assert.AreNotEqual(expectedUpdatedNextDueTimeUtc, expectedNextDueTimeUtc);
         }
+        
+        [TestMethod]
+        public void StartPreservation_InactiveTag_ShouldAddChildEntityAddedEvent()
+        {
+            var dut = new TagRequirement(TestPlant, TwoWeeksInterval, _reqDefWithCheckBoxFieldMock.Object);
+
+            dut.StartPreservation();
+
+            var eventTypes = dut.DomainEvents.Select(e => e.GetType()).ToList();
+            CollectionAssert.Contains(eventTypes, typeof(ChildEntityAddedEvent<TagRequirement, PreservationPeriod>));
+        }
 
         #endregion
 

--- a/src/tests/Equinor.ProCoSys.Preservation.Domain.Tests/AggregateModels/ProjectAggregate/TagTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Domain.Tests/AggregateModels/ProjectAggregate/TagTests.cs
@@ -1950,7 +1950,7 @@ namespace Equinor.ProCoSys.Preservation.Domain.Tests.AggregateModels.ProjectAggr
             _dutWithOneReqNotNeedInputTwoWeekInterval.AddAction(action);
             var eventTypes = _dutWithOneReqNotNeedInputTwoWeekInterval.DomainEvents.Select(e => e.GetType()).ToList();
 
-            CollectionAssert.Contains(eventTypes, typeof(EntityAddedChildEntityEvent<Tag, Action>));
+            CollectionAssert.Contains(eventTypes, typeof(ChildEntityAddedEvent<Tag, Action>));
         }
 
         #endregion

--- a/src/tests/Equinor.ProCoSys.Preservation.Domain.Tests/AggregateModels/RequirementTypeAggregate/RequirementDefinitionTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Domain.Tests/AggregateModels/RequirementTypeAggregate/RequirementDefinitionTests.cs
@@ -67,7 +67,7 @@ namespace Equinor.ProCoSys.Preservation.Domain.Tests.AggregateModels.Requirement
             _dut.AddField(f);
 
             var eventTypes = _dut.DomainEvents.Select(e => e.GetType()).ToList();
-            CollectionAssert.Contains(eventTypes, typeof(EntityAddedChildEntityEvent<RequirementDefinition, Field>));
+            CollectionAssert.Contains(eventTypes, typeof(ChildEntityAddedEvent<RequirementDefinition, Field>));
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.Preservation.Domain.Tests/AggregateModels/RequirementTypeAggregate/RequirementTypeTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Domain.Tests/AggregateModels/RequirementTypeAggregate/RequirementTypeTests.cs
@@ -63,7 +63,7 @@ namespace Equinor.ProCoSys.Preservation.Domain.Tests.AggregateModels.Requirement
             _dut.AddRequirementDefinition(rd);
 
             var eventTypes = _dut.DomainEvents.Select(e => e.GetType()).ToList();
-            CollectionAssert.Contains(eventTypes, typeof(EntityAddedChildEntityEvent<RequirementType, RequirementDefinition>));
+            CollectionAssert.Contains(eventTypes, typeof(ChildEntityAddedEvent<RequirementType, RequirementDefinition>));
         }
 
         [TestMethod]


### PR DESCRIPTION
Adding a requirement to a active tag was causing an exception. The requirement would be added, and a preservation period would also be added for the tag requirement. 
This resulted in an event being created for the preservation period entity creation. When the creation event was being handled the logic retrieved the parent tag requirement. Since the tag requirement had not been stored yet, this resulted in an exception.

Fixed by refactoring the logic to send a child added event from the tag requirement, that includes information about the parent tag requirement and the child preservation period. This circumvents the need to retrieve the parent when handling the event.

Covering this use case by added an integration test for adding tag requirements to a active tag.

https://github.com/equinor/cc-toolbox/issues/696