### PR TITLE
Removing redundant app settings

### DIFF
--- a/src/Equinor.ProCoSys.Preservation.WebApi/appsettings.json
+++ b/src/Equinor.ProCoSys.Preservation.WebApi/appsettings.json
@@ -1,7 +1,9 @@
 {
   "AllowedHosts": "*",
   "Application": {
-    "DevOnLocalhost": false
+    "DevOnLocalhost": false,
+    "MigrateDatabase": false,
+    "SeedDummyData": false
   },
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",

--- a/src/Equinor.ProCoSys.Preservation.WebApi/appsettings.json
+++ b/src/Equinor.ProCoSys.Preservation.WebApi/appsettings.json
@@ -54,8 +54,6 @@
   "MainApi": {
     "ApiVersion": "4.1"
   },
-  "MigrateDatabase": false,
-  "SeedDummyData": false,
   "Swagger": {
     "AuthorizationUrl": "https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/oauth2/authorize",
     "Scopes": {}


### PR DESCRIPTION
These configurations should have been removed in PR #1014

They have been moved into the application section, and the configurations default to false. Making it redundant to have them in the configuration.

https://github.com/equinor/cc-toolbox/issues/1098