### PR TITLE
Delete requirement type integration event

### DIFF
--- a/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/EventHelpers/CreateRequirementTypeDeletedEventHelper.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/EventHandlers/IntegrationEvents/EventHelpers/CreateRequirementTypeDeletedEventHelper.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+using Equinor.ProCoSys.Preservation.Command.Events;
+using Equinor.ProCoSys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
+
+namespace Equinor.ProCoSys.Preservation.Command.EventHandlers.IntegrationEvents.EventHelpers;
+
+public class CreateRequirementTypeDeletedEventHelper : ICreateEventHelper<RequirementType, RequirementTypeDeleteEvent>
+{
+    public Task<RequirementTypeDeleteEvent> CreateEvent(RequirementType entity) => Task.FromResult(new RequirementTypeDeleteEvent(entity.Guid, entity.Plant));
+}

--- a/src/Equinor.ProCoSys.Preservation.Command/Events/RequirementTypeDeleteEvent.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/Events/RequirementTypeDeleteEvent.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using Equinor.ProCoSys.Preservation.Command.Events.EntityNames;
+using Equinor.ProCoSys.Preservation.Domain.AggregateModels.ModeAggregate;
+using Equinor.ProCoSys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
+
+namespace Equinor.ProCoSys.Preservation.Command.Events;
+
+[EntityNameRequirementType]
+public class RequirementTypeDeleteEvent(Guid guid, string plant) : DeleteEvent<RequirementType>(guid, plant, null);

--- a/src/Equinor.ProCoSys.Preservation.Command/RequirementTypeCommands/DeleteRequirementType/DeleteRequirementTypeCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/RequirementTypeCommands/DeleteRequirementType/DeleteRequirementTypeCommandHandler.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Equinor.ProCoSys.Preservation.Domain;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
+using Equinor.ProCoSys.Preservation.Domain.Events;
 using MediatR;
 using ServiceResult;
 
