### PR TITLE
792 pipeline fix

### DIFF
--- a/src/Equinor.ProCoSys.Preservation.Command/Equinor.ProCoSys.Preservation.Command.csproj
+++ b/src/Equinor.ProCoSys.Preservation.Command/Equinor.ProCoSys.Preservation.Command.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,9 +15,9 @@
     <PackageReference Include="Equinor.ProCoSys.BlobStorage" Version="1.0.2" />
     <PackageReference Include="FluentValidation" Version="11.7.1" />
     <PackageReference Include="MediatR" Version="12.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="MassTransit" Version="8.2.3" />
     <PackageReference Include="MassTransit.Azure.ServiceBus.Core" Version="8.2.3" />
   </ItemGroup>

--- a/src/Equinor.ProCoSys.Preservation.Domain/Equinor.ProCoSys.Preservation.Domain.csproj
+++ b/src/Equinor.ProCoSys.Preservation.Domain/Equinor.ProCoSys.Preservation.Domain.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <Reference Include="Equinor.ProCoSys.Common">
-      <HintPath>..\..\..\procosys-common\src\Equinor.ProCoSys.Common\bin\Debug\net7.0\Equinor.ProCoSys.Common.dll</HintPath>
+      <HintPath>..\..\..\procosys-common\src\Equinor.ProCoSys.Common\bin\Debug\net8.0\Equinor.ProCoSys.Common.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/src/Equinor.ProCoSys.Preservation.Infrastructure/Equinor.ProCoSys.Preservation.Infrastructure.csproj
+++ b/src/Equinor.ProCoSys.Preservation.Infrastructure/Equinor.ProCoSys.Preservation.Infrastructure.csproj
@@ -1,20 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="MassTransit" Version="8.2.3" />
     <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.2.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.10">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Equinor.ProCoSys.Preservation.MainApi/Equinor.ProCoSys.Preservation.MainApi.csproj
+++ b/src/Equinor.ProCoSys.Preservation.MainApi/Equinor.ProCoSys.Preservation.MainApi.csproj
@@ -1,14 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Equinor.ProCoSys.Auth" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Equinor.ProCoSys.Preservation.Query/Equinor.ProCoSys.Preservation.Query.csproj
+++ b/src/Equinor.ProCoSys.Preservation.Query/Equinor.ProCoSys.Preservation.Query.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Equinor.ProCoSys.Preservation.WebApi/Dockerfile
+++ b/src/Equinor.ProCoSys.Preservation.WebApi/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 
 # Copy project files separately and restore NuGet packages to create layers. Skip test projects!
@@ -31,7 +31,7 @@ WORKDIR "/src/Equinor.ProCoSys.Preservation.WebApi"
 RUN dotnet publish "Equinor.ProCoSys.Preservation.WebApi.csproj" -c Release --no-restore -o /app/publish
 
 # Define the image used for the final result
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 
 # Install System.Drawing native dependencies (added because of Excel export (ClosedXML library) support).
 RUN apt-get update

--- a/src/Equinor.ProCoSys.Preservation.WebApi/Equinor.ProCoSys.Preservation.WebApi.csproj
+++ b/src/Equinor.ProCoSys.Preservation.WebApi/Equinor.ProCoSys.Preservation.WebApi.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.10">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Equinor.ProCoSys.Preservation.WebApi/Equinor.ProCoSys.Preservation.WebApi.csproj
+++ b/src/Equinor.ProCoSys.Preservation.WebApi/Equinor.ProCoSys.Preservation.WebApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>e47b709b-5c82-4a61-935c-823e332955f9</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <ApplicationInsightsResourceId>/subscriptions/343069e3-ceaa-4256-bdc8-49fa3646c1c4/resourcegroups/pcs-preservation-dev-rg/providers/microsoft.insights/components/pcs-pres-dev-ai</ApplicationInsightsResourceId>
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.11.4" />
+    <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="ClosedXML" Version="0.102.1" />
     <PackageReference Include="Equinor.ProCoSys.PcsServiceBus" Version="4.0.10" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
@@ -42,16 +42,16 @@
     <PackageReference Include="MicroElements.Swashbuckle.FluentValidation" Version="5.7.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.21.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="7.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="6.1.0" />
+    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.66.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />
     <PackageReference Include="ServiceResult.ApiExtensions" Version="1.0.1" />

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/Equinor.ProCoSys.Preservation.Command.Tests.csproj
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/Equinor.ProCoSys.Preservation.Command.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/tests/Equinor.ProCoSys.Preservation.Domain.Tests/Equinor.ProCoSys.Preservation.Domain.Tests.csproj
+++ b/src/tests/Equinor.ProCoSys.Preservation.Domain.Tests/Equinor.ProCoSys.Preservation.Domain.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/tests/Equinor.ProCoSys.Preservation.Infrastructure.Tests/Equinor.ProCoSys.Preservation.Infrastructure.Tests.csproj
+++ b/src/tests/Equinor.ProCoSys.Preservation.Infrastructure.Tests/Equinor.ProCoSys.Preservation.Infrastructure.Tests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="MockQueryable.Moq" Version="7.0.0" />
     <PackageReference Include="Moq" Version="4.18.4" />

--- a/src/tests/Equinor.ProCoSys.Preservation.MainApi.Tests/Equinor.ProCoSys.Preservation.MainApi.Tests.csproj
+++ b/src/tests/Equinor.ProCoSys.Preservation.MainApi.Tests/Equinor.ProCoSys.Preservation.MainApi.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/tests/Equinor.ProCoSys.Preservation.Query.Tests/Equinor.ProCoSys.Preservation.Query.Tests.csproj
+++ b/src/tests/Equinor.ProCoSys.Preservation.Query.Tests/Equinor.ProCoSys.Preservation.Query.Tests.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />

--- a/src/tests/Equinor.ProCoSys.Preservation.Test.Common/Equinor.ProCoSys.Preservation.Test.Common.csproj
+++ b/src/tests/Equinor.ProCoSys.Preservation.Test.Common/Equinor.ProCoSys.Preservation.Test.Common.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
   </ItemGroup>

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.csproj
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.Tests/Equinor.ProCoSys.Preservation.WebApi.Tests.csproj
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.Tests/Equinor.ProCoSys.Preservation.WebApi.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Infra pipeline has been updated to .net 8, causing preservation tests to fail. Fixing by updating the project to version 8.

https://github.com/equinor/cc-toolbox/issues/792