### PR TITLE
1064 re-adding development configuration options

### DIFF
--- a/src/Equinor.ProCoSys.Preservation.WebApi/DiModules/SetupDatabase.cs
+++ b/src/Equinor.ProCoSys.Preservation.WebApi/DiModules/SetupDatabase.cs
@@ -1,0 +1,28 @@
+﻿using Equinor.ProCoSys.Preservation.WebApi.Middleware;
+using Equinor.ProCoSys.Preservation.WebApi.Seeding;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Equinor.ProCoSys.Preservation.WebApi.DiModules;
+
+public static class SetupDatabase
+{
+    public static void ConfigureDatabase(this IHostApplicationBuilder builder)
+    {
+        if (!builder.Environment.IsDevelopment())
+        {
+            return;
+        }
+
+        if (builder.Configuration.GetValue<bool>("MigrateDatabase"))
+        {
+            builder.Services.AddHostedService<DatabaseMigrator>();
+        }
+
+        if (builder.Configuration.GetValue<bool>("SeedDummyData"))
+        {
+            builder.Services.AddHostedService<Seeder>();
+        }
+    }
+}

--- a/src/Equinor.ProCoSys.Preservation.WebApi/Program.cs
+++ b/src/Equinor.ProCoSys.Preservation.WebApi/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Reflection;
 using Equinor.ProCoSys.Auth;
+using Equinor.ProCoSys.Common.Misc;
 using Equinor.ProCoSys.Completion.WebApi.DIModules;
 using Equinor.ProCoSys.Preservation.Command;
 using Equinor.ProCoSys.Preservation.Query;
@@ -17,6 +18,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.ConfigureDatabase();
 
 builder.ConfigureAuthentication(out var credential);
 
