### PR TITLE
1066 blob storage update

### DIFF
--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -35,6 +35,7 @@ spec:
         AzureAd__ClientId: 67b2f053-30bf-4ffc-9206-ef57f631efcb # App registration: ProCoSys - Preservation Api - Dev
         AzureAd__ClientCredentials__0__SourceType: SignedAssertionFilePath
         ASPNETCORE_ENVIRONMENT: 'Development'
+        BlobStorage__AccountName: pcsdevsa
         LEADERELECTOR_SERVICE: http://leader-elector:3003
         MainApi__BaseAddress: 'https://pcs-main-api-dev.azurewebsites.net/api/'
         MainApi__MainApiScope: 'api://dd38f169-bccf-4d0e-a4ad-d830893cfa75/.default'
@@ -63,6 +64,7 @@ spec:
         AzureAd__ClientCredentials__0__SourceType: SignedAssertionFilePath
         ASPNETCORE_ENVIRONMENT: 'Test'
         LEADERELECTOR_SERVICE: http://leader-elector:3003
+        BlobStorage__AccountName: pcstestsa
         MainApi__BaseAddress: 'https://procosyswebapitest.equinor.com/api/'
         MainApi__MainApiScope: 'api://2d0ed80f-3013-422d-b8bd-2b8ac70b2ce1/.default'
         ServiceBus__Enable: 'true'
@@ -90,6 +92,7 @@ spec:
         AzureAd__ClientId: 1eb50c54-e897-4216-93d0-6ca86b0cf681 # App registration: ProCoSys - Preservation Api - Prod
         AzureAd__ClientCredentials__0__SourceType: SignedAssertionFilePath
         ASPNETCORE_ENVIRONMENT: 'Prod'
+        BlobStorage__AccountName: pcsprodsa
         LEADERELECTOR_SERVICE: http://leader-elector:3003
         MainApi__BaseAddress: 'https://procosyswebapi.equinor.com/api/'
         MainApi__MainApiScope: 'api://47641c40-0135-459b-8ab4-459e68dc8d08/.default'

--- a/src/Equinor.ProCoSys.Preservation.Command/ActionAttachmentCommands/Upload/UploadActionAttachmentCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/ActionAttachmentCommands/Upload/UploadActionAttachmentCommandHandler.cs
@@ -58,7 +58,8 @@ namespace Equinor.ProCoSys.Preservation.Command.ActionAttachmentCommands.Upload
             await _azureBlobService.UploadAsync(
                 _blobStorageOptions.Value.BlobContainer,
                 fullBlobPath, 
-                request.Content, 
+                request.Content,
+                "application/octet-stream",
                 request.OverwriteIfExists, 
                 cancellationToken);
 

--- a/src/Equinor.ProCoSys.Preservation.Command/Equinor.ProCoSys.Preservation.Command.csproj
+++ b/src/Equinor.ProCoSys.Preservation.Command/Equinor.ProCoSys.Preservation.Command.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Equinor.ProCoSys.Auth" Version="3.1.4" />
-    <PackageReference Include="Equinor.ProCoSys.BlobStorage" Version="1.0.2" />
+    <PackageReference Include="Equinor.ProCoSys.BlobStorage" Version="2.1.3" />
     <PackageReference Include="FluentValidation" Version="11.7.1" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />

--- a/src/Equinor.ProCoSys.Preservation.Command/RequirementCommands/Upload/UploadFieldValueAttachmentCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/RequirementCommands/Upload/UploadFieldValueAttachmentCommandHandler.cs
@@ -67,7 +67,8 @@ namespace Equinor.ProCoSys.Preservation.Command.RequirementCommands.Upload
             await _azureBlobService.UploadAsync(
                 _blobStorageOptions.Value.BlobContainer,
                 fullBlobPath, 
-                request.Content, 
+                request.Content,
+                "application/octet-stream",
                 true, 
                 cancellationToken);
 

--- a/src/Equinor.ProCoSys.Preservation.Command/TagAttachmentCommands/Upload/UploadTagAttachmentCommandHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Command/TagAttachmentCommands/Upload/UploadTagAttachmentCommandHandler.cs
@@ -56,7 +56,8 @@ namespace Equinor.ProCoSys.Preservation.Command.TagAttachmentCommands.Upload
             await _azureBlobService.UploadAsync(
                 _blobStorageOptions.Value.BlobContainer,
                 fullBlobPath, 
-                request.Content, 
+                request.Content,
+                "application/octet-stream",
                 request.OverwriteIfExists, 
                 cancellationToken);
 