@@ -22,6 +23,7 @@ namespace Equinor.ProCoSys.Preservation.Command.RequirementTypeCommands.DeleteRe
         {
             var requirementType = await _requirementTypeRepository.GetByIdAsync(request.RequirementTypeId);
             requirementType.SetRowVersion(request.RowVersion);
+            requirementType.AddDomainEvent(new DeletedEvent<RequirementType>(requirementType));
 
             _requirementTypeRepository.Remove(requirementType);
             await _unitOfWork.SaveChangesAsync(cancellationToken);

--- a/src/Equinor.ProCoSys.Preservation.WebApi/DiModules/ApplicationModule.cs
+++ b/src/Equinor.ProCoSys.Preservation.WebApi/DiModules/ApplicationModule.cs
@@ -183,8 +183,11 @@ namespace Equinor.ProCoSys.Preservation.WebApi.DIModules
             
             services.AddTransient<INotificationHandler<CreatedEvent<RequirementType>>, IntegrationEventHandler<CreatedEvent<RequirementType>, RequirementType>>();
             services.AddTransient<INotificationHandler<ModifiedEvent<RequirementType>>, IntegrationEventHandler<ModifiedEvent<RequirementType>, RequirementType>>();
+            services.AddTransient<INotificationHandler<DeletedEvent<RequirementType>>, IntegrationDeleteEventHandler<DeletedEvent<RequirementType>, RequirementType>>();
             services.AddTransient<IPublishEntityEventHelper<RequirementType>, PublishEntityEventHelper<RequirementType, RequirementTypeEvent>>();
+            services.AddTransient<IPublishDeleteEntityEventHelper<RequirementType>, PublishDeleteEntityEventHelper<RequirementType, RequirementTypeDeleteEvent>>();
             services.AddTransient<ICreateEventHelper<RequirementType, RequirementTypeEvent>, CreateRequirementTypeEventHelper>();
+            services.AddTransient<ICreateEventHelper<RequirementType, RequirementTypeDeleteEvent>, CreateRequirementTypeDeletedEventHelper>();
             
             services.AddTransient<INotificationHandler<CreatedEvent<Responsible>>, IntegrationEventHandler<CreatedEvent<Responsible>, Responsible>>();
             services.AddTransient<INotificationHandler<ModifiedEvent<Responsible>>, IntegrationEventHandler<ModifiedEvent<Responsible>, Responsible>>();

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/EventHandlers/IntegrationEvents/CreateRequirementTypeDeletedEventHelperTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/EventHandlers/IntegrationEvents/CreateRequirementTypeDeletedEventHelperTests.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Equinor.ProCoSys.Preservation.Command.EventHandlers.IntegrationEvents.EventHelpers;
+using Equinor.ProCoSys.Preservation.Command.Events;
+using Equinor.ProCoSys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Equinor.ProCoSys.Preservation.Command.Tests.EventHandlers.IntegrationEvents;
+
+[TestClass]
+public class CreateRequirementTypeDeletedEventHelperTests
+{
+    private const string TestPlant = "PCS$PlantA";
+    private RequirementType _requirementType;
+    private CreateRequirementTypeDeletedEventHelper _dut;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        // Arrange
+        _requirementType = new RequirementType(TestPlant, "Test Code", "Test Type Title", RequirementTypeIcon.Other, 10);
+
+        _dut = new CreateRequirementTypeDeletedEventHelper();
+    }
+
+    [DataTestMethod]
+    [DataRow(nameof(RequirementTypeDeleteEvent.Plant), TestPlant)]
+    [DataRow(nameof(RequirementTypeDeleteEvent.ProjectName), null)]
+    [DataRow(nameof(RequirementTypeDeleteEvent.Behavior), "delete")]
+    public async Task CreateEvent_ShouldCreateRequirementDefinitionEventExpectedValues(string property, object expected)
+    {
+        // Act
+        var integrationEvent = await _dut.CreateEvent(_requirementType);
+        var result = integrationEvent.GetType()
+            .GetProperties()
+            .Single(p => p.Name == property)
+            .GetValue(integrationEvent);
+
+        // Assert
+        Assert.AreEqual(expected, result);
+    }
+    
+    [TestMethod]
+    public async Task CreateEvent_ShouldCreateRequirementDefinitionEventWithExpectedProCoSysGuid()
+    {
+        // Arrange
+        var expected = _requirementType.Guid;
+        
+        // Act
+        var integrationEvent = await _dut.CreateEvent(_requirementType);
+        var result = integrationEvent.ProCoSysGuid;
+
+        // Assert
+        Assert.AreEqual(result, expected);
+    }
+}

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/RequirementTypeCommands/DeleteRequirementType/DeleteRequirementTypeCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/RequirementTypeCommands/DeleteRequirementType/DeleteRequirementTypeCommandHandlerTests.cs
@@ -1,6 +1,9 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using Equinor.ProCoSys.Preservation.Command.RequirementTypeCommands.DeleteRequirementType;
+using Equinor.ProCoSys.Preservation.Domain.AggregateModels.JourneyAggregate;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
+using Equinor.ProCoSys.Preservation.Domain.Events;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
@@ -51,6 +54,17 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.RequirementTypeCommands.De
             
             // Assert
             UnitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+        }
+        
+        [TestMethod]
+        public async Task HandlingDeleteRequirementTypeCommand_ShouldAddDeletionEvent()
+        {
+            // Act
+            await _dut.Handle(_command, default);
+            var eventTypes = _requirementType.DomainEvents.Select(e => e.GetType()).ToList();
+            
+            // Assert
+            CollectionAssert.Contains(eventTypes, typeof(DeletedEvent<RequirementType>));
         }
     }
 }


### PR DESCRIPTION
Emitting a deletion integration event when deleting a requirement type.

Note, this change does not include child objects that should also emit deletion events. They will each get their respective change.