### PR TITLE
ClientCascade Project Tag OnDelete NoAction with ClientCascade 

### DIFF
--- a/src/Equinor.ProCoSys.Preservation.Infrastructure/Entityconfigurations/ProjectConfiguration.cs
+++ b/src/Equinor.ProCoSys.Preservation.Infrastructure/Entityconfigurations/ProjectConfiguration.cs
@@ -25,8 +25,7 @@ namespace Equinor.ProCoSys.Preservation.Infrastructure.EntityConfigurations
             builder
                 .HasMany(x => x.Tags)
                 .WithOne()
-                .IsRequired()
-                .OnDelete(DeleteBehavior.NoAction);
+                .IsRequired();
 
             builder
                 .HasIndex(p => p.Plant)

--- a/src/Equinor.ProCoSys.Preservation.Infrastructure/Entityconfigurations/ProjectConfiguration.cs
+++ b/src/Equinor.ProCoSys.Preservation.Infrastructure/Entityconfigurations/ProjectConfiguration.cs
@@ -25,7 +25,8 @@ namespace Equinor.ProCoSys.Preservation.Infrastructure.EntityConfigurations
             builder
                 .HasMany(x => x.Tags)
                 .WithOne()
-                .IsRequired();
+                .IsRequired()
+                .OnDelete(DeleteBehavior.ClientCascade);
 
             builder
                 .HasIndex(p => p.Plant)


### PR DESCRIPTION
Moving a tag from one project to another existing project was causing an exception in the audit data setter logic (preservation context), when accessing the change tracker.

The error would originate when the tag is removed from a project before being added to another. The entity framework would interpret this as the Tag having been set to null, even through it was added to another project.
Accessing the change tracker would then in turn throw an exception because the tag project cannot be null.

This is likely a bug in EF. I will be following up on that in the associated issue. https://github.com/equinor/cc-toolbox/issues/1642

Replacing the NoAction configuration with ClientCascade fixed the behaviour, and EF no longer attempted to set the project to null.