--- a/src/Equinor.ProCoSys.Preservation.Query/Equinor.ProCoSys.Preservation.Query.csproj
+++ b/src/Equinor.ProCoSys.Preservation.Query/Equinor.ProCoSys.Preservation.Query.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Equinor.ProCoSys.BlobStorage" Version="1.0.2" />
+    <PackageReference Include="Equinor.ProCoSys.BlobStorage" Version="2.1.3" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="ServiceResult" Version="1.0.1" />
   </ItemGroup>

--- a/src/Equinor.ProCoSys.Preservation.Query/GetFieldValueAttachment/GetFieldValueAttachmentQueryHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Query/GetFieldValueAttachment/GetFieldValueAttachmentQueryHandler.cs
@@ -7,6 +7,7 @@ using Equinor.ProCoSys.Common;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.RequirementTypeAggregate;
 using Equinor.ProCoSys.Common.Time;
+using Equinor.ProCoSys.Preservation.Query.UserDelegationProvider;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -14,23 +15,18 @@ using ServiceResult;
 
 namespace Equinor.ProCoSys.Preservation.Query.GetFieldValueAttachment
 {
-    public class GetFieldValueAttachmentQueryHandler : IRequestHandler<GetFieldValueAttachmentQuery, Result<Uri>>
+    public class GetFieldValueAttachmentQueryHandler(
+        IReadOnlyContext context,
+        IAzureBlobService azureBlobService,
+        IUserDelegationProvider userDelegationProvider,
+        IOptionsSnapshot<BlobStorageOptions> blobStorageOptions
+        )
+        : IRequestHandler<GetFieldValueAttachmentQuery, Result<Uri>>
     {
-        private readonly IReadOnlyContext _context;
-        private readonly IAzureBlobService _azureBlobService;
-        private readonly IOptionsSnapshot<BlobStorageOptions> _blobStorageOptions;
-
-        public GetFieldValueAttachmentQueryHandler(IReadOnlyContext context, IAzureBlobService azureBlobService, IOptionsSnapshot<BlobStorageOptions> blobStorageOptions)
-        {
-            _context = context;
-            _azureBlobService = azureBlobService;
-            _blobStorageOptions = blobStorageOptions;
-        }
-
         public async Task<Result<Uri>> Handle(GetFieldValueAttachmentQuery request, CancellationToken cancellationToken)
         {
             var tag = await
-                (from t in _context.QuerySet<Tag>()
+                (from t in context.QuerySet<Tag>()
                         .Include(t => t.Requirements)
                             .ThenInclude(r => r.PreservationPeriods)
                             .ThenInclude(p => p.FieldValues)
@@ -46,7 +42,7 @@ namespace Equinor.ProCoSys.Preservation.Query.GetFieldValueAttachment
             var requirement = tag.Requirements.Single(r => r.Id == request.RequirementId);
 
             var requirementDefinition = await
-                (from rd in _context.QuerySet<RequirementDefinition>().Include(rd => rd.Fields)
+                (from rd in context.QuerySet<RequirementDefinition>().Include(rd => rd.Fields)
                     where rd.Id == requirement.RequirementDefinitionId
                     select rd
                 ).SingleOrDefaultAsync(cancellationToken);
@@ -60,11 +56,12 @@ namespace Equinor.ProCoSys.Preservation.Query.GetFieldValueAttachment
 
             var now = TimeService.UtcNow;
             var fullBlobPath = attachment.GetFullBlobPath();
-            var uri = _azureBlobService.GetDownloadSasUri(
-                _blobStorageOptions.Value.BlobContainer,
+            var uri = azureBlobService.GetDownloadSasUri(
+                blobStorageOptions.Value.BlobContainer,
                 fullBlobPath,
-                new DateTimeOffset(now.AddMinutes(_blobStorageOptions.Value.BlobClockSkewMinutes * -1)),
-                new DateTimeOffset(now.AddMinutes(_blobStorageOptions.Value.BlobClockSkewMinutes)));
+                new DateTimeOffset(now.AddMinutes(blobStorageOptions.Value.BlobClockSkewMinutes * -1)),
+                new DateTimeOffset(now.AddMinutes(blobStorageOptions.Value.BlobClockSkewMinutes)),
+                userDelegationProvider.GetUserDelegationKey());
             return new SuccessResult<Uri>(uri);
         }
     }

--- a/src/Equinor.ProCoSys.Preservation.Query/GetTagAttachment/GetTagAttachmentQueryHandler.cs
+++ b/src/Equinor.ProCoSys.Preservation.Query/GetTagAttachment/GetTagAttachmentQueryHandler.cs
@@ -6,6 +6,7 @@ using Equinor.ProCoSys.BlobStorage;
 using Equinor.ProCoSys.Common;
 using Equinor.ProCoSys.Preservation.Domain.AggregateModels.ProjectAggregate;
 using Equinor.ProCoSys.Common.Time;
+using Equinor.ProCoSys.Preservation.Query.UserDelegationProvider;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -13,25 +14,19 @@ using ServiceResult;
 
 namespace Equinor.ProCoSys.Preservation.Query.GetTagAttachment
 {
-    public class GetTagAttachmentQueryHandler : IRequestHandler<GetTagAttachmentQuery, Result<Uri>>
+    public class GetTagAttachmentQueryHandler(
+        IReadOnlyContext context,
+        IAzureBlobService azureBlobService,
+        IUserDelegationProvider userDelegationProvider,
+        IOptionsSnapshot<BlobStorageOptions> blobStorageOptions)
+        : IRequestHandler<GetTagAttachmentQuery, Result<Uri>>
     {
-        private readonly IReadOnlyContext _context;
-        private readonly IAzureBlobService _azureBlobService;
-        private readonly IOptionsSnapshot<BlobStorageOptions> _blobStorageOptions;
-
-        public GetTagAttachmentQueryHandler(IReadOnlyContext context, IAzureBlobService azureBlobService, IOptionsSnapshot<BlobStorageOptions> blobStorageOptions)
-        {
-            _context = context;
-            _azureBlobService = azureBlobService;
-            _blobStorageOptions = blobStorageOptions;
-        }
-
         public async Task<Result<Uri>> Handle(GetTagAttachmentQuery request, CancellationToken cancellationToken)
         {
             var attachment = await
-                (from a in _context.QuerySet<TagAttachment>()
+                (from a in context.QuerySet<TagAttachment>()
                     // also join tag to return null if request.TagId not exists
-                    join tag in _context.QuerySet<Tag>() on request.TagId equals tag.Id
+                    join tag in context.QuerySet<Tag>() on request.TagId equals tag.Id
                     where a.Id == request.AttachmentId
                     select a).SingleOrDefaultAsync(cancellationToken);
 
@@ -42,11 +37,12 @@ namespace Equinor.ProCoSys.Preservation.Query.GetTagAttachment
 
             var now = TimeService.UtcNow;
             var fullBlobPath = attachment.GetFullBlobPath();
-            var uri = _azureBlobService.GetDownloadSasUri(
-                _blobStorageOptions.Value.BlobContainer,
+            var uri = azureBlobService.GetDownloadSasUri(
+                blobStorageOptions.Value.BlobContainer,
                 fullBlobPath,
-                new DateTimeOffset(now.AddMinutes(_blobStorageOptions.Value.BlobClockSkewMinutes * -1)),
-                new DateTimeOffset(now.AddMinutes(_blobStorageOptions.Value.BlobClockSkewMinutes)));
+                new DateTimeOffset(now.AddMinutes(blobStorageOptions.Value.BlobClockSkewMinutes * -1)),
+                new DateTimeOffset(now.AddMinutes(blobStorageOptions.Value.BlobClockSkewMinutes)),
+                userDelegationProvider.GetUserDelegationKey());
             return new SuccessResult<Uri>(uri);
         }
     }

--- a/src/Equinor.ProCoSys.Preservation.Query/UserDelegationProvider/IUserDelegationProvider.cs
+++ b/src/Equinor.ProCoSys.Preservation.Query/UserDelegationProvider/IUserDelegationProvider.cs
@@ -1,0 +1,8 @@
+﻿using Azure.Storage.Blobs.Models;
+
+namespace Equinor.ProCoSys.Preservation.Query.UserDelegationProvider;
+
+public interface IUserDelegationProvider
+{
+    public UserDelegationKey GetUserDelegationKey();
+}

--- a/src/Equinor.ProCoSys.Preservation.Query/UserDelegationProvider/UserDelegationProvider.cs
+++ b/src/Equinor.ProCoSys.Preservation.Query/UserDelegationProvider/UserDelegationProvider.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Azure.Core;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Equinor.ProCoSys.BlobStorage;
+using Microsoft.Extensions.Options;
+
+namespace Equinor.ProCoSys.Preservation.Query.UserDelegationProvider;
+
+public class UserDelegationProvider : IUserDelegationProvider
+{
+    private readonly BlobServiceClient _blobServiceClient;
+    private UserDelegationKey? _userDelegationKeyCached;
+    private DateTimeOffset? _expirationTime;
+
+    public UserDelegationProvider(IOptionsMonitor<BlobStorageOptions> options, TokenCredential credential)
+    {
+        if (string.IsNullOrEmpty(options.CurrentValue.AccountUrl))
+        {
+            throw new ArgumentNullException(nameof(options.CurrentValue.AccountUrl));
+        }
+
+        _blobServiceClient = new BlobServiceClient(new Uri($"{options.CurrentValue.AccountUrl}"), credential);
+    }
+
+    public UserDelegationKey GetUserDelegationKey()
+    {
+        // We get and cache a new User Delegation Key if we don't already have one, or if the one we're
+        // using is about to run out in the next hour.
+        // We want a bit of leeway here, as we don't want the key to be valid as we check it here as its about to
+        // expire, and then have it expire and be invalid as we are trying to use it.
+        if (_userDelegationKeyCached == null || _expirationTime <= DateTimeOffset.UtcNow.AddHours(1))
+        {
+            // Set to about 7 days in the future, because that is the maximum lifetime
+            // of a user delegation key.
+            var startsOn = DateTimeOffset.UtcNow.AddMinutes(-4);
+            var expiresOn = DateTimeOffset.UtcNow.AddDays(7).AddMinutes(-5);
+            _userDelegationKeyCached = _blobServiceClient.GetUserDelegationKey(startsOn, expiresOn);
+            _expirationTime = _userDelegationKeyCached.SignedExpiresOn;
+        }
+
+        return _userDelegationKeyCached;
+    }
+}

--- a/src/Equinor.ProCoSys.Preservation.WebApi/DiModules/ApplicationModule.cs
+++ b/src/Equinor.ProCoSys.Preservation.WebApi/DiModules/ApplicationModule.cs
@@ -51,6 +51,7 @@ using Equinor.ProCoSys.Preservation.MainApi.Project;
 using Equinor.ProCoSys.Preservation.MainApi.Responsible;
 using Equinor.ProCoSys.Preservation.MainApi.Tag;
 using Equinor.ProCoSys.Preservation.MainApi.TagFunction;
+using Equinor.ProCoSys.Preservation.Query.UserDelegationProvider;
 using Equinor.ProCoSys.Preservation.WebApi.Authorizations;
 using Equinor.ProCoSys.Preservation.WebApi.Excel;
 using Equinor.ProCoSys.Preservation.WebApi.Misc;
@@ -116,6 +117,9 @@ namespace Equinor.ProCoSys.Preservation.WebApi.DIModules
             // TimedSynchronization WAS WRITTEN TO RUN A ONETIME TRANSFORMATION WHEN WE INTRODUCED ProCoSysGuid
             // WE KEEP THE CODE ... MAYBE WE WANT TO DO SIMILAR STUFF LATER
             // services.AddHostedService<TimedSynchronization>();
+            
+            // Singleton - Created the first time they are requested
+            services.AddSingleton<IUserDelegationProvider, UserDelegationProvider>();
 
             services.AddHttpContextAccessor();
             services.AddHttpClient();

--- a/src/Equinor.ProCoSys.Preservation.WebApi/appsettings.json
+++ b/src/Equinor.ProCoSys.Preservation.WebApi/appsettings.json
@@ -22,7 +22,6 @@
       ".xlsm",
       ".xltm"
     ],
-    "ConnectionString": "",
     "MaxSizeMb": 100
   },
   "CacheOptions": {

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/ActionAttachmentCommands/Upload/UploadActionAttachmentCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/ActionAttachmentCommands/Upload/UploadActionAttachmentCommandHandlerTests.cs
@@ -134,7 +134,8 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.ActionAttachmentCommands.U
                 => b.UploadAsync(
                     _blobContainer, 
                     p, 
-                    It.IsAny<Stream>(), 
+                    It.IsAny<Stream>(),
+                    null,
                     _commandWithoutOverwrite.OverwriteIfExists, 
                     default), Times.Once);
         }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/ActionAttachmentCommands/Upload/UploadActionAttachmentCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/ActionAttachmentCommands/Upload/UploadActionAttachmentCommandHandlerTests.cs
@@ -135,7 +135,7 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.ActionAttachmentCommands.U
                     _blobContainer, 
                     p, 
                     It.IsAny<Stream>(),
-                    null,
+                    "application/octet-stream",
                     _commandWithoutOverwrite.OverwriteIfExists, 
                     default), Times.Once);
         }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/RequirementCommands/Upload/UploadFieldValueAttachmentCommandTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/RequirementCommands/Upload/UploadFieldValueAttachmentCommandTests.cs