@@ -80,6 +83,8 @@ if (builder.Configuration.GetValue<bool>("Application:UseAzureAppConfiguration")
 
 if (builder.Environment.IsDevelopment())
 {
+    DebugOptions.DebugEntityFrameworkInDevelopment = builder.Configuration.GetValue<bool>("DebugEntityFrameworkInDevelopment");
+    
     app.UseDeveloperExceptionPage();
 }
 

--- a/src/Equinor.ProCoSys.Preservation.WebApi/Program.cs
+++ b/src/Equinor.ProCoSys.Preservation.WebApi/Program.cs
@@ -19,8 +19,6 @@ using Microsoft.Extensions.Hosting;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.ConfigureDatabase();
-
 builder.ConfigureAuthentication(out var credential);
 
 builder.ConfigureAzureAppConfig(credential);
@@ -69,10 +67,7 @@ builder.Services.AddApplicationModules(builder.Configuration, credential);
 
 builder.ConfigureServiceBus(credential);
 
-if (builder.Environment.IsDevelopment() && builder.Configuration.GetValue<bool>("MigrateDatabase"))
-{
-    builder.Services.AddHostedService<DatabaseMigrator>();
-}
+builder.ConfigureDatabase();
 
 var app = builder.Build();
 

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.csproj
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests/Equinor.ProCoSys.Preservation.WebApi.IntegrationTests.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="8.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.18.4" />

--- a/src/tests/Equinor.ProCoSys.Preservation.WebApi.Tests/SetupDatabaseTests.cs
+++ b/src/tests/Equinor.ProCoSys.Preservation.WebApi.Tests/SetupDatabaseTests.cs
@@ -1,0 +1,128 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Equinor.ProCoSys.Preservation.WebApi.DiModules;
+using Equinor.ProCoSys.Preservation.WebApi.Middleware;
+using Equinor.ProCoSys.Preservation.WebApi.Seeding;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using ConfigurationManager = Microsoft.Extensions.Configuration.ConfigurationManager;
+
+namespace Equinor.ProCoSys.Preservation.WebApi.Tests;
+
+[TestClass]
+public class SetupDatabaseTests
+{
+    [TestMethod]
+    public void ConfigureDatabase_ShouldNotAddServices_WhenNotInDevelopment()
+    {
+        // Arrange
+        var builderMock = new Mock<IHostApplicationBuilder>();
+        
+        var environmentMock = new Mock<IWebHostEnvironment>();
+        environmentMock.Setup(e => e.EnvironmentName).Returns(Environments.Production);
+        builderMock.Setup(b => b.Environment).Returns(environmentMock.Object);
+        
+        var configuration = new ConfigurationManager();
+        configuration["MigrateDatabase"] = "true";
+        configuration["SeedDummyData"] = "true";
+        builderMock.Setup(b => b.Configuration).Returns(configuration);
+        
+        var services = new List<ServiceDescriptor>();
+        var servicesMock = new Mock<IServiceCollection>();
+        servicesMock.Setup(s => s.Add(It.IsAny<ServiceDescriptor>())).Callback<ServiceDescriptor>(sd => services.Add(sd));
+        builderMock.Setup(b => b.Services).Returns(servicesMock.Object);
+
+        // Act
+        builderMock.Object.ConfigureDatabase();
+
+        // Assert
+        services.Should().BeEmpty();
+    }
+    
+    [TestMethod]
+    public void ConfigureDatabase_ShouldAddServices_WhenInDevelopmentAndConfigurationsAreFalse()
+    {
+        // Arrange
+        var builderMock = new Mock<IHostApplicationBuilder>();
+        
+        var environmentMock = new Mock<IWebHostEnvironment>();
+        environmentMock.Setup(e => e.EnvironmentName).Returns(Environments.Development);
+        builderMock.Setup(b => b.Environment).Returns(environmentMock.Object);
+        
+        var configuration = new ConfigurationManager();
+        configuration["MigrateDatabase"] = "false";
+        configuration["SeedDummyData"] = "false";
+        builderMock.Setup(b => b.Configuration).Returns(configuration);
+        
+        var services = new List<ServiceDescriptor>();
+        var servicesMock = new Mock<IServiceCollection>();
+        servicesMock.Setup(s => s.Add(It.IsAny<ServiceDescriptor>())).Callback<ServiceDescriptor>(sd => services.Add(sd));
+        builderMock.Setup(b => b.Services).Returns(servicesMock.Object);
+
+        // Act
+        builderMock.Object.ConfigureDatabase();
+        var serviceTypes = services.Select(s => s.ImplementationType);
+
+        // Assert
+        services.Should().BeEmpty();
+    }
+    
+    
+    [TestMethod]
+    public void ConfigureDatabase_ShouldAddDatabaseMigratorService_WhenInDevelopmentAndConfigurationIsTrue()
+    {
+        // Arrange
+        var builderMock = new Mock<IHostApplicationBuilder>();
+        
+        var environmentMock = new Mock<IWebHostEnvironment>();
+        environmentMock.Setup(e => e.EnvironmentName).Returns(Environments.Development);
+        builderMock.Setup(b => b.Environment).Returns(environmentMock.Object);
+        
+        var configuration = new ConfigurationManager();
+        configuration["MigrateDatabase"] = "true";
+        builderMock.Setup(b => b.Configuration).Returns(configuration);
+        
+        var services = new List<ServiceDescriptor>();
+        var servicesMock = new Mock<IServiceCollection>();
+        servicesMock.Setup(s => s.Add(It.IsAny<ServiceDescriptor>())).Callback<ServiceDescriptor>(sd => services.Add(sd));
+        builderMock.Setup(b => b.Services).Returns(servicesMock.Object);
+
+        // Act
+        builderMock.Object.ConfigureDatabase();
+        var serviceTypes = services.Select(s => s.ImplementationType);
+
+        // Assert
+        serviceTypes.Should().Contain(typeof(DatabaseMigrator));
+    }
+    
+    [TestMethod]
+    public void ConfigureDatabase_ShouldAddSeederService_WhenInDevelopmentAndConfigurationIsTrue()
+    {
+        // Arrange
+        var builderMock = new Mock<IHostApplicationBuilder>();
+        
+        var environmentMock = new Mock<IWebHostEnvironment>();
+        environmentMock.Setup(e => e.EnvironmentName).Returns(Environments.Development);
+        builderMock.Setup(b => b.Environment).Returns(environmentMock.Object);
+        
+        var configuration = new ConfigurationManager();
+        configuration["SeedDummyData"] = "true";
+        builderMock.Setup(b => b.Configuration).Returns(configuration);
+        
+        var services = new List<ServiceDescriptor>();
+        var servicesMock = new Mock<IServiceCollection>();
+        servicesMock.Setup(s => s.Add(It.IsAny<ServiceDescriptor>())).Callback<ServiceDescriptor>(sd => services.Add(sd));
+        builderMock.Setup(b => b.Services).Returns(servicesMock.Object);
+
+        // Act
+        builderMock.Object.ConfigureDatabase();
+        var serviceTypes = services.Select(s => s.ImplementationType);
+
+        // Assert
+        serviceTypes.Should().Contain(typeof(Seeder));
+    }
+}


### PR DESCRIPTION
A previous change removed development configuration options that it should not have been removed. 

https://github.com/equinor/procosys-preservation-api/blob/2f2a9d6daee5f0e3fb67731ace0cd27f2902b44c/src/Equinor.ProCoSys.Preservation.WebApi/Startup.cs#L51
https://github.com/equinor/procosys-preservation-api/pull/1001

https://github.com/equinor/cc-toolbox/issues/1064