@@ -136,7 +136,7 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.RequirementCommands.Upload
                 _blobContainer,
                 p, 
                 It.IsAny<Stream>(),
-                null,
+                "application/octet-stream",
                 true, 
                 default), Times.Once);
         }
@@ -158,7 +158,7 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.RequirementCommands.Upload
                 _blobContainer,
                 It.IsAny<string>(),
                 It.IsAny<Stream>(),
-                null,
+                "application/octet-stream",
                 true,
                 default), Times.Once);
         }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/RequirementCommands/Upload/UploadFieldValueAttachmentCommandTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/RequirementCommands/Upload/UploadFieldValueAttachmentCommandTests.cs
@@ -135,7 +135,8 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.RequirementCommands.Upload
             _blobStorageMock.Verify(b => b.UploadAsync(
                 _blobContainer,
                 p, 
-                It.IsAny<Stream>(), 
+                It.IsAny<Stream>(),
+                null,
                 true, 
                 default), Times.Once);
         }
@@ -153,7 +154,13 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.RequirementCommands.Upload
 
             // Assert
             _blobStorageMock.Verify(b => b.DeleteAsync(_blobContainer, p, default), Times.Once);
-            _blobStorageMock.Verify(b => b.UploadAsync(_blobContainer, It.IsAny<string>(), It.IsAny<Stream>(), true, default), Times.Once);
+            _blobStorageMock.Verify(b => b.UploadAsync(
+                _blobContainer,
+                It.IsAny<string>(),
+                It.IsAny<Stream>(),
+                null,
+                true,
+                default), Times.Once);
         }
 
         [TestMethod]

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagAttachmentCommands/Upload/UploadTagAttachmentCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagAttachmentCommands/Upload/UploadTagAttachmentCommandHandlerTests.cs
@@ -135,7 +135,8 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagAttachmentCommands.Uplo
                 => b.UploadAsync(
                     _blobContainer,
                     p,
-                    It.IsAny<Stream>(), 
+                    It.IsAny<Stream>(),
+                    null,
                     _commandWithoutOverwrite.OverwriteIfExists, 
                     default), Times.Once);
         }

--- a/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagAttachmentCommands/Upload/UploadTagAttachmentCommandHandlerTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.Command.Tests/TagAttachmentCommands/Upload/UploadTagAttachmentCommandHandlerTests.cs
@@ -136,7 +136,7 @@ namespace Equinor.ProCoSys.Preservation.Command.Tests.TagAttachmentCommands.Uplo
                     _blobContainer,
                     p,
                     It.IsAny<Stream>(),
-                    null,
+                    "application/octet-stream",
                     _commandWithoutOverwrite.OverwriteIfExists, 
                     default), Times.Once);
         }

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/TestFactory.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/TestFactory.cs
@@ -17,6 +17,7 @@ using Equinor.ProCoSys.Preservation.MainApi.Project;
 using Equinor.ProCoSys.Preservation.MainApi.Responsible;
 using Equinor.ProCoSys.Preservation.MainApi.Tag;
 using Equinor.ProCoSys.Preservation.MainApi.TagFunction;
+using Equinor.ProCoSys.Preservation.Query.UserDelegationProvider;
 using Equinor.ProCoSys.Preservation.WebApi.Middleware;
 using MassTransit;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -52,6 +53,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests
         public readonly Mock<IDisciplineApiService> DisciplineApiServiceMock = new Mock<IDisciplineApiService>();
         public readonly Mock<IAreaApiService> AreaApiServiceMock = new Mock<IAreaApiService>();
         public readonly Mock<IAzureBlobService> BlobStorageMock = new Mock<IAzureBlobService>();
+        public readonly Mock<IUserDelegationProvider> UserDelegationProviderMock = new Mock<IUserDelegationProvider>();
         public readonly Mock<ITagApiService> TagApiServiceMock = new Mock<ITagApiService>();
         public readonly Mock<ITagFunctionApiService> TagFunctionApiServiceMock = new Mock<ITagFunctionApiService>();
 
@@ -161,6 +163,7 @@ namespace Equinor.ProCoSys.Preservation.WebApi.IntegrationTests
                 services.AddScoped(_ => DisciplineApiServiceMock.Object);
                 services.AddScoped(_ => AreaApiServiceMock.Object);
                 services.AddScoped(_ => BlobStorageMock.Object);
+                services.AddScoped(_ => UserDelegationProviderMock.Object);
             });
 
             builder.ConfigureServices(services =>


### PR DESCRIPTION
Updating the blob storage package version in order to make use of credential tokens for authentication instead of connection strings.

Completion API change referenced for this update: https://github.com/equinor/procosys-completion-api/pull/266

https://github.com/equinor/cc-toolbox/issues/